### PR TITLE
feat(cli): add --version/-v and -h CLI flags (Closes #16)

### DIFF
--- a/Sources/OpenClip/AppDelegate.swift
+++ b/Sources/OpenClip/AppDelegate.swift
@@ -41,6 +41,9 @@ class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCenterDele
         _ = DebugLogStore.shared
 
         switch DebugLogCommand.parse(CommandLine.arguments) {
+        case .showVersion:
+            print(DebugLogCommand.version)
+            exit(0)
         case .showHelp:
             print(DebugLogCommand.usage)
             exit(0)

--- a/Sources/OpenClip/Platform/DebugLogging/DebugLogCommand.swift
+++ b/Sources/OpenClip/Platform/DebugLogging/DebugLogCommand.swift
@@ -21,6 +21,7 @@ enum DebugLogCommand {
         case none
         case dumpLogs(DumpOptions)
         case showHelp
+        case showVersion
         case usageError(String)
     }
 
@@ -33,8 +34,10 @@ enum DebugLogCommand {
             let arg = args[index]
             if arg == "--dump-logs" {
                 sawDump = true
-            } else if arg == "--help" {
+            } else if arg == "--help" || arg == "-h" {
                 return .showHelp
+            } else if arg == "--version" || arg == "-v" {
+                return .showVersion
             } else if let (key, value) = splitFlag(arg) {
                 switch key {
                 case "category": options.category = value
@@ -74,23 +77,40 @@ enum DebugLogCommand {
         return (String(body[..<eq]), String(body[body.index(after: eq)...]))
     }
 
+    /// The app version and build, e.g. `OpenClip 1.2.0 (5)`. Reads the running binary's
+    /// `CFBundleShortVersionString` / `CFBundleVersion` (XcodeGen derives both from
+    /// `MARKETING_VERSION` / `CURRENT_PROJECT_VERSION` in project.yml), falling back to
+    /// `unknown` if the keys are absent.
+    static var version: String {
+        let short = Bundle.main.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String ?? "unknown"
+        let build = Bundle.main.object(forInfoDictionaryKey: "CFBundleVersion") as? String
+        if let build, !build.isEmpty {
+            return "OpenClip \(short) (\(build))"
+        }
+        return "OpenClip \(short)"
+    }
+
     static var usage: String {
         """
-        Usage: OpenClip --dump-logs [options]
+        Usage: OpenClip [--version | --help] [--dump-logs [options]]
 
-        Prints recent OpenClip log entries (subsystem com.openclip) from this process
-        and exits. Run the app binary directly (not via dev_run.sh).
+        Prints the OpenClip version, shows help, or dumps recent OpenClip log entries
+        (subsystem com.openclip) from this process and exits. Run the app binary
+        directly (not via dev_run.sh).
 
         Logs are also persistently written to ~/Library/Logs/OpenClip/openclip.log.
 
         Options:
+          --version, -v          Print the OpenClip version and exit
+          --help, -h             Show this help
+          --dump-logs            Dump recent log entries and exit
           --category=<name>      Only entries from this Log category (e.g. extensions)
           --level=<level>        Only entries at this severity: debug, info, notice, warning, error, fault
           --count=<N>            Max number of lines (default 500)
           --collect=<seconds>    Collect window before dumping (default 4)
-          --help                 Show this help
 
         Examples:
+          OpenClip --version
           OpenClip --dump-logs --category=extensions --level=error
           OpenClip --dump-logs --count=20 --collect=0
         """

--- a/Tests/OpenClipTests/DebugLogCommandTests.swift
+++ b/Tests/OpenClipTests/DebugLogCommandTests.swift
@@ -55,6 +55,22 @@ final class DebugLogCommandTests: XCTestCase {
         XCTAssertEqual(DebugLogCommand.parse(["OpenClip", "--help"]), .showHelp)
     }
 
+    func testShortHelpFlag() {
+        XCTAssertEqual(DebugLogCommand.parse(["OpenClip", "-h"]), .showHelp)
+    }
+
+    func testVersionLongFlag() {
+        XCTAssertEqual(DebugLogCommand.parse(["OpenClip", "--version"]), .showVersion)
+    }
+
+    func testVersionShortFlag() {
+        XCTAssertEqual(DebugLogCommand.parse(["OpenClip", "-v"]), .showVersion)
+    }
+
+    func testVersionStringPrefixedWithAppName() {
+        XCTAssertTrue(DebugLogCommand.version.hasPrefix("OpenClip"))
+    }
+
     func testUnknownFlagIsUsageError() {
         guard case .usageError(let message) = DebugLogCommand.parse(["OpenClip", "--bogus"]) else {
             return XCTFail("expected usageError")


### PR DESCRIPTION
Closes #16

## Summary

Adds standard `--version` / `-v` and `-h` CLI flags to the OpenClip binary so it behaves like a conventional command-line tool. Previously:

- `OpenClip --version` failed with `error: Unknown flag '--version'` and exited 2
- `OpenClip -v` / `-h` were silently ignored (fell through the "ignore non-\`--\` args" branch) and launched the app

## Changes

- `Sources/OpenClip/Platform/DebugLogging/DebugLogCommand.swift`
  - New `Mode.showVersion` case; `--version` / `-v` parse to it; `-h` now parses to `showHelp` alongside `--help`
  - New `DebugLogCommand.version` — reads `CFBundleShortVersionString` / `CFBundleVersion` (derived from `MARKETING_VERSION` / `CURRENT_PROJECT_VERSION` in `project.yml`), e.g. `OpenClip 1.2.0 (5)`, with an `unknown` fallback
  - `usage` text updated to document the new flags
- `Sources/OpenClip/AppDelegate.swift` — handles `.showVersion` by printing the version and exiting 0 (mirrors the existing `.showHelp` path)
- `Tests/OpenClipTests/DebugLogCommandTests.swift` — tests for `--version`, `-v`, `-h`, and a version-string sanity check

## Verification

- Full test suite: **938 tests, 0 failures** (includes the 4 new CLI tests)
- Manual end-to-end against the built Debug binary:
  - `OpenClip --version` → `OpenClip 1.2.0 (5)`, exit 0
  - `OpenClip -v` → `OpenClip 1.2.0 (5)`, exit 0
  - `OpenClip -h` / `--help` → usage text, exit 0
  - `OpenClip --bogus` → still errors on stderr with exit 2 (unknown-flag behavior preserved)

No changes to app launch behavior for normal (no-arg) invocations.