### PR TITLE
docs: correct Xcode prerequisite to 16+ in CONTRIBUTING.md (Fixes #23)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,7 +11,7 @@ required reading before touching code.
 
 ## Getting started
 
-**Prerequisites:** macOS 14+, [Xcode 15+](https://apps.apple.com/us/app/xcode/id497799835),
+**Prerequisites:** macOS 14+, [Xcode 16+](https://apps.apple.com/us/app/xcode/id497799835),
 [XcodeGen](https://github.com/yonaskolb/XcodeGen) (`brew install xcodegen`).
 
 ```bash


### PR DESCRIPTION
Closes #23

## Summary
`CONTRIBUTING.md` listed `Xcode 15+` as a prerequisite, but the project requires Swift 6 with `SWIFT_STRICT_CONCURRENCY: complete`, which needs Xcode 16+. `README.md` already documents `Xcode 16+`, so this brings `CONTRIBUTING.md` in line.

## Changes
- `CONTRIBUTING.md`: `Xcode 15+` → `Xcode 16+` in the Getting Started prerequisites.

Docs-only change; no code or tests affected.