### PR TITLE
feat(scripts): verify referenced local icon files exist in validate_extension.sh (Closes #20)

### DIFF
--- a/scripts/validate_extension.sh
+++ b/scripts/validate_extension.sh
@@ -9,6 +9,7 @@
 #   * group sub-actions are validated recursively
 #   * option identifiers are unique and complete
 #   * referenced script files must exist inside the package
+#   * referenced local icon files must exist inside the package
 #
 # Usage: scripts/validate_extension.sh <extension-directory>
 # Exit: 0 = manifest found and valid; 1 = manifest found but invalid; 2 = no manifest found.
@@ -160,6 +161,33 @@ done < <(jq -r '[.. | objects | .script?] | map(select(type == "string" and leng
 
 if [ -n "$MISSING" ]; then
     echo "validate_extension: $MANIFEST references missing script file(s):$MISSING" >&2
+    exit 1
+fi
+
+# Referenced local icon files must exist inside the package.
+# Mirrors the host's ExtensionManager.parseIcon (see Constants.imageExtensions):
+# a value ending with a known image extension is resolved as a local file inside
+# the package directory; everything else — `symbol(...)` / `symbol:` prefixes,
+# bare SF Symbol names, and HTTP(S) URLs — is a symbol and needs no file.
+MISSING_ICON=""
+while IFS= read -r icon; do
+    [ -n "$icon" ] || continue
+    case "$icon" in
+        symbol\(*|symbol:*|http://*|https://*) continue ;;
+    esac
+    icon_lower="$(printf '%s' "$icon" | tr '[:upper:]' '[:lower:]')"
+    case "$icon_lower" in
+        *.png|*.jpg|*.jpeg|*.icns|*.gif|*.svg)
+            if [ ! -f "$SRC_DIR/$icon" ]; then
+                MISSING_ICON="$MISSING_ICON missing icon file: $icon"
+            fi
+            ;;
+        *) continue ;;
+    esac
+done < <(jq -r '[.. | objects | .icon?] | map(select(type == "string" and length > 0)) | unique[]' "$MANIFEST")
+
+if [ -n "$MISSING_ICON" ]; then
+    echo "validate_extension: $MANIFEST references missing local icon file(s):$MISSING_ICON" >&2
     exit 1
 fi
 


### PR DESCRIPTION
## Summary

Closes #20. The extension pre-flight validator (`scripts/validate_extension.sh`) validated manifest structure, action schema, script file paths, and `require()` dependency graphs, but silently skipped **local icon file references** — a misconfigured `"icon"` path (typo, missing asset) passed validation with `OK (manifest.json)` and shipped broken.

This PR adds a filesystem validation loop that mirrors the host's icon resolution exactly, so the pre-flight check now catches broken icon references before packaging.

## What changed

In `scripts/validate_extension.sh`, after the existing script-file existence check:

- Extracts every `icon` string value in the manifest (top-level **and** per-action, including nested `group` `subActions`) via `jq` — same recursive walk the script check already uses.
- Classifies each value the same way the host's `ExtensionManager.parseIcon` does (`Sources/Core/Extensions/ExtensionManager.swift` + `Constants.imageExtensions`):
  - `symbol(...)` / `symbol:` prefixes, bare SF Symbol names, and HTTP(S) URLs → treated as symbols, **no file required**.
  - Values ending with a known image extension (`.png`, `.jpg`, `.jpeg`, `.icns`, `.gif`, `.svg`, case-insensitive) → resolved as a **local file inside the package** and checked with `[ -f "$SRC_DIR/$icon" ]`.
- On any missing local icon, fails with a clear message listing each missing file (exit 1), matching the style of the existing missing-script check.

## Verification

- **Zero false positives on the catalog**: ran the validator on all **97** packages in `Extensions/raw/` → 0 unexpected failures (every existing local icon file resolves).
- **Broken package rejected**: a test manifest referencing `missing-icon.png` (top-level) and `assets/nope.svg` (action-level) fails with both files reported.
- **Legitimate icon forms still pass**: `symbol:…`, `symbol(…)`, bare SF Symbol names, `https://…` URLs, case-variant `sub/icon.PNG`, and nested group `subActions` icons all validate cleanly.
- `bash -n scripts/validate_extension.sh` passes.