### PR TITLE
fix(tests): run suite in English via -testLanguage en for locale-independent assertions

### DIFF
--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -43,7 +43,11 @@ CORE_TEST_FLAGS=(
 
 run_xcodebuild() {
     local extra_args=("$@")
-    local cmd=(xcodebuild -project OpenClip.xcodeproj -scheme OpenClipTests -destination 'platform=macOS' "${extra_args[@]}" test)
+    # Force tests to run in English (-testLanguage en) so hardcoded English assertions in the
+    # suite are deterministic regardless of the host machine's locale (dev machines run zh-Hans;
+    # CI runners are en). Without this, `String(localized:)` resolves per-locale and tests that
+    # assert English copy fail outside English environments.
+    local cmd=(xcodebuild -project OpenClip.xcodeproj -scheme OpenClipTests -destination 'platform=macOS' -testLanguage en "${extra_args[@]}" test)
 
     if [ "$VERBOSE" = true ]; then
         "${cmd[@]}"


### PR DESCRIPTION
## Problem
The full test suite fails on non-English dev machines. Tests hardcode English assertions (e.g. `"Check for Updates…"`, `"Proofread"`, `"Generating…"`, `"Required option not set."`), but `String(localized:)` resolves per-locale. On a zh-Hans machine this produced 13 failures across 4 classes:

- `AIActionTests.testAIActionIconForPreset` (8)
- `AppUpdateManagerTests.testStatusBarControllerUpdatesMenuItemWhenUpdateAvailable` (3)
- `OpenClipJSHostTests.testMissingRequiredOptionsShortCircuitsToOpenConfigurationBeforeJSRuns` (1)
- `PopupPanelTests.testRunAIPresetShowsLoadingToastAndDismissesOnResultCard` (1)

CI (macOS runners, English) never saw these; they only surface on localized hosts.

## Fix
Force the test host to run in English via xcodebuild's `-testLanguage en` in `scripts/test.sh`. This makes the suite deterministic and locale-independent — fixing all 13 failures plus any future locale-dependent assertions, regardless of the host machine's language. Verified end-to-end; a per-process `UserDefaults` `AppleLanguages` injection does **not** work (the app bundle resolves its preferred localizations at process start).

## Verification
- `./scripts/test.sh` → **934 tests, 0 failures** (was 13 failures on zh-Hans host).
- Targeted check: `xcodebuild ... -testLanguage en -only-testing:OpenClipTests/AppUpdateManagerTests test` → 3/3 pass.