### PR TITLE
fix(popup): coordinate-based hover highlighting for sub-bar

### DIFF
--- a/Sources/OpenClip/UI/Popup/GroupSubActionBarView.swift
+++ b/Sources/OpenClip/UI/Popup/GroupSubActionBarView.swift
@@ -24,6 +24,7 @@ public struct GroupSubActionBarView: View {
     public let hoveredTarget: PopupHoverTarget?
     public let scale: CGFloat
     @Binding public var currentPage: Int
+    private let hoverState: SubBarHoverState
 
     @AppStorage(SettingKey.popupPageSize.name) private var pageSize: Int = SettingKey.popupPageSize.defaultValue
 
@@ -34,6 +35,7 @@ public struct GroupSubActionBarView: View {
     public init(
         subActions: [any Action],
         currentPage: Binding<Int>,
+        hoverState: SubBarHoverState = .shared,
         onResult: @escaping @MainActor (ActionResult) -> Void,
         onRunAI: @escaping @MainActor (String) -> Void,
         onRunLoadingAction: @escaping @MainActor (any Action) -> Void,
@@ -49,6 +51,7 @@ public struct GroupSubActionBarView: View {
     ) {
         self.subActions = subActions
         self._currentPage = currentPage
+        self.hoverState = hoverState
         self.onResult = onResult
         self.onRunAI = onRunAI
         self.onRunLoadingAction = onRunLoadingAction
@@ -232,7 +235,7 @@ public struct GroupSubActionBarView: View {
         .accessibilityLabel(action.displayTitle(using: presenter))
         .popupHoverTarget(.subAction(index))
         .onHover { isHovering in
-            onHoverTarget(.subAction(index), isHovering)
+            useLocalHoverFallback(for: .subAction(index), isHovering: isHovering)
         }
     }
 
@@ -251,7 +254,12 @@ public struct GroupSubActionBarView: View {
         .accessibilityLabel(label)
         .popupHoverTarget(.chevron(targetKey))
         .onHover { isHovering in
-            onHoverTarget(.chevron(targetKey), isHovering)
+            useLocalHoverFallback(for: .chevron(targetKey), isHovering: isHovering)
         }
+    }
+
+    private func useLocalHoverFallback(for target: PopupHoverTarget, isHovering: Bool) {
+        guard !hoverState.usesGlobalMouseMonitoring else { return }
+        onHoverTarget(target, isHovering)
     }
 }

--- a/Sources/OpenClip/UI/Popup/PopupHoverSupport.swift
+++ b/Sources/OpenClip/UI/Popup/PopupHoverSupport.swift
@@ -17,6 +17,16 @@ public final class PopupHoverState: ObservableObject {
     public init() {}
 }
 
+@MainActor
+public final class SubBarHoverState: ObservableObject {
+    public static let shared = SubBarHoverState()
+
+    @Published public var location: CGPoint?
+    @Published public var usesGlobalMouseMonitoring = false
+
+    public init() {}
+}
+
 public enum PopupHoverTarget: Hashable, Sendable {
     case action(Int)
     case subAction(Int)

--- a/Sources/OpenClip/UI/Popup/PopupWindowController.swift
+++ b/Sources/OpenClip/UI/Popup/PopupWindowController.swift
@@ -557,6 +557,7 @@ public class PopupWindowController {
         hoveredAction = nil
         isMenuTracking = false
         PopupHoverState.shared.location = nil
+        SubBarHoverState.shared.location = nil
     }
     
     private func setupMonitors() {
@@ -564,6 +565,7 @@ public class PopupWindowController {
 
         let canMonitorGlobally = PermissionManager.shared.isAccessibilityGranted
         PopupHoverState.shared.usesGlobalMouseMonitoring = canMonitorGlobally
+        SubBarHoverState.shared.usesGlobalMouseMonitoring = canMonitorGlobally
         if canMonitorGlobally {
             globalEventMonitor = NSEvent.addGlobalMonitorForEvents(matching: [.leftMouseDown, .rightMouseDown, .rightMouseUp, .mouseMoved, .scrollWheel, .keyDown]) { [weak self] event in
                 self?.handleEvent(event)
@@ -729,7 +731,7 @@ public class PopupWindowController {
         return contentView.bounds.contains(contentPoint)
     }
 
-    private func updatePopupHover(at screenLocation: CGPoint) {
+    func updatePopupHover(at screenLocation: CGPoint) {
         guard let panel, panel.isVisible, let contentView = panel.contentView else {
             PopupHoverState.shared.location = nil
             return
@@ -764,12 +766,39 @@ public class PopupWindowController {
         PopupHoverState.shared.location = point
     }
 
-    private func updateSubBarHover(at screenLocation: CGPoint) {
-        guard subBarController.isShowing, !subBarController.isPinned else { return }
+    func updateSubBarHover(at screenLocation: CGPoint) {
+        guard subBarController.isShowing else {
+            SubBarHoverState.shared.location = nil
+            return
+        }
 
-        if subBarController.isOverContent(screenLocation) {
+        let subPanel = subBarController.panel
+        guard subPanel.isVisible, let contentView = subPanel.contentView else {
+            SubBarHoverState.shared.location = nil
+            return
+        }
+
+        let overContent = subBarController.isOverContent(screenLocation)
+        if SubBarHoverState.shared.usesGlobalMouseMonitoring {
+            subPanel.ignoresMouseEvents = !overContent
+        }
+        if overContent {
             NSCursor.arrow.set()
         }
+
+        let windowPoint = subPanel.convertPoint(fromScreen: screenLocation)
+        let contentPoint = contentView.convert(windowPoint, from: nil)
+        if contentView.bounds.contains(contentPoint) {
+            let y = contentView.isFlipped ? contentPoint.y : contentView.bounds.height - contentPoint.y
+            let point = CGPoint(x: contentPoint.x, y: y)
+            if point != SubBarHoverState.shared.location {
+                SubBarHoverState.shared.location = point
+            }
+        } else {
+            SubBarHoverState.shared.location = nil
+        }
+
+        guard !subBarController.isPinned else { return }
 
         // Is the pointer anywhere over the sub-bar window (including comfort margin)?
         let overSubBar = subBarController.panelFrame.insetBy(dx: -4, dy: -4).contains(screenLocation)

--- a/Sources/OpenClip/UI/Popup/SubBarPanelController.swift
+++ b/Sources/OpenClip/UI/Popup/SubBarPanelController.swift
@@ -213,6 +213,8 @@ public final class SubBarPanelController {
         cancelGrace()
         guard isShowing || activeState != nil else { return }
         activeState = nil
+        SubBarHoverState.shared.location = nil
+        panel.ignoresMouseEvents = false
         panel.orderOut(nil)
         panel.contentView = nil
         onDismiss?()
@@ -249,6 +251,7 @@ private struct SubBarContentView: View {
     let onHoverChange: @MainActor @Sendable (Bool) -> Void
 
     @State private var currentPage: Int = 0
+    private let hoverState: SubBarHoverState = .shared
     @State private var hoveredTarget: PopupHoverTarget? = nil
     @State private var activeTooltip: (text: String, frame: CGRect)? = nil
     @State private var isTooltipHot: Bool = false
@@ -261,6 +264,7 @@ private struct SubBarContentView: View {
         let subBar = GroupSubActionBarView(
             subActions: subActions,
             currentPage: $currentPage,
+            hoverState: hoverState,
             onResult: onResult,
             onRunAI: onRunAI,
             onRunLoadingAction: onRunLoadingAction,
@@ -317,6 +321,10 @@ private struct SubBarContentView: View {
         .coordinateSpace(name: "popupHoverSpace")
         .onPreferenceChange(PopupHoverFramePreferenceKey.self) { frames in
             hoverFrames = frames
+            updateHoveredTarget(for: hoverState.location)
+        }
+        .onReceive(hoverState.$location) { location in
+            updateHoveredTarget(for: location)
         }
         .overlay(alignment: .topLeading) {
             GeometryReader { geo in
@@ -339,6 +347,14 @@ private struct SubBarContentView: View {
         .onChange(of: hoveredTarget) { _, newTarget in
             updateTooltip(for: newTarget)
         }
+    }
+
+    private func updateHoveredTarget(for location: CGPoint?) {
+        let target = location.flatMap { point in
+            hoverFrames.first(where: { $0.value.contains(point) })?.key
+        }
+        guard target != hoveredTarget else { return }
+        hoveredTarget = target
     }
 
     private func updateTooltip(for target: PopupHoverTarget?) {

--- a/Tests/OpenClipTests/GroupSubActionBarViewTests.swift
+++ b/Tests/OpenClipTests/GroupSubActionBarViewTests.swift
@@ -1,5 +1,6 @@
 // GroupSubActionBarViewTests.swift
 import XCTest
+import SwiftUI
 @testable import OpenClip
 @testable import Core
 
@@ -81,6 +82,51 @@ final class GroupSubActionBarViewTests: XCTestCase {
 
         let widthWithChevrons = GroupSubActionBarView.measuredPageWidth(actions: [a1, a2], hasLeftChevron: true, hasRightChevron: true)
         XCTAssertEqual(widthWithChevrons, expectedActionWidth + 29 + 29)
+    }
+
+    @MainActor
+    func testSubBarHoverStateIsolation() {
+        let subBarState = SubBarHoverState.shared
+        let mainState = PopupHoverState.shared
+
+        subBarState.location = CGPoint(x: 123, y: 456)
+        mainState.location = CGPoint(x: 789, y: 101)
+
+        XCTAssertEqual(subBarState.location, CGPoint(x: 123, y: 456))
+        XCTAssertEqual(mainState.location, CGPoint(x: 789, y: 101))
+
+        subBarState.location = nil
+        XCTAssertNil(subBarState.location)
+        XCTAssertEqual(mainState.location, CGPoint(x: 789, y: 101), "Modifying SubBarHoverState must not touch PopupHoverState")
+
+        mainState.location = nil
+    }
+
+    @MainActor
+    func testGroupSubActionBarViewCustomHoverStateInjection() {
+        let customState = SubBarHoverState()
+        customState.usesGlobalMouseMonitoring = true
+        customState.location = CGPoint(x: 50, y: 20)
+
+        let a1 = TestAction(id: "1", title: "A", icon: .symbol("star"))
+        var page = 0
+        let view = GroupSubActionBarView(
+            subActions: [a1],
+            currentPage: Binding(get: { page }, set: { page = $0 }),
+            hoverState: customState,
+            onResult: { _ in },
+            onRunAI: { _ in },
+            onRunLoadingAction: { _ in },
+            onWillPerformAction: { _ in },
+            onActionPerformed: { _ in },
+            onClickIntent: { .primary },
+            context: ActionContext(selection: SelectionContext(text: "test", sourceApp: AppIdentity(bundleIdentifier: "com.test", localizedName: "Test"), cursorPosition: .zero, timestamp: Date(), appPolicy: .default)),
+            presenter: ActionCustomizationManager.shared,
+            effectiveTheme: "dark",
+            hoveredTarget: nil,
+            scale: 1.0
+        )
+        XCTAssertNotNil(view)
     }
 }
 

--- a/Tests/OpenClipTests/SubBarPanelControllerTests.swift
+++ b/Tests/OpenClipTests/SubBarPanelControllerTests.swift
@@ -468,5 +468,53 @@ final class SubBarPanelControllerTests: XCTestCase {
         host.mouseEntered(with: dummyEvent)
         host.resetCursorRects()
     }
+
+    func testSubBarHoverLocationPublishedOnMouseMoveAndClearedOnHide() {
+        let isolatedPasteboard = NSPasteboard(name: NSPasteboard.Name("OpenClipTest-\(UUID().uuidString)"))
+        let subBar = SubBarPanelController()
+        let controller = PopupWindowController(
+            resultHandler: DefaultActionResultHandler(pasteboard: isolatedPasteboard),
+            subBarController: subBar
+        )
+        let parent = TestAction(id: "group.test", title: "Test Group", icon: .symbol("folder"))
+        let sub1 = TestAction(id: "sub.1", title: "Sub 1", icon: .symbol("star"))
+        let buttonFrame = NSRect(x: 200, y: 300, width: 40, height: 29)
+
+        subBar.show(
+            for: parent,
+            parentIndex: 0,
+            subActions: [sub1],
+            parentButtonScreenFrame: buttonFrame,
+            isPinned: false,
+            searchResultsAbove: true,
+            effectiveTheme: "dark",
+            effectiveColorScheme: .dark,
+            scale: 1.0,
+            context: makeContext(),
+            presenter: ActionCustomizationManager.shared,
+            onResult: { _ in },
+            onRunAI: { _ in },
+            onRunLoadingAction: { _ in },
+            onWillPerformAction: { _ in },
+            onActionPerformed: { _ in },
+            onClickIntent: { .primary }
+        )
+
+        XCTAssertTrue(subBar.isShowing)
+
+        // Mouse over center of sub-bar
+        let center = CGPoint(x: subBar.panelFrame.midX, y: subBar.panelFrame.midY)
+        controller.updateSubBarHover(at: center)
+        XCTAssertNotNil(SubBarHoverState.shared.location, "SubBarHoverState location must be set when hovering over sub-bar")
+
+        // Mouse moved far away
+        let farAway = CGPoint(x: 10, y: 10)
+        controller.updateSubBarHover(at: farAway)
+        XCTAssertNil(SubBarHoverState.shared.location, "SubBarHoverState location must be nil when cursor is outside sub-bar")
+
+        // Hide clears state
+        subBar.hide()
+        XCTAssertNil(SubBarHoverState.shared.location)
+    }
 }
 


### PR DESCRIPTION
## Summary

Fixes #10.

Implements fast, coordinate-based button hover highlighting in the group sub-bar (`GroupSubActionBarView`) to match the main action bar's 0ms responsiveness, without touching or altering `PopupHoverState.shared`.

## Changes
- **Scoped SubBarHoverState**: Introduced `SubBarHoverState` (`SubBarHoverState.shared`) in `PopupHoverSupport.swift` structurally scoped to the sub-bar panel's coordinate space.
- **Coordinate Conversion & Dynamic Click-Through**: Updated `PopupWindowController.updateSubBarHover(at:)` to transform screen coordinates into the sub-bar panel's content view space, invert Y, and publish to `SubBarHoverState.shared.location`. Also added dynamic click-through (`subPanel.ignoresMouseEvents = !overContent`).
- **Narrow Subscription Pattern**: `SubBarContentView` holds `SubBarHoverState` unobserved and subscribes to `$location` via `.onReceive` to hit-test against registered `hoverFrames` without triggering full view body re-evaluations.
- **Local Fallback**: Replaced direct `.onHover` in `GroupSubActionBarView` with `useLocalHoverFallback` that bypasses `.onHover` when global monitoring is active while preserving functionality when Accessibility permissions are unavailable.
- **Tests**: Added tests in `GroupSubActionBarViewTests` and `SubBarPanelControllerTests` verifying state isolation, coordinate publishing, and clean teardown on hide.

## Verification
- Ran `GroupSubActionBarViewTests` (10/10 passed).
- Ran `SubBarPanelControllerTests` (13/13 passed).
- Ran full test suite via `./scripts/test.sh` (927/927 tests passed, 0 failures, 0 skips).