### PR TITLE
feat(settings): add menu bar icon visibility toggle

### DIFF
--- a/OpenClip.xcodeproj/project.pbxproj
+++ b/OpenClip.xcodeproj/project.pbxproj
@@ -94,6 +94,7 @@
 		4F04EDDEE2B8E5135E1E9B5B /* ExtensionOption.swift in Sources */ = {isa = PBXBuildFile; fileRef = B7534A2D6FD5368B237CB5C5 /* ExtensionOption.swift */; };
 		502E0EAB60D92A89C1F8957F /* ResultCardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C14D435609D5583A39FA164 /* ResultCardView.swift */; };
 		505BCF709F1851C81A35DD64 /* ActionCoordinatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7BBCBD7E4F5F0D1015061E8D /* ActionCoordinatorTests.swift */; };
+		5116F40F001337D7A910E311 /* StatusBarControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 831EE1ACBF685660FC4A7E1C /* StatusBarControllerTests.swift */; };
 		5177FD69CB1889103918E06A /* ValidateExpressionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 18AD4B01A699AB19272C3068 /* ValidateExpressionTests.swift */; };
 		5217746177125684C4C0D562 /* AIConfigureForm.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0840C0956DCD2948A2E47F53 /* AIConfigureForm.swift */; };
 		525E21DA64B3EB439A493E1C /* SDWebImageSwiftUI in Frameworks */ = {isa = PBXBuildFile; productRef = A589B0B4E6EC4ACB11944E7D /* SDWebImageSwiftUI */; };
@@ -291,6 +292,7 @@
 		ED408F095ADAD70E95B15D39 /* OpenClipJSHostTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8CB9BA0577EDDA7E174755C2 /* OpenClipJSHostTests.swift */; };
 		EE047575D4BBDD2F0D88A15C /* OpenClipModuleLoader.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC570E95AD00AF13279BF5F1 /* OpenClipModuleLoader.swift */; };
 		EF3BE1F10E35A392B5F686F8 /* RecommendedExtensionsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1EE6E52A608F70478CA1BB44 /* RecommendedExtensionsView.swift */; };
+		F3605465C595AC6C4AD817D6 /* SettingKey+MenuBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34FD5FB4055A0801CFE23340 /* SettingKey+MenuBar.swift */; };
 		F3838DAB280C70F3FF8196FF /* OpenClipJSHost.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B2196A93CE938E3BCD2D73F /* OpenClipJSHost.swift */; };
 		F499E888422C2452E64E2F06 /* ExtensionsStoreViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A9596443229B1173DAB2434 /* ExtensionsStoreViewTests.swift */; };
 		F5366871A0E5C9E04682EDC1 /* AIAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D1B055BC4EBEB77FCF23D59 /* AIAction.swift */; };
@@ -413,6 +415,7 @@
 		3359F30EB7FC15DFC02A4D9B /* OpenClipSnippetParserTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OpenClipSnippetParserTests.swift; sourceTree = "<group>"; };
 		336067B05C52B87CD8C9DA9F /* ExtensionManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExtensionManager.swift; sourceTree = "<group>"; };
 		34B69B093ED3342ADFC46D78 /* ValidateExpression.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ValidateExpression.swift; sourceTree = "<group>"; };
+		34FD5FB4055A0801CFE23340 /* SettingKey+MenuBar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SettingKey+MenuBar.swift"; sourceTree = "<group>"; };
 		3573C5F0E0C00C1A562BBBDC /* SelectionRetrievalMode.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SelectionRetrievalMode.swift; sourceTree = "<group>"; };
 		36016F74951C9B2E0CAA6894 /* AboutTabView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AboutTabView.swift; sourceTree = "<group>"; };
 		3675FDD7BC06CF3B3CBDA003 /* DynamicActionConfigView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DynamicActionConfigView.swift; sourceTree = "<group>"; };
@@ -491,6 +494,7 @@
 		82321CCDFB4EDE96ABB905F7 /* CompletionAction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CompletionAction.swift; sourceTree = "<group>"; };
 		82CA57F3B19ABD7C1FADC2C8 /* SearchHoverSupport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchHoverSupport.swift; sourceTree = "<group>"; };
 		83107D1DC88F388F201AE1D2 /* LogExporterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LogExporterTests.swift; sourceTree = "<group>"; };
+		831EE1ACBF685660FC4A7E1C /* StatusBarControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatusBarControllerTests.swift; sourceTree = "<group>"; };
 		842374852607342FFC468020 /* PopupGesturePolicy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PopupGesturePolicy.swift; sourceTree = "<group>"; };
 		85CB0D7F545A74562723950E /* RevealInFinderAction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RevealInFinderAction.swift; sourceTree = "<group>"; };
 		867F5FE32483EEF1ED7B18D1 /* DebugLogEntryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DebugLogEntryTests.swift; sourceTree = "<group>"; };
@@ -851,6 +855,7 @@
 				15E13C36EF68E62BC6FCD64A /* AI */,
 				46C7DB6847FF8142FDA21957 /* Notifications */,
 				307D28809D1A3464A7225CFC /* Platform */,
+				5A04A32905EAF7C7E411FD73 /* Settings */,
 				203ACF6C403D1ECF4A1F2F8D /* UI */,
 			);
 			name = OpenClip;
@@ -926,6 +931,14 @@
 				1677D9FC64906D22CF696930 /* ActionUsageStore.swift */,
 				1830B25888AE1D0532D00813 /* SettingKey.swift */,
 				2C2E0CE18FC287126307E67B /* SettingsStore.swift */,
+			);
+			path = Settings;
+			sourceTree = "<group>";
+		};
+		5A04A32905EAF7C7E411FD73 /* Settings */ = {
+			isa = PBXGroup;
+			children = (
+				34FD5FB4055A0801CFE23340 /* SettingKey+MenuBar.swift */,
 			);
 			path = Settings;
 			sourceTree = "<group>";
@@ -1204,6 +1217,7 @@
 				8D8A87C79135F4CF21CF2AF8 /* SelectionRetrievalCoordinatorTests.swift */,
 				C11A4CF4CA3DB3FB261289FA /* SemanticVersionTests.swift */,
 				47E51843D196C894F4B98910 /* SettingsStoreTests.swift */,
+				831EE1ACBF685660FC4A7E1C /* StatusBarControllerTests.swift */,
 				0B0459953290FD365F1B2DF6 /* StatusFeedbackTests.swift */,
 				A2EA847B6CB570918B4952D1 /* SubActionResolverTests.swift */,
 				2FB27AADC6E8AFED7FA86F02 /* TestIsolation.swift */,
@@ -1441,6 +1455,7 @@
 				8A768A0D221B74CC422DE0C7 /* SelectionRetrievalCoordinatorTests.swift in Sources */,
 				9460536EEABCEF2149F00781 /* SemanticVersionTests.swift in Sources */,
 				BAAC7407A886FC8D771D2ED6 /* SettingsStoreTests.swift in Sources */,
+				5116F40F001337D7A910E311 /* StatusBarControllerTests.swift in Sources */,
 				7694E581EABA2067BF562FDB /* StatusFeedbackTests.swift in Sources */,
 				BCB8FC0BDBC8396AF4A017A4 /* SubActionResolverTests.swift in Sources */,
 				2B3E3EB0BC1A9BA0919C017E /* TestIsolation.swift in Sources */,
@@ -1649,6 +1664,7 @@
 				BCD32C05AB22670492608CB7 /* SecretActionOptionStore.swift in Sources */,
 				A0AFEE7C0160491BE2D7F44A /* SecretStore.swift in Sources */,
 				686A3F272FC08062C9AA808E /* SelectionRetrievalCoordinator.swift in Sources */,
+				F3605465C595AC6C4AD817D6 /* SettingKey+MenuBar.swift in Sources */,
 				E6C58D0747EA41DECA6FFFA2 /* ShortcutAction.swift in Sources */,
 				4C5773E0C53E2A28F2664CD5 /* StatusBarController.swift in Sources */,
 				D90C12D950B6DE84BA1DB509 /* ToastPanel.swift in Sources */,

--- a/Sources/OpenClip/AppDelegate.swift
+++ b/Sources/OpenClip/AppDelegate.swift
@@ -23,6 +23,14 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     private var permissionRecoveryWindowController: PermissionRecoveryWindowController?
     private var coachMarkController: CoachMarkController?
 
+    func applicationShouldHandleReopen(
+        _ sender: NSApplication,
+        hasVisibleWindows flag: Bool
+    ) -> Bool {
+        statusBarController?.showPreferences()
+        return true
+    }
+
     func applicationDidFinishLaunching(_ notification: Notification) {
         // Register logging sinks (Rotating File Appender and In-Memory Buffer)
         let rotatingSink = RotatingFileLogSink()

--- a/Sources/OpenClip/Notifications/Notification.Name+OpenClip.swift
+++ b/Sources/OpenClip/Notifications/Notification.Name+OpenClip.swift
@@ -18,6 +18,9 @@ extension Notification.Name {
     /// Posted when the master app enabled state changes.
     static let openClipEnabledStateChanged = Notification.Name("OpenClipEnabledStateChanged")
 
+    /// Posted when the user changes whether OpenClip appears in the menu bar.
+    static let openClipMenuBarVisibilityChanged = Notification.Name("OpenClipMenuBarVisibilityChanged")
+
     /// Posted when accessibility authorization changes. The new `Bool` status travels in `object`.
     static let openClipAccessibilityChanged = Notification.Name("OpenClipAccessibilityChanged")
 

--- a/Sources/OpenClip/Settings/SettingKey+MenuBar.swift
+++ b/Sources/OpenClip/Settings/SettingKey+MenuBar.swift
@@ -1,0 +1,11 @@
+// SettingKey+MenuBar.swift
+// OpenClip
+//
+// Defines the AppKit presentation preference for the menu bar status item.
+import Core
+
+extension SettingKey where Value == Bool {
+    static var showMenuBarIcon: SettingKey<Bool> {
+        SettingKey<Bool>("showMenuBarIcon", defaultValue: true)
+    }
+}

--- a/Sources/OpenClip/StatusBarController.swift
+++ b/Sources/OpenClip/StatusBarController.swift
@@ -11,29 +11,44 @@ import Core
 /// Manages the menu bar status icon for OpenClip.
 @MainActor
 class StatusBarController: NSObject, NSMenuDelegate {
-    private var statusItem: NSStatusItem
+    private let settingsStore: any SettingsStore
+    private let notificationCenter: NotificationCenter
+    private var statusItem: NSStatusItem?
     private var preferencesWindow: NSWindow?
     private var toggleEnabledItem: NSMenuItem?
     private var extensionsSubmenu: NSMenu?
+
+    var isMenuBarIconVisible: Bool { statusItem != nil }
     
     /// Initializes a new status bar controller.
-    override init() {
-        self.statusItem = NSStatusBar.system.statusItem(withLength: NSStatusItem.variableLength)
+    init(
+        settingsStore: any SettingsStore = DefaultSettingsStore.shared,
+        notificationCenter: NotificationCenter = .default
+    ) {
+        self.settingsStore = settingsStore
+        self.notificationCenter = notificationCenter
         super.init()
-        setupMenu()
         
-        NotificationCenter.default.addObserver(
+        notificationCenter.addObserver(
             self,
             selector: #selector(handleStateChanged(_:)),
             name: .openClipEnabledStateChanged,
             object: nil
         )
-        NotificationCenter.default.addObserver(
+        notificationCenter.addObserver(
+            self,
+            selector: #selector(handleMenuBarVisibilityChanged(_:)),
+            name: .openClipMenuBarVisibilityChanged,
+            object: nil
+        )
+        notificationCenter.addObserver(
             self,
             selector: #selector(handleOpenConfiguration(_:)),
             name: .openClipOpenActionConfiguration,
             object: nil
         )
+
+        setMenuBarIconVisible(settingsStore.get(.showMenuBarIcon))
     }
     
     /// Sets up the menu for the status bar item following standard macOS menu hierarchy.
@@ -41,7 +56,7 @@ class StatusBarController: NSObject, NSMenuDelegate {
         let menu = NSMenu()
         
         // Section 1: Core State Toggle
-        let isEnabled = DefaultSettingsStore.shared.get(.isAppEnabled)
+        let isEnabled = settingsStore.get(.isAppEnabled)
         let toggleItem = NSMenuItem(
             title: "Appear Automatically",
             action: #selector(toggleEnabled),
@@ -78,7 +93,7 @@ class StatusBarController: NSObject, NSMenuDelegate {
         quitItem.target = NSApp
         menu.addItem(quitItem)
         
-        statusItem.menu = menu
+        statusItem?.menu = menu
         updateStatusIcon(isEnabled: isEnabled)
     }
     
@@ -90,11 +105,11 @@ class StatusBarController: NSObject, NSMenuDelegate {
     }
 
     @objc private func toggleEnabled() {
-        let current = DefaultSettingsStore.shared.get(.isAppEnabled)
+        let current = settingsStore.get(.isAppEnabled)
         let newStatus = !current
-        DefaultSettingsStore.shared.set(.isAppEnabled, value: newStatus)
+        settingsStore.set(.isAppEnabled, value: newStatus)
         updateStatusItem(isEnabled: newStatus)
-        NotificationCenter.default.post(name: .openClipEnabledStateChanged, object: newStatus)
+        notificationCenter.post(name: .openClipEnabledStateChanged, object: newStatus)
     }
 
     // MARK: - NSMenuDelegate
@@ -115,7 +130,7 @@ class StatusBarController: NSObject, NSMenuDelegate {
         menu.addItem(NSMenuItem.separator())
 
         let actions = ActionCoordinator.shared.actions
-        let disabledPackages = DefaultSettingsStore.shared.get(.disabledPackages)
+        let disabledPackages = settingsStore.get(.disabledPackages)
         let packages = ExtensionPackageResolver.resolvePackages(from: actions, disabledPackages: disabledPackages)
 
         if packages.isEmpty {
@@ -144,31 +159,36 @@ class StatusBarController: NSObject, NSMenuDelegate {
 
     @objc private func toggleExtensionPackage(_ sender: NSMenuItem) {
         guard let packageID = sender.representedObject as? String else { return }
-        var disabledPackages = DefaultSettingsStore.shared.get(.disabledPackages)
+        var disabledPackages = settingsStore.get(.disabledPackages)
         let isCurrentlyDisabled = disabledPackages.contains(packageID)
 
         if isCurrentlyDisabled {
             disabledPackages.remove(packageID)
-            DefaultSettingsStore.shared.set(.disabledPackages, value: disabledPackages)
+            settingsStore.set(.disabledPackages, value: disabledPackages)
             sender.state = .on
             Task { @MainActor in
                 await ExtensionManager.shared.enablePackage(packageID: packageID)
-                NotificationCenter.default.post(name: .openClipExtensionsDidChange, object: nil)
+                notificationCenter.post(name: .openClipExtensionsDidChange, object: nil)
             }
         } else {
             disabledPackages.insert(packageID)
-            DefaultSettingsStore.shared.set(.disabledPackages, value: disabledPackages)
+            settingsStore.set(.disabledPackages, value: disabledPackages)
             sender.state = .off
             Task { @MainActor in
                 await ExtensionManager.shared.disablePackage(packageID: packageID)
-                NotificationCenter.default.post(name: .openClipExtensionsDidChange, object: nil)
+                notificationCenter.post(name: .openClipExtensionsDidChange, object: nil)
             }
         }
     }
     
     @objc private func handleStateChanged(_ notification: Notification) {
-        let isEnabled = (notification.object as? Bool) ?? DefaultSettingsStore.shared.get(.isAppEnabled)
+        let isEnabled = (notification.object as? Bool) ?? settingsStore.get(.isAppEnabled)
         updateStatusItem(isEnabled: isEnabled)
+    }
+
+    @objc private func handleMenuBarVisibilityChanged(_ notification: Notification) {
+        let isVisible = (notification.object as? Bool) ?? settingsStore.get(.showMenuBarIcon)
+        setMenuBarIconVisible(isVisible)
     }
 
     @objc private func openReportIssue() {
@@ -196,17 +216,30 @@ class StatusBarController: NSObject, NSMenuDelegate {
     /// Screen frame of the status item's button, for anchoring surfaces (e.g. the post-onboarding
     /// coach mark) below it. Nil until the button has joined a window.
     var statusItemButtonFrame: NSRect? {
-        statusItem.button?.window?.frame
+        statusItem?.button?.window?.frame
     }
     
     private func updateStatusIcon(isEnabled: Bool) {
-        if let button = statusItem.button {
+        if let button = statusItem?.button {
             button.image = NSImage(named: "MenuBarIcon") ?? NSImage(systemSymbolName: "paperclip", accessibilityDescription: "OpenClip")
             button.image?.isTemplate = true
             button.alphaValue = isEnabled ? 1.0 : 0.45
             // The enabled state must be legible beyond the purely visual alpha dimming.
             button.setAccessibilityLabel("OpenClip")
             button.setAccessibilityValue(isEnabled ? "Appear Automatically is on" : "Appear Automatically is off")
+        }
+    }
+
+    private func setMenuBarIconVisible(_ isVisible: Bool) {
+        if isVisible {
+            guard statusItem == nil else { return }
+            statusItem = NSStatusBar.system.statusItem(withLength: NSStatusItem.variableLength)
+            setupMenu()
+        } else if let statusItem {
+            NSStatusBar.system.removeStatusItem(statusItem)
+            self.statusItem = nil
+            toggleEnabledItem = nil
+            extensionsSubmenu = nil
         }
     }
     
@@ -216,7 +249,7 @@ class StatusBarController: NSObject, NSMenuDelegate {
 
     public func showPreferences(tab: PreferenceTab = .general) {
         if let window = preferencesWindow, window.isVisible {
-            NotificationCenter.default.post(name: .openClipSelectPreferencesTab, object: tab)
+            notificationCenter.post(name: .openClipSelectPreferencesTab, object: tab)
             window.makeKeyAndOrderFront(nil)
             NSApp.activate(ignoringOtherApps: true)
             return

--- a/Sources/OpenClip/UI/Preferences/GeneralTabView.swift
+++ b/Sources/OpenClip/UI/Preferences/GeneralTabView.swift
@@ -1,8 +1,8 @@
 // GeneralTabView.swift
 // OpenClip
 //
-// The General preferences tab: app enable toggle, trigger hotkey, start-at-login,
-// and system-permission status. Split out of PreferencesView.swift.
+// The General preferences tab: app enable and menu bar toggles, trigger hotkey,
+// start-at-login, and system-permission status. Split out of PreferencesView.swift.
 import SwiftUI
 import Core
 import KeyboardShortcuts
@@ -12,6 +12,7 @@ struct GeneralTab: View {
     /// Backed by the settings store — the single owner of `isAppEnabled`. Seeded at init and kept
     /// in sync with external changes (status-bar toggle) via the shared state-changed notification.
     @State private var isAppEnabled: Bool
+    @State private var showMenuBarIcon: Bool
     @State private var isMouseHoldEnabled: Bool
     @State private var primaryBehavior: String
     @State private var secondaryBehavior: String
@@ -20,6 +21,7 @@ struct GeneralTab: View {
 
     init() {
         _isAppEnabled = State(initialValue: DefaultSettingsStore.shared.get(.isAppEnabled))
+        _showMenuBarIcon = State(initialValue: DefaultSettingsStore.shared.get(.showMenuBarIcon))
         _isMouseHoldEnabled = State(initialValue: DefaultSettingsStore.shared.get(.isMouseHoldEnabled))
         _primaryBehavior = State(initialValue: DefaultSettingsStore.shared.get(.primaryClickBehavior))
         _secondaryBehavior = State(initialValue: DefaultSettingsStore.shared.get(.secondaryClickBehavior))
@@ -54,7 +56,33 @@ struct GeneralTab: View {
                 }
                 .padding(.vertical, 4)
                 
-                // Row 2: Trigger Shortcut
+                // Row 2: Menu Bar Icon
+                HStack {
+                    HStack(spacing: 12) {
+                        Image(systemName: "menubar.rectangle")
+                            .font(.system(size: 16))
+                            .foregroundColor(showMenuBarIcon ? .accentColor : .secondary)
+                            .frame(width: 22, alignment: .center)
+
+                        Text("Show Menu Bar Icon")
+                            .font(.body)
+                            .fontWeight(.medium)
+                    }
+                    Spacer()
+                    Toggle("", isOn: $showMenuBarIcon)
+                        .labelsHidden()
+                        .accessibilityLabel("Show Menu Bar Icon")
+                        .onChange(of: showMenuBarIcon) { _, newValue in
+                            DefaultSettingsStore.shared.set(.showMenuBarIcon, value: newValue)
+                            NotificationCenter.default.post(
+                                name: .openClipMenuBarVisibilityChanged,
+                                object: newValue
+                            )
+                        }
+                }
+                .padding(.vertical, 4)
+
+                // Row 3: Trigger Shortcut
                 HStack {
                     HStack(spacing: 12) {
                         Image(systemName: "keyboard")
@@ -71,7 +99,7 @@ struct GeneralTab: View {
                 }
                 .padding(.vertical, 4)
 
-                // Row 3: Hold Mouse to Trigger
+                // Row 4: Hold Mouse to Trigger
                 HStack {
                     HStack(spacing: 12) {
                         Image(systemName: "hand.tap")
@@ -93,7 +121,7 @@ struct GeneralTab: View {
                 }
                 .padding(.vertical, 4)
                 
-                // Row 3: Start at Login
+                // Row 5: Start at Login
                 HStack {
                     HStack(spacing: 12) {
                         Image(systemName: "arrow.clockwise.circle")

--- a/Tests/OpenClipTests/SettingsStoreTests.swift
+++ b/Tests/OpenClipTests/SettingsStoreTests.swift
@@ -55,6 +55,13 @@ final class SettingsStoreTests: XCTestCase {
     }
 
     @MainActor
+    func testMenuBarIconVisibilityDefaultsToShownAndRoundTrips() {
+        XCTAssertTrue(store.get(.showMenuBarIcon))
+        store.set(.showMenuBarIcon, value: false)
+        XCTAssertFalse(store.get(.showMenuBarIcon))
+    }
+
+    @MainActor
     func testResultDeliveryDefaults() {
         XCTAssertEqual(store.get(.primaryClickBehavior), "paste")
         XCTAssertEqual(store.get(.secondaryClickBehavior), "copy")

--- a/Tests/OpenClipTests/StatusBarControllerTests.swift
+++ b/Tests/OpenClipTests/StatusBarControllerTests.swift
@@ -1,0 +1,40 @@
+import XCTest
+@testable import Core
+@testable import OpenClip
+
+@MainActor
+final class StatusBarControllerTests: XCTestCase {
+    func testStartsWithoutStatusItemWhenPreferenceIsDisabled() {
+        let store = MemorySettingsStore()
+        store.set(.showMenuBarIcon, value: false)
+        let notificationCenter = NotificationCenter()
+        let controller = StatusBarController(
+            settingsStore: store,
+            notificationCenter: notificationCenter
+        )
+
+        XCTAssertFalse(controller.isMenuBarIconVisible)
+    }
+
+    func testVisibilityNotificationRemovesAndRecreatesStatusItem() {
+        let store = MemorySettingsStore()
+        let notificationCenter = NotificationCenter()
+        let controller = StatusBarController(
+            settingsStore: store,
+            notificationCenter: notificationCenter
+        )
+
+        XCTAssertTrue(controller.isMenuBarIconVisible)
+
+        store.set(.showMenuBarIcon, value: false)
+        notificationCenter.post(name: .openClipMenuBarVisibilityChanged, object: false)
+        XCTAssertFalse(controller.isMenuBarIconVisible)
+
+        store.set(.showMenuBarIcon, value: true)
+        notificationCenter.post(name: .openClipMenuBarVisibilityChanged, object: true)
+        XCTAssertTrue(controller.isMenuBarIconVisible)
+
+        store.set(.showMenuBarIcon, value: false)
+        notificationCenter.post(name: .openClipMenuBarVisibilityChanged, object: false)
+    }
+}

--- a/docs/architecture/known-debt.md
+++ b/docs/architecture/known-debt.md
@@ -26,6 +26,10 @@ areas; stale debt notes are worse than none.
   the Preferences toggle all read/write through `DefaultSettingsStore`. Builtin store-backed actions
   (`CalculateAction`, `CalendarAction`, `SearchAction`) accept an injected `SettingsStore` via
   `BuiltinRegistry.makeCoreBuiltins(settingsStore:)`.
+- **Menu bar visibility is store-backed and reversible.** `SettingKey.showMenuBarIcon` defaults to
+  true. `StatusBarController` removes/recreates its `NSStatusItem` immediately when the General-tab
+  toggle changes, while reopening the running app presents Preferences so a hidden icon can be
+  restored without terminating OpenClip.
 - **`ActionConfigSheet` is gone** (dead code — zero presenting call sites; its `useText` keys were
   write-only). Removing it also dropped the only UI that wrote `SettingKey.searchURL` /
   `SettingKey.calculateMode`; the actions still read those keys (defaults apply), so a future

--- a/docs/user-guide/preferences.md
+++ b/docs/user-guide/preferences.md
@@ -6,9 +6,15 @@ OpenClip offers extensive customization for action ordering, display labels, cus
 
 ## Opening Preferences
 
-You can open OpenClip Preferences in two ways:
+You can open OpenClip Preferences in these ways:
 - Click the OpenClip menu bar icon and select **Preferences...**
 - Press `Cmd + ,` while the OpenClip popup bar or settings window is focused.
+- If the menu bar icon is hidden, open OpenClip again from Finder or Spotlight.
+
+## General
+
+The **Show Menu Bar Icon** toggle is enabled by default. Turning it off removes the icon
+immediately without stopping OpenClip, its selection monitoring, or its global shortcut.
 
 ---
 


### PR DESCRIPTION
## Summary

- Add a default-enabled **Show Menu Bar Icon** toggle under General preferences.
- Remove and recreate the `NSStatusItem` immediately when the preference changes while keeping OpenClip and its shortcuts running.
- Reopen Preferences when the already-running app is opened again, so users can restore a hidden icon.
- Add isolated persistence and status-item lifecycle tests, and update the user and architecture documentation.

Closes #2

## Type of Change

- [ ] Bug fix (non-breaking change fixing an issue)
- [x] New feature (non-breaking change adding functionality)
- [ ] Extension API / Catalog update
- [x] Documentation update
- [ ] Infrastructure / CI / Build tooling

## Verification & Testing

- [x] Ran `./scripts/test.sh` cleanly: 836 tests, 0 failures.
- [x] Built and launched the Debug app via `./scripts/dev_run.sh`.
- [x] Added coverage for the default preference and immediate status-item removal/recreation.

## Code Checklist

- [x] Adheres to architectural rules in `AGENTS.md` (Swift 6 complete strict concurrency, pure `Core`).
- [x] Uses the existing logging architecture; no `print()` or raw `Logger()` additions.
- [x] Uses `SettingsStore` and a typed `SettingKey`; no new raw `UserDefaults.standard` access.
- [x] Updated documentation in `docs/` for the new behavior.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a preference to show or hide the OpenClip menu bar icon.
  * The icon visibility updates immediately without interrupting clipboard monitoring or shortcuts.
  * Preferences can be reopened by launching OpenClip again when the icon is hidden.
* **Documentation**
  * Updated the preferences guide with menu bar visibility details and alternate ways to open Preferences.
* **Bug Fixes**
  * Improved menu bar icon handling when preferences change or the app is reopened.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->