### PR TITLE
fix(popup): resolve cursor stickiness by installing AppKit tracking areas on popup and sub-bar panels

### DIFF
--- a/Sources/OpenClip/UI/Popup/PopupPanel.swift
+++ b/Sources/OpenClip/UI/Popup/PopupPanel.swift
@@ -39,6 +39,7 @@ public class PopupPanel: NSPanel {
         self.backgroundColor = .clear
         self.isOpaque = false
         self.hasShadow = false   // SwiftUI draws its own shadow; panel shadow causes double artifacts
+        self.acceptsMouseMovedEvents = true
     }
 
     override public var canBecomeKey: Bool { allowsKey }
@@ -52,6 +53,8 @@ public class PopupPanel: NSPanel {
     /// whatever window is actually beneath the pointer, where the controller's global monitor then
     /// dismisses the popup.
     public final class ContentView: NSHostingView<PopupView> {
+        private var trackingAreaRef: NSTrackingArea?
+
         /// Pure hit-test rule (unit-testable without a live SwiftUI tree): only the area inside the
         /// shadow ring belongs to the popup.
         public static func isInsideClickableRegion(point: NSPoint, bounds: NSRect) -> Bool {
@@ -60,6 +63,38 @@ public class PopupPanel: NSPanel {
 
         public override func isMousePoint(_ point: NSPoint, in rect: NSRect) -> Bool {
             Self.isInsideClickableRegion(point: point, bounds: bounds)
+        }
+
+        public override func updateTrackingAreas() {
+            super.updateTrackingAreas()
+            if let existing = trackingAreaRef {
+                removeTrackingArea(existing)
+            }
+            let area = NSTrackingArea(
+                rect: bounds,
+                options: [.cursorUpdate, .activeAlways, .inVisibleRect, .mouseEnteredAndExited],
+                owner: self,
+                userInfo: nil
+            )
+            addTrackingArea(area)
+            self.trackingAreaRef = area
+        }
+
+        public override func cursorUpdate(with event: NSEvent) {
+            NSCursor.arrow.set()
+        }
+
+        public override func mouseEntered(with event: NSEvent) {
+            super.mouseEntered(with: event)
+            NSCursor.arrow.set()
+        }
+
+        public override func resetCursorRects() {
+            super.resetCursorRects()
+            let clickable = bounds.insetBy(dx: PopupMetrics.popupShadowInset, dy: PopupMetrics.popupShadowInset)
+            if !clickable.isEmpty {
+                addCursorRect(clickable, cursor: .arrow)
+            }
         }
     }
 

--- a/Sources/OpenClip/UI/Popup/PopupWindowController.swift
+++ b/Sources/OpenClip/UI/Popup/PopupWindowController.swift
@@ -744,6 +744,9 @@ public class PopupWindowController {
         if PopupHoverState.shared.usesGlobalMouseMonitoring {
             panel.ignoresMouseEvents = !overContent
         }
+        if overContent {
+            NSCursor.arrow.set()
+        }
 
         let windowPoint = panel.convertPoint(fromScreen: screenLocation)
         let contentPoint = contentView.convert(windowPoint, from: nil)
@@ -758,12 +761,15 @@ public class PopupWindowController {
         // pixel boundary; `@Published` emits on every assignment, so skip identical locations to
         // keep the `.onReceive` hit-tests from re-running at event-monitor rate.
         guard point != PopupHoverState.shared.location else { return }
-        NSCursor.arrow.set()
         PopupHoverState.shared.location = point
     }
 
     private func updateSubBarHover(at screenLocation: CGPoint) {
         guard subBarController.isShowing, !subBarController.isPinned else { return }
+
+        if subBarController.isOverContent(screenLocation) {
+            NSCursor.arrow.set()
+        }
 
         // Is the pointer anywhere over the sub-bar window (including comfort margin)?
         let overSubBar = subBarController.panelFrame.insetBy(dx: -4, dy: -4).contains(screenLocation)

--- a/Sources/OpenClip/UI/Popup/SubBarPanel.swift
+++ b/Sources/OpenClip/UI/Popup/SubBarPanel.swift
@@ -32,12 +32,46 @@ public final class SubBarPanel: NSPanel {
 
     /// Root content view of the sub-bar panel. Excludes the shadow inset ring from mouse clicks.
     public final class ContentView: NSHostingView<AnyView> {
+        private var trackingAreaRef: NSTrackingArea?
+
         public static func isInsideClickableRegion(point: NSPoint, bounds: NSRect) -> Bool {
             bounds.insetBy(dx: PopupMetrics.popupShadowInset, dy: PopupMetrics.popupShadowInset).contains(point)
         }
 
         public override func isMousePoint(_ point: NSPoint, in rect: NSRect) -> Bool {
             Self.isInsideClickableRegion(point: point, bounds: bounds)
+        }
+
+        public override func updateTrackingAreas() {
+            super.updateTrackingAreas()
+            if let existing = trackingAreaRef {
+                removeTrackingArea(existing)
+            }
+            let area = NSTrackingArea(
+                rect: bounds,
+                options: [.cursorUpdate, .activeAlways, .inVisibleRect, .mouseEnteredAndExited],
+                owner: self,
+                userInfo: nil
+            )
+            addTrackingArea(area)
+            self.trackingAreaRef = area
+        }
+
+        public override func cursorUpdate(with event: NSEvent) {
+            NSCursor.arrow.set()
+        }
+
+        public override func mouseEntered(with event: NSEvent) {
+            super.mouseEntered(with: event)
+            NSCursor.arrow.set()
+        }
+
+        public override func resetCursorRects() {
+            super.resetCursorRects()
+            let clickable = bounds.insetBy(dx: PopupMetrics.popupShadowInset, dy: PopupMetrics.popupShadowInset)
+            if !clickable.isEmpty {
+                addCursorRect(clickable, cursor: .arrow)
+            }
         }
     }
 }

--- a/Tests/OpenClipTests/PopupPanelTests.swift
+++ b/Tests/OpenClipTests/PopupPanelTests.swift
@@ -740,4 +740,45 @@ final class PopupPanelTests: XCTestCase {
         controller.modeStore.isSubBarActive = false
         XCTAssertTrue(panel.pinBottomEdgeOnResize)
     }
+
+    func testPopupPanelAcceptsMouseMovedEvents() {
+        let panel = PopupPanel()
+        XCTAssertTrue(panel.acceptsMouseMovedEvents, "PopupPanel must accept mouse-moved events for responsive cursor tracking")
+    }
+
+    func testPopupPanelContentViewInstallsTrackingAreaForCursorUpdate() {
+        let panel = PopupPanel()
+        let host = PopupPanel.ContentView(rootView: PopupView(actions: [], context: ActionContext(selection: SelectionContext(text: "test", sourceApp: AppIdentity(bundleIdentifier: "com.test", localizedName: "Test"), cursorPosition: .zero, timestamp: Date(), appPolicy: .default)), onResult: { _ in }))
+        host.frame = NSRect(x: 0, y: 0, width: 200, height: 60)
+        panel.contentView = host
+        host.updateTrackingAreas()
+
+        let trackingAreas = host.trackingAreas
+        XCTAssertFalse(trackingAreas.isEmpty, "ContentView must install a tracking area")
+        guard let area = trackingAreas.first else { return }
+        XCTAssertTrue(area.options.contains(.cursorUpdate), "Tracking area must contain .cursorUpdate")
+        XCTAssertTrue(area.options.contains(.activeAlways), "Tracking area must contain .activeAlways")
+        XCTAssertTrue(area.options.contains(.inVisibleRect), "Tracking area must contain .inVisibleRect")
+        XCTAssertTrue(area.options.contains(.mouseEnteredAndExited), "Tracking area must contain .mouseEnteredAndExited")
+    }
+
+    func testPopupPanelContentViewCursorUpdateAndMouseEntered() {
+        let host = PopupPanel.ContentView(rootView: PopupView(actions: [], context: ActionContext(selection: SelectionContext(text: "test", sourceApp: AppIdentity(bundleIdentifier: "com.test", localizedName: "Test"), cursorPosition: .zero, timestamp: Date(), appPolicy: .default)), onResult: { _ in }))
+        let dummyEvent = NSEvent.mouseEvent(
+            with: .mouseMoved,
+            location: .zero,
+            modifierFlags: [],
+            timestamp: 0,
+            windowNumber: 0,
+            context: nil,
+            eventNumber: 0,
+            clickCount: 0,
+            pressure: 0
+        )!
+
+        // Should execute cleanly without runtime error
+        host.cursorUpdate(with: dummyEvent)
+        host.mouseEntered(with: dummyEvent)
+        host.resetCursorRects()
+    }
 }

--- a/Tests/OpenClipTests/SubBarPanelControllerTests.swift
+++ b/Tests/OpenClipTests/SubBarPanelControllerTests.swift
@@ -2,6 +2,8 @@
 // OpenClipTests
 
 import XCTest
+import AppKit
+import SwiftUI
 @testable import OpenClip
 @testable import Core
 
@@ -429,6 +431,42 @@ final class SubBarPanelControllerTests: XCTestCase {
         XCTAssertEqual(controller.activeState?.groupID, "group.test")
         controller.hide()
         XCTAssertFalse(controller.isShowing)
+    }
+
+    func testSubBarPanelContentViewInstallsTrackingAreaForCursorUpdate() {
+        let panel = SubBarPanel()
+        let host = SubBarPanel.ContentView(rootView: AnyView(Text("test")))
+        host.frame = NSRect(x: 0, y: 0, width: 200, height: 60)
+        panel.contentView = host
+        host.updateTrackingAreas()
+
+        let trackingAreas = host.trackingAreas
+        XCTAssertFalse(trackingAreas.isEmpty, "ContentView must install a tracking area")
+        guard let area = trackingAreas.first else { return }
+        XCTAssertTrue(area.options.contains(.cursorUpdate), "Tracking area must contain .cursorUpdate")
+        XCTAssertTrue(area.options.contains(.activeAlways), "Tracking area must contain .activeAlways")
+        XCTAssertTrue(area.options.contains(.inVisibleRect), "Tracking area must contain .inVisibleRect")
+        XCTAssertTrue(area.options.contains(.mouseEnteredAndExited), "Tracking area must contain .mouseEnteredAndExited")
+    }
+
+    func testSubBarPanelContentViewCursorUpdateAndMouseEntered() {
+        let host = SubBarPanel.ContentView(rootView: AnyView(Text("test")))
+        let dummyEvent = NSEvent.mouseEvent(
+            with: .mouseMoved,
+            location: .zero,
+            modifierFlags: [],
+            timestamp: 0,
+            windowNumber: 0,
+            context: nil,
+            eventNumber: 0,
+            clickCount: 0,
+            pressure: 0
+        )!
+
+        // Should execute cleanly without runtime error
+        host.cursorUpdate(with: dummyEvent)
+        host.mouseEntered(with: dummyEvent)
+        host.resetCursorRects()
     }
 }
 


### PR DESCRIPTION
## Summary

Fixes #11.

Resolves the issue where the cursor intermittently remained stuck displaying the background application's cursor (I-beam, pointing hand, crosshair, etc.) when hovering over the floating popup bar and sub-bar buttons.

## Root Cause Analysis
1. **Missing AppKit Cursor Tracking**: `PopupPanel` and `SubBarPanel` are non-activating panels (`[.nonactivatingPanel]`). Without an `NSTrackingArea` or cursor rect registered with WindowServer, AppKit never issued cursor change events (`cursorUpdate:`) across window boundaries when hovering from background applications.
2. **Throttled Ad-hoc Cursor Setting**: `NSCursor.arrow.set()` in `PopupWindowController.updatePopupHover` was only triggered if the mouse location changed to a new discretized point (`point != PopupHoverState.shared.location`), preventing reassertion when stationary or during slight sub-pixel movement.
3. **Sub-Bar Omission**: `SubBarPanel` and `updateSubBarHover` did not have cursor assertions.
4. **Missing Window Tracking**: `PopupPanel` did not have `acceptsMouseMovedEvents = true`.

## Fixes Implemented
- Installed `NSTrackingArea` with `[.cursorUpdate, .activeAlways, .inVisibleRect, .mouseEnteredAndExited]` on `PopupPanel.ContentView` and `SubBarPanel.ContentView`.
- Overrode `cursorUpdate(with:)`, `mouseEntered(with:)`, and `resetCursorRects()` on both content views to assert `NSCursor.arrow`.
- Configured `PopupPanel.init()` with `self.acceptsMouseMovedEvents = true`.
- Updated `PopupWindowController.updatePopupHover` and `updateSubBarHover` to assert `NSCursor.arrow` whenever hovering over interactive content (`isOverPanelContent` / `isOverContent`) without throttling.
- Added unit tests in `PopupPanelTests` and `SubBarPanelControllerTests` verifying tracking areas, window configuration, and cursor updates.

## Verification
- Ran `./scripts/test.sh PopupPanelTests` (32/32 tests passed).
- Ran `./scripts/test.sh SubBarPanelControllerTests` (12/12 tests passed).
- Ran full test suite via `./scripts/test.sh` (924/924 tests passed, 0 failures, 0 skips).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved cursor behavior in popup panels and sub-bars.
  - The arrow cursor now appears only over interactive content, avoiding incorrect cursor changes outside clickable areas.
  - Cursor tracking remains reliable as the pointer enters, moves within, or leaves popup regions.

- **Tests**
  - Added coverage for mouse tracking, cursor updates, and cursor behavior across popup components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->