### PR TITLE
fix(settings): replace unsafe force-casts in SettingsStore.get with safe fallbacks

### DIFF
--- a/Sources/Core/Settings/SettingsStore.swift
+++ b/Sources/Core/Settings/SettingsStore.swift
@@ -26,12 +26,15 @@ public final class DefaultSettingsStore: SettingsStore, @unchecked Sendable {
     }
 
     public func get<T>(_ key: SettingKey<T>) -> T {
+        // All branches use conditional casts and fall back to key.defaultValue: stored
+        // preferences can be missing, corrupted, or hold an unexpected type, and setting
+        // retrieval must never crash the host process.
         if T.self == Set<String>.self {
             let array = userDefaults.stringArray(forKey: key.name) ?? []
-            return (Set(array) as! T)
+            return (Set(array) as? T) ?? key.defaultValue
         }
         if T.self == Data?.self {
-            return (userDefaults.data(forKey: key.name) as! T)
+            return (userDefaults.data(forKey: key.name) as? T) ?? key.defaultValue
         }
         return (userDefaults.object(forKey: key.name) as? T) ?? key.defaultValue
     }

--- a/Tests/OpenClipTests/SettingsStoreTests.swift
+++ b/Tests/OpenClipTests/SettingsStoreTests.swift
@@ -75,6 +75,47 @@ final class SettingsStoreTests: XCTestCase {
         XCTAssertEqual(store.get(.secondaryClickBehavior), "paste")
     }
 
+    // MARK: - Safe fallbacks (issue #21)
+
+    @MainActor
+    func testSetKeyWithUnexpectedStoredTypeReturnsDefault() {
+        // A non-array value stored under a Set<String> key must not crash — fall back to [].
+        userDefaults.set("not-an-array", forKey: SettingKey.disabledActionIDs.name)
+        XCTAssertEqual(store.get(.disabledActionIDs), [])
+
+        // An array of the wrong element type is not readable as [String] — fall back to [].
+        userDefaults.set([1, 2, 3], forKey: SettingKey.disabledPackages.name)
+        XCTAssertEqual(store.get(.disabledPackages), [])
+    }
+
+    @MainActor
+    func testSetKeyRoundTripStillWorks() {
+        store.set(.disabledActionIDs, value: ["builtin.search", "builtin.define"])
+        XCTAssertEqual(store.get(.disabledActionIDs), ["builtin.search", "builtin.define"])
+        store.set(.disabledActionIDs, value: [])
+        XCTAssertEqual(store.get(.disabledActionIDs), [])
+    }
+
+    @MainActor
+    func testOptionalDataKeyWithUnexpectedStoredTypeReturnsDefault() {
+        // A non-data value stored under a Data? key must not crash — fall back to nil.
+        userDefaults.set("not-data", forKey: SettingKey.actionGroups.name)
+        XCTAssertNil(store.get(.actionGroups))
+
+        userDefaults.set(42, forKey: SettingKey.actionCustomizations.name)
+        XCTAssertNil(store.get(.actionCustomizations))
+    }
+
+    @MainActor
+    func testOptionalDataKeyRoundTrip() {
+        // Unset key reads back the default (nil).
+        XCTAssertNil(store.get(.actionGroups))
+
+        let payload = "hello".data(using: .utf8)
+        store.set(.actionCustomizations, value: payload)
+        XCTAssertEqual(store.get(.actionCustomizations), payload)
+    }
+
     func testResultDeliveryPreferenceMapping() {
         XCTAssertEqual(ResultDeliveryPreference.allCases, [.preview, .paste, .copy])
         XCTAssertEqual(ResultDeliveryPreference(rawValue: "preview"), .preview)


### PR DESCRIPTION
Closes #21

## Summary
`DefaultSettingsStore.get` contained two explicit force-casts (`as! T`) for the `Set<String>` and `Data?` branches. If `UserDefaults` ever returns an unexpected type or a dynamic cast fails, `as! T` triggers a fatal runtime crash and takes down the host process.

This replaces both with safe conditional casts that fall back to `key.defaultValue`.

## Changes
- `Sources/Core/Settings/SettingsStore.swift`: `as! T` → `as? T ?? key.defaultValue` for the `Set<String>` and `Data?` branches.
- `Tests/OpenClipTests/SettingsStoreTests.swift`: added tests verifying that unexpected stored types (string / int-array under a `Set<String>` key, string / int under a `Data?` key) return the default value without throwing or crashing, plus round-trip regression guards.

## Verification
- `./scripts/test.sh SettingsStoreTests` → 13 tests, 0 failures.
- Full suite: 906/911 pass; the 5 failures are pre-existing localization-assertion issues in `AppUpdateManagerTests`/`OpenClipJSHostTests` (hardcoded English expectations vs. zh-Hans runtime locale) and reproduce identically on `main` without these changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Prevented settings retrieval from crashing when stored values are missing, corrupted, or have an unexpected type.
  - Settings now safely fall back to their default values when necessary.

- **Tests**
  - Added coverage for invalid stored values and round-trip handling of set and data settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->