### PR TITLE
feat(ui): add search engine preset picker to builtin Search config

### DIFF
--- a/OpenClip.xcodeproj/project.pbxproj
+++ b/OpenClip.xcodeproj/project.pbxproj
@@ -239,6 +239,7 @@
 		B65680000C72C06585A1B730 /* DebugLogStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 28C251D684663DDC867A7E7C /* DebugLogStoreTests.swift */; };
 		B776223E716B18F4F53A4D3F /* AppRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = E21F7917E14860EA903D0552 /* AppRule.swift */; };
 		B7BFA2A49A47859753B93E6F /* DebugLogFilterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B826FB17017910B8919BF18F /* DebugLogFilterTests.swift */; };
+		B878E8AD390655A32B1948AB /* SearchEnginePreset.swift in Sources */ = {isa = PBXBuildFile; fileRef = DAD285A6E160A8CFE29AB959 /* SearchEnginePreset.swift */; };
 		B89E9C568ACA99C944DA119C /* ActionGroupDef.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56859A8B4DA8A93F7CC38373 /* ActionGroupDef.swift */; };
 		B9AF5DDB7DFBC46EE834CAF8 /* CoachMarkController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1E417DA92C87224C35768951 /* CoachMarkController.swift */; };
 		BA308E09D1ED265BC04ACBD5 /* ActionCoordinatorGroupTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = ACBA587ACDBB04B70F0E8E79 /* ActionCoordinatorGroupTests.swift */; };
@@ -316,6 +317,7 @@
 		F3838DAB280C70F3FF8196FF /* OpenClipJSHost.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B2196A93CE938E3BCD2D73F /* OpenClipJSHost.swift */; };
 		F499E888422C2452E64E2F06 /* ExtensionsStoreViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A9596443229B1173DAB2434 /* ExtensionsStoreViewTests.swift */; };
 		F5366871A0E5C9E04682EDC1 /* AIAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D1B055BC4EBEB77FCF23D59 /* AIAction.swift */; };
+		F71A7F8F3E0FDB5E5504D490 /* SearchEnginePresetTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CB7CF86CA702AEF008FD8E5 /* SearchEnginePresetTests.swift */; };
 		F771AE634BA65CAA36353E65 /* ConfigurableAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58A3A4C1ECD9EF519BE8134B /* ConfigurableAction.swift */; };
 		F81572C7094A8DFE873AAA02 /* PopupHoverSupport.swift in Sources */ = {isa = PBXBuildFile; fileRef = A088DDC9F9B0BD52F785ACCB /* PopupHoverSupport.swift */; };
 		F84E32706E2047EE57752FAD /* ExtensionTrustState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F9E1A41335E79BECD9E7B7B /* ExtensionTrustState.swift */; };
@@ -380,6 +382,7 @@
 		0AC7C388035A937859369C48 /* IconPickerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IconPickerView.swift; sourceTree = "<group>"; };
 		0B0459953290FD365F1B2DF6 /* StatusFeedbackTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatusFeedbackTests.swift; sourceTree = "<group>"; };
 		0C14D435609D5583A39FA164 /* ResultCardView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ResultCardView.swift; sourceTree = "<group>"; };
+		0CB7CF86CA702AEF008FD8E5 /* SearchEnginePresetTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchEnginePresetTests.swift; sourceTree = "<group>"; };
 		0CF97DDF5B196383416AB162 /* CompletionActionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CompletionActionTests.swift; sourceTree = "<group>"; };
 		0D770B00EA584CD6DC259086 /* CalendarAction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalendarAction.swift; sourceTree = "<group>"; };
 		0D7A473B890B4C97C343497A /* AppIcon.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppIcon.swift; sourceTree = "<group>"; };
@@ -639,6 +642,7 @@
 		D65DE0BF7E0609929C64B1DA /* AXElementInspector.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AXElementInspector.swift; sourceTree = "<group>"; };
 		D719D2B6B3F32C056AED329D /* CalculateActionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalculateActionTests.swift; sourceTree = "<group>"; };
 		D9FE4B50AD5CCA0A39301667 /* Log.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Log.swift; sourceTree = "<group>"; };
+		DAD285A6E160A8CFE29AB959 /* SearchEnginePreset.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchEnginePreset.swift; sourceTree = "<group>"; };
 		DB02C8F39926FFDCB6BBF5D1 /* ActionDelivery.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActionDelivery.swift; sourceTree = "<group>"; };
 		DCA0A12F58628A20E611FABA /* SubBarPanel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SubBarPanel.swift; sourceTree = "<group>"; };
 		DDD3B55E83E9C71B05706009 /* CursorClassifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CursorClassifier.swift; sourceTree = "<group>"; };
@@ -918,6 +922,7 @@
 				CB70EAE4A67E1C59A1977A8D /* DefineAction.swift */,
 				301F027F5438EEDF87A6645B /* PasteAction.swift */,
 				C5FC00AC73CC488DBF7F7240 /* SearchAction.swift */,
+				DAD285A6E160A8CFE29AB959 /* SearchEnginePreset.swift */,
 			);
 			path = Builtin;
 			sourceTree = "<group>";
@@ -1277,6 +1282,7 @@
 				E1A3B31A9407EA4D8E0EBF6E /* RotatingFileLogSinkTests.swift */,
 				06C43223F2E4E777CC9F7673 /* RuleEngineTests.swift */,
 				BA4CE0EEDB520B882DB1A0CD /* ScriptActionExecutionTests.swift */,
+				0CB7CF86CA702AEF008FD8E5 /* SearchEnginePresetTests.swift */,
 				C7987E34A7967713991DA9F3 /* SecretActionOptionStoreTests.swift */,
 				F4AD51BBA1C1F3ABEF4061B8 /* SelectionGatePolicyTests.swift */,
 				8D8A87C79135F4CF21CF2AF8 /* SelectionRetrievalCoordinatorTests.swift */,
@@ -1526,6 +1532,7 @@
 				87B7B3D8AAA1E4C9D01750FE /* RotatingFileLogSinkTests.swift in Sources */,
 				611F612CDB50CBDCE4916F4E /* RuleEngineTests.swift in Sources */,
 				3B367A7B4C49C2F54DB9FAD4 /* ScriptActionExecutionTests.swift in Sources */,
+				F71A7F8F3E0FDB5E5504D490 /* SearchEnginePresetTests.swift in Sources */,
 				935725012DC74D36432AB713 /* SecretActionOptionStoreTests.swift in Sources */,
 				C29F35CC3C92862EF2972660 /* SelectionGatePolicyTests.swift in Sources */,
 				8A768A0D221B74CC422DE0C7 /* SelectionRetrievalCoordinatorTests.swift in Sources */,
@@ -1619,6 +1626,7 @@
 				02AF81963047538ADE0363F5 /* RuleEngine.swift in Sources */,
 				386E98180E02243B9DE6B5CA /* ScriptAction.swift in Sources */,
 				7CDDEAAD6790A7471D61A940 /* SearchAction.swift in Sources */,
+				B878E8AD390655A32B1948AB /* SearchEnginePreset.swift in Sources */,
 				EBE9FB46AD56F10020544D24 /* SelectionContext.swift in Sources */,
 				A255B2AD8EDA8F740EABEE0F /* SelectionGatePolicy.swift in Sources */,
 				C02DCB05C24F9A9EFA004B12 /* SelectionMonitoring.swift in Sources */,

--- a/Sources/Core/Actions/Builtin/SearchAction.swift
+++ b/Sources/Core/Actions/Builtin/SearchAction.swift
@@ -16,7 +16,7 @@ public struct SearchAction: ConfigurableAction {
                 identifier: "url",
                 label: String(localized: "Search Engine URL Template"),
                 type: .string,
-                defaultValue: "https://www.google.com/search?q={query}"
+                defaultValue: SearchEnginePreset.defaultURLTemplate
             )
         ]
     }
@@ -59,6 +59,6 @@ public struct SearchAction: ConfigurableAction {
         if !configured.isEmpty { return configured }
         let legacy = settingsStore.get(.searchURL)
         if !legacy.isEmpty { return legacy }
-        return "https://www.google.com/search?q={query}"
+        return SearchEnginePreset.defaultURLTemplate
     }
 }

--- a/Sources/Core/Actions/Builtin/SearchEnginePreset.swift
+++ b/Sources/Core/Actions/Builtin/SearchEnginePreset.swift
@@ -1,0 +1,76 @@
+// SearchEnginePreset.swift
+// OpenClip
+//
+// Curated one-click search engine presets for the built-in Search action. Pure domain metadata:
+// the configured value always stays the `{query}` URL template string written through the option
+// store, so a stored template that matches no preset simply renders as "Custom" — no migration,
+// no loss of custom/self-hosted endpoints.
+import Foundation
+
+public struct SearchEnginePreset: Sendable, Equatable, Identifiable {
+    /// Stable identifier used as the picker tag (e.g. "google", "kagi").
+    public let id: String
+    /// User-facing display name (e.g. "Google", "Brave Search").
+    public let displayName: String
+    /// The `{query}` URL template that SearchAction resolves against selected text.
+    public let urlTemplate: String
+
+    public init(id: String, displayName: String, urlTemplate: String) {
+        self.id = id
+        self.displayName = displayName
+        self.urlTemplate = urlTemplate
+    }
+
+    // MARK: - Curated presets
+
+    public static let google = SearchEnginePreset(
+        id: "google",
+        displayName: String(localized: "Google"),
+        urlTemplate: "https://www.google.com/search?q={query}"
+    )
+    public static let duckduckgo = SearchEnginePreset(
+        id: "duckduckgo",
+        displayName: String(localized: "DuckDuckGo"),
+        urlTemplate: "https://duckduckgo.com/?q={query}"
+    )
+    public static let kagi = SearchEnginePreset(
+        id: "kagi",
+        displayName: String(localized: "Kagi"),
+        urlTemplate: "https://kagi.com/search?q={query}"
+    )
+    public static let brave = SearchEnginePreset(
+        id: "brave",
+        displayName: String(localized: "Brave Search"),
+        urlTemplate: "https://search.brave.com/search?q={query}"
+    )
+    public static let bing = SearchEnginePreset(
+        id: "bing",
+        displayName: String(localized: "Bing"),
+        urlTemplate: "https://www.bing.com/search?q={query}"
+    )
+    public static let ecosia = SearchEnginePreset(
+        id: "ecosia",
+        displayName: String(localized: "Ecosia"),
+        urlTemplate: "https://www.ecosia.org/search?q={query}"
+    )
+
+    /// All curated presets, in picker order.
+    public static let all: [SearchEnginePreset] = [google, duckduckgo, kagi, brave, bing, ecosia]
+
+    /// Default `{query}` template (Google). Single source of truth for the Search action's default.
+    public static let defaultURLTemplate = google.urlTemplate
+
+    // MARK: - Lookup
+
+    /// Returns the preset whose URL template exactly matches `template`, or nil when the template
+    /// is custom/empty. Matching is exact so a user's hand-edited variant of a preset URL (e.g.
+    /// appending `&hl=en`) is treated as Custom rather than silently snapping back to the preset.
+    public static func preset(matching template: String) -> SearchEnginePreset? {
+        all.first { $0.urlTemplate == template }
+    }
+
+    /// Returns the preset with the given stable id, or nil.
+    public static func preset(id: String) -> SearchEnginePreset? {
+        all.first { $0.id == id }
+    }
+}

--- a/Sources/OpenClip/Resources/Localizable.xcstrings
+++ b/Sources/OpenClip/Resources/Localizable.xcstrings
@@ -471,6 +471,26 @@
         }
       }
     },
+    "Bing": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "必应"
+          }
+        }
+      }
+    },
+    "Brave Search": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Brave 搜索"
+          }
+        }
+      }
+    },
     "Browse 100+ extensions in Menu Bar → Preferences": {
       "localizations": {
         "zh-Hans": {
@@ -871,6 +891,16 @@
         }
       }
     },
+    "Custom...": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "自定义…"
+          }
+        }
+      }
+    },
     "Cut": {
       "localizations": {
         "zh-Hans": {
@@ -971,12 +1001,32 @@
         }
       }
     },
+    "DuckDuckGo": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "DuckDuckGo"
+          }
+        }
+      }
+    },
     "EXECUTION LOGIC": {
       "localizations": {
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
             "value": "执行逻辑"
+          }
+        }
+      }
+    },
+    "Ecosia": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ecosia"
           }
         }
       }
@@ -1291,6 +1341,16 @@
         }
       }
     },
+    "Google": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "谷歌"
+          }
+        }
+      }
+    },
     "Google Gemini": {
       "localizations": {
         "zh-Hans": {
@@ -1517,6 +1577,16 @@
           "stringUnit": {
             "state": "translated",
             "value": "问题反馈"
+          }
+        }
+      }
+    },
+    "Kagi": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Kagi"
           }
         }
       }

--- a/Sources/OpenClip/UI/Preferences/DynamicActionConfigView.swift
+++ b/Sources/OpenClip/UI/Preferences/DynamicActionConfigView.swift
@@ -81,6 +81,25 @@ struct DynamicOptionRowView: View {
     }
 
     var body: some View {
+        if isSearchURLOption {
+            SearchEngineURLOptionView(
+                actionID: actionID,
+                option: option,
+                optionStore: optionStore,
+                isMissing: isMissing
+            )
+        } else {
+            standardRowBody
+        }
+    }
+
+    /// The built-in Search action's `url` option gets the search-engine preset picker (Google /
+    /// DuckDuckGo / Kagi / Brave / Bing / Ecosia / Custom) instead of a bare template text field.
+    private var isSearchURLOption: Bool {
+        actionID == SearchAction().id && option.identifier == "url"
+    }
+
+    private var standardRowBody: some View {
         HStack(spacing: 12) {
             HStack(spacing: 6) {
                 Text(option.label)
@@ -153,6 +172,113 @@ struct DynamicOptionRowView: View {
         case "google": return "Google Calendar"
         default: return choice.capitalized
         }
+    }
+}
+
+/// Renders the built-in Search action's URL option as a search-engine preset picker. Provides
+/// one-click selection among curated presets (Google / DuckDuckGo / Kagi / Brave / Bing / Ecosia)
+/// while keeping a raw `{query}` template field reachable through the trailing "Custom..." choice.
+/// Every write still routes through the injected option store (SettingsStore-backed), so the stored
+/// `action.builtin.search.option.url` value remains the single source of truth; a stored template
+/// that matches no preset simply shows the picker on "Custom..." with the template in the field.
+@MainActor
+private struct SearchEngineURLOptionView: View {
+    let actionID: String
+    let option: ExtensionOption
+    let optionStore: any ActionOptionReading & ActionOptionWriting
+    var isMissing: Bool
+
+    private enum SearchEngineSelection: Hashable {
+        case preset(String) // stable preset id
+        case custom
+    }
+
+    @State private var selection: SearchEngineSelection
+    @State private var customTemplate: String
+
+    init(
+        actionID: String,
+        option: ExtensionOption,
+        optionStore: any ActionOptionReading & ActionOptionWriting,
+        isMissing: Bool
+    ) {
+        self.actionID = actionID
+        self.option = option
+        self.optionStore = optionStore
+        self.isMissing = isMissing
+        let stored = optionStore.stringValue(actionID: actionID, option: option)
+        _selection = State(initialValue: Self.initialSelection(for: stored))
+        _customTemplate = State(initialValue: stored)
+    }
+
+    /// Preset when the stored template matches exactly; otherwise Custom (covers self-hosted or
+    /// hand-edited endpoints, which are never silently snapped back to a preset).
+    private static func initialSelection(for stored: String) -> SearchEngineSelection {
+        SearchEnginePreset.preset(matching: stored).map { .preset($0.id) } ?? .custom
+    }
+
+    private var pickerBinding: Binding<SearchEngineSelection> {
+        Binding(
+            get: { selection },
+            set: { newValue in
+                selection = newValue
+                if case .preset(let presetID) = newValue, let preset = SearchEnginePreset.preset(id: presetID) {
+                    customTemplate = preset.urlTemplate
+                    optionStore.setStringValue(preset.urlTemplate, actionID: actionID, option: option)
+                }
+            }
+        )
+    }
+
+    private var customTemplateBinding: Binding<String> {
+        Binding(
+            get: { customTemplate },
+            set: { newValue in
+                customTemplate = newValue
+                optionStore.setStringValue(newValue, actionID: actionID, option: option)
+            }
+        )
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            HStack(spacing: 12) {
+                HStack(spacing: 6) {
+                    Text(option.label)
+                        .font(.subheadline)
+                        .foregroundColor(.primary)
+
+                    if isMissing {
+                        Text("Required")
+                            .font(.caption2)
+                            .fontWeight(.semibold)
+                            .foregroundColor(.red)
+                    }
+                }
+
+                Spacer(minLength: 8)
+
+                Picker("", selection: pickerBinding) {
+                    ForEach(SearchEnginePreset.all) { preset in
+                        Text(preset.displayName).tag(SearchEngineSelection.preset(preset.id))
+                    }
+                    Text(String(localized: "Custom...")).tag(SearchEngineSelection.custom)
+                }
+                .pickerStyle(.menu)
+                .labelsHidden()
+                .frame(maxWidth: 200)
+                .missingFieldHighlight(isMissing)
+            }
+
+            if selection == .custom {
+                TextField("https://example.com/search?q={query}", text: customTemplateBinding)
+                    .textFieldStyle(.roundedBorder)
+                    .font(.system(.body, design: .monospaced))
+                    .missingFieldHighlight(isMissing)
+            }
+        }
+        .padding(.horizontal, 12)
+        .padding(.vertical, 8)
     }
 }
 

--- a/Tests/OpenClipTests/SearchEnginePresetTests.swift
+++ b/Tests/OpenClipTests/SearchEnginePresetTests.swift
@@ -1,0 +1,75 @@
+import XCTest
+@testable import Core
+@testable import OpenClip
+
+/// Covers the curated search-engine presets powering the Search action's preset picker: catalog
+/// invariants, exact-match resolution, custom fallback, and the single source of truth for the
+/// default template.
+final class SearchEnginePresetTests: XCTestCase {
+
+    func testAllPresetsAreWellFormedAndUnique() {
+        let ids = SearchEnginePreset.all.map(\.id)
+        XCTAssertEqual(Set(ids).count, ids.count, "Preset ids must be unique")
+
+        for preset in SearchEnginePreset.all {
+            XCTAssertFalse(preset.displayName.isEmpty, "\(preset.id) must have a display name")
+            XCTAssertTrue(preset.urlTemplate.hasPrefix("https://"), "\(preset.id) must be an https template")
+            XCTAssertTrue(preset.urlTemplate.contains("{query}"), "\(preset.id) template must contain {query}")
+        }
+    }
+
+    /// The issue-suggested preset catalog, in order. Asserts on stable ids (display names are
+    /// localized and may vary with the test host's locale).
+    func testCatalogMatchesRequestedPresets() {
+        let ids = SearchEnginePreset.all.map(\.id)
+        XCTAssertEqual(ids, ["google", "duckduckgo", "kagi", "brave", "bing", "ecosia"])
+        let templates = SearchEnginePreset.all.map(\.urlTemplate)
+        XCTAssertEqual(templates, [
+            "https://www.google.com/search?q={query}",
+            "https://duckduckgo.com/?q={query}",
+            "https://kagi.com/search?q={query}",
+            "https://search.brave.com/search?q={query}",
+            "https://www.bing.com/search?q={query}",
+            "https://www.ecosia.org/search?q={query}",
+        ])
+    }
+
+    func testPresetMatchingReturnsPresetForExactTemplate() {
+        for preset in SearchEnginePreset.all {
+            XCTAssertEqual(SearchEnginePreset.preset(matching: preset.urlTemplate), preset)
+        }
+    }
+
+    func testPresetMatchingReturnsNilForCustomTemplate() {
+        // Self-hosted / internal endpoints and empty values never match a preset.
+        XCTAssertNil(SearchEnginePreset.preset(matching: "https://search.mysite.dev/search?q={query}"))
+        XCTAssertNil(SearchEnginePreset.preset(matching: ""))
+    }
+
+    func testPresetMatchingIsExactAndDoesNotSnapBackHandEditedVariants() {
+        // A user's tweaked variant must stay Custom, not silently reset to the preset.
+        XCTAssertNil(SearchEnginePreset.preset(matching: "https://www.google.com/search?q={query}&hl=en"))
+        XCTAssertNil(SearchEnginePreset.preset(matching: "https://www.bing.com/search?q={query}&cc=us"))
+        XCTAssertNil(SearchEnginePreset.preset(matching: "https://duckduckgo.com/?q={query}&ia=web"))
+    }
+
+    func testPresetLookupByStableID() {
+        // Stable id and template are locale-independent; display names are localized.
+        XCTAssertEqual(SearchEnginePreset.preset(id: "google")?.id, "google")
+        XCTAssertEqual(SearchEnginePreset.preset(id: "kagi")?.urlTemplate, "https://kagi.com/search?q={query}")
+        XCTAssertEqual(SearchEnginePreset.preset(id: "bing")?.displayName, String(localized: "Bing"))
+        XCTAssertNil(SearchEnginePreset.preset(id: "nonexistent"))
+    }
+
+    func testDefaultTemplateIsGoogle() {
+        XCTAssertEqual(SearchEnginePreset.defaultURLTemplate, SearchEnginePreset.google.urlTemplate)
+        XCTAssertEqual(SearchEnginePreset.defaultURLTemplate, "https://www.google.com/search?q={query}")
+    }
+
+    @MainActor
+    func testSearchActionDefaultUsesPresetTemplate() {
+        let action = SearchAction()
+        let urlOption = action.actionOptions.first { $0.identifier == "url" }
+        XCTAssertEqual(urlOption?.defaultValue, SearchEnginePreset.defaultURLTemplate)
+    }
+}

--- a/docs/architecture/known-debt.md
+++ b/docs/architecture/known-debt.md
@@ -32,8 +32,12 @@ areas; stale debt notes are worse than none.
   restored without terminating OpenClip.
 - **`ActionConfigSheet` is gone** (dead code — zero presenting call sites; its `useText` keys were
   write-only). Removing it also dropped the only UI that wrote `SettingKey.searchURL` /
-  `SettingKey.calculateMode`; the actions still read those keys (defaults apply), so a future
-  Preferences surface for search-engine / calculate-result-mode would restore configurability.
+  `SettingKey.calculateMode`; the actions still read those keys (defaults apply). Search-engine
+  configurability is **restored** via the built-in Search action's preset picker in the Preferences
+  edit sheet (`DynamicActionConfigView` — Google / DuckDuckGo / Kagi / Brave / Bing / Ecosia /
+  Custom), which writes the option-store key `action.builtin.search.option.url`
+  (`SearchEnginePreset` in Core holds the curated catalog); calculate-result-mode still has no
+  Preferences surface.
   `ConfigurableAction` keeps only `preferenceIconName` (used by `tableIcon`/`rowIcon` icon fallback).
 - **Dynamic action option keys** (`JavaScriptAction`, `AppleScriptAction`): the target pattern is
   `SettingKey<String>("action.<id>.option.<identifier>", defaultValue:)` via `SettingsStore`. The JS

--- a/scripts/generate_localizable.py
+++ b/scripts/generate_localizable.py
@@ -337,6 +337,14 @@ TRANSLATIONS: dict[str, str] = {
     "Word Completion": "单词补全",
     "Search Engine URL Template": "搜索引擎 URL 模板",
     "Calendar Destination": "日历目标",
+    # Search engine presets (built-in Search action)
+    "Google": "谷歌",
+    "DuckDuckGo": "DuckDuckGo",
+    "Kagi": "Kagi",
+    "Brave Search": "Brave 搜索",
+    "Bing": "必应",
+    "Ecosia": "Ecosia",
+    "Custom...": "自定义…",
     "Required option not set.": "尚未设置必填选项。",
     "Required options not set.": "尚未设置必填选项。",
     # Deep link / alerts


### PR DESCRIPTION
## Summary

Closes #6 — adds a **Search Engine Preset Picker** to the built-in **Search** action's configuration in Preferences.

When configuring the Search action, users now get a dropdown with one-click presets (**Google** / **DuckDuckGo** / **Kagi** / **Brave Search** / **Bing** / **Ecosia**) plus a trailing **Custom...** choice that reveals the raw `{query}` URL template field. No more typing URL templates by hand for popular engines — while self-hosted endpoints like SearXNG stay fully supported.

## Changes

- **Core** — new `Sources/Core/Actions/Builtin/SearchEnginePreset.swift`:
  - Curated preset catalog (Google / DuckDuckGo / Kagi / Brave / Bing / Ecosia) with exact-match lookup (`preset(matching:)`), so a stored template that matches no preset — including a hand-edited variant of a preset URL — renders as **Custom** instead of silently snapping back.
  - `defaultURLTemplate` as the single source of truth; `SearchAction` now references it (behavior unchanged).
- **UI** — `Sources/OpenClip/UI/Preferences/DynamicActionConfigView.swift`:
  - The builtin `builtin.search` `url` option renders a preset `Picker` + (when Custom) a monospaced template `TextField`.
  - Selecting a preset immediately writes the template through the injected option store (`SecretActionOptionStore` → `SettingsStore`, key `action.builtin.search.option.url`); no raw `UserDefaults.standard` access.
- **Tests** — `Tests/OpenClipTests/SearchEnginePresetTests.swift` (8 cases): catalog invariants, issue-suggested preset list, exact matching, custom/self-hosted fallback, hand-edited-variant no-snap-back, preset-by-id lookup, default = Google, and SearchAction default referencing the preset.
- **Docs** — `docs/architecture/known-debt.md` updated (search config surface restored).

## Verification

- `./scripts/test.sh` → **841 tests, 0 failures, 0 skips**
- `./scripts/package_app.sh` (Release build + zip/dmg) → succeeds
- `./scripts/dev_run.sh` → app launches cleanly

## Notes

The issue mentioned localization (`scripts/generate_localizable.py` / `Localizable.xcstrings`), but this repo has no localization infrastructure today (all UI strings are hardcoded English), so this PR follows the existing convention.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a search-engine picker for the built-in Search action.
  * Choose from Google, DuckDuckGo, Kagi, Brave, Bing, and Ecosia.
  * Added a Custom option for entering or preserving other search URL templates.
  * Search settings now use a consistent default search engine configuration.

* **Documentation**
  * Updated settings documentation to reflect the available search-engine configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->