### PR TITLE
feat(popup): diff view, draggable and modal result card

### DIFF
--- a/OpenClip.xcodeproj/project.pbxproj
+++ b/OpenClip.xcodeproj/project.pbxproj
@@ -106,6 +106,7 @@
 		502E0EAB60D92A89C1F8957F /* ResultCardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C14D435609D5583A39FA164 /* ResultCardView.swift */; };
 		505BCF709F1851C81A35DD64 /* ActionCoordinatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7BBCBD7E4F5F0D1015061E8D /* ActionCoordinatorTests.swift */; };
 		50CDF4FBA60DD7E30580869A /* SubBarStateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F6D2EFD3816A5D71776023F4 /* SubBarStateTests.swift */; };
+		50D063B985561A99C37509F8 /* ResultCardModalTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 366BBDDE22A116FFDAF1A755 /* ResultCardModalTests.swift */; };
 		5116F40F001337D7A910E311 /* StatusBarControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 831EE1ACBF685660FC4A7E1C /* StatusBarControllerTests.swift */; };
 		5177FD69CB1889103918E06A /* ValidateExpressionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 18AD4B01A699AB19272C3068 /* ValidateExpressionTests.swift */; };
 		5217746177125684C4C0D562 /* AIConfigureForm.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0840C0956DCD2948A2E47F53 /* AIConfigureForm.swift */; };
@@ -122,6 +123,7 @@
 		5C944B60B5BAB6D4687431F4 /* AXWebAreaStrategy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87B88E027DEFE5D5E8F50D5E /* AXWebAreaStrategy.swift */; };
 		5DA0AEF4E0DB181460C32C7E /* Core.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C75D3BF228023DEA93C5D3D /* Core.swift */; };
 		5DCF177C003BF07A068E9A51 /* BrowserScriptStrategy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B48E991911FC42DA1795980 /* BrowserScriptStrategy.swift */; };
+		5F17CA4DBAD195FC86891D22 /* TextDiff.swift in Sources */ = {isa = PBXBuildFile; fileRef = 72D2A86162DC9AE0BED27272 /* TextDiff.swift */; };
 		6110BA1FB01D390A8592ADC9 /* ExtensionsDirectoryWatcherTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 691C4AB5E7CCD2F8E5D4A214 /* ExtensionsDirectoryWatcherTests.swift */; };
 		611F612CDB50CBDCE4916F4E /* RuleEngineTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 06C43223F2E4E777CC9F7673 /* RuleEngineTests.swift */; };
 		62694BC577DF6210819143D5 /* URLTemplateAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = F2CB1948C425181EE3DCFAAA /* URLTemplateAction.swift */; };
@@ -323,6 +325,7 @@
 		EE047575D4BBDD2F0D88A15C /* OpenClipModuleLoader.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC570E95AD00AF13279BF5F1 /* OpenClipModuleLoader.swift */; };
 		EF3BE1F10E35A392B5F686F8 /* RecommendedExtensionsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1EE6E52A608F70478CA1BB44 /* RecommendedExtensionsView.swift */; };
 		F0469675D9268D8B2FF96930 /* PopupPageLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3DDE8FADF17FFAAA734E652D /* PopupPageLayout.swift */; };
+		F1F3954D6FA609E1F9A1D41F /* TextDiffTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F550B3391CB67E294AE13EC /* TextDiffTests.swift */; };
 		F3605465C595AC6C4AD817D6 /* SettingKey+MenuBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34FD5FB4055A0801CFE23340 /* SettingKey+MenuBar.swift */; };
 		F3838DAB280C70F3FF8196FF /* OpenClipJSHost.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B2196A93CE938E3BCD2D73F /* OpenClipJSHost.swift */; };
 		F499E888422C2452E64E2F06 /* ExtensionsStoreViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A9596443229B1173DAB2434 /* ExtensionsStoreViewTests.swift */; };
@@ -455,6 +458,7 @@
 		34FD5FB4055A0801CFE23340 /* SettingKey+MenuBar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SettingKey+MenuBar.swift"; sourceTree = "<group>"; };
 		3573C5F0E0C00C1A562BBBDC /* SelectionRetrievalMode.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SelectionRetrievalMode.swift; sourceTree = "<group>"; };
 		36016F74951C9B2E0CAA6894 /* AboutTabView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AboutTabView.swift; sourceTree = "<group>"; };
+		366BBDDE22A116FFDAF1A755 /* ResultCardModalTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ResultCardModalTests.swift; sourceTree = "<group>"; };
 		3675FDD7BC06CF3B3CBDA003 /* DynamicActionConfigView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DynamicActionConfigView.swift; sourceTree = "<group>"; };
 		37C5B4BFF2D115C64916D6E9 /* CustomActionManifestWriter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomActionManifestWriter.swift; sourceTree = "<group>"; };
 		382F45A3CA8BFDC01E3132BD /* LogCoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LogCoreTests.swift; sourceTree = "<group>"; };
@@ -467,6 +471,7 @@
 		3DDE8FADF17FFAAA734E652D /* PopupPageLayout.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PopupPageLayout.swift; sourceTree = "<group>"; };
 		3E47D4C3D096CE979274DCDA /* BuiltinRegistryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BuiltinRegistryTests.swift; sourceTree = "<group>"; };
 		3F2731480550C2912B357B1C /* PasteAvailabilityTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PasteAvailabilityTests.swift; sourceTree = "<group>"; };
+		3F550B3391CB67E294AE13EC /* TextDiffTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextDiffTests.swift; sourceTree = "<group>"; };
 		40068DD0346E93060C2DE55A /* PasteboardCopyEngineTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PasteboardCopyEngineTests.swift; sourceTree = "<group>"; };
 		408D34C4B02A270BFAC45B52 /* CoachMarkControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoachMarkControllerTests.swift; sourceTree = "<group>"; };
 		40BC7280676281FD11450DF2 /* ActionFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActionFactory.swift; sourceTree = "<group>"; };
@@ -523,6 +528,7 @@
 		7065CFC746479DF29BD1525F /* ExtensionTrustStateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExtensionTrustStateTests.swift; sourceTree = "<group>"; };
 		71D66B03CE90BB5DD34187BD /* KeyPressSpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyPressSpec.swift; sourceTree = "<group>"; };
 		72319E0C350B35EBFCFFB9F4 /* PermissionRecoveryWindowController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PermissionRecoveryWindowController.swift; sourceTree = "<group>"; };
+		72D2A86162DC9AE0BED27272 /* TextDiff.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextDiff.swift; sourceTree = "<group>"; };
 		74011E62AB2E26EB03C81D18 /* ExtensionPackageHashResolverTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExtensionPackageHashResolverTests.swift; sourceTree = "<group>"; };
 		74377A23CADC86774742A0BD /* InstalledAppsScannerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InstalledAppsScannerTests.swift; sourceTree = "<group>"; };
 		750ADA88A976EEF10B2481E2 /* AppFilter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppFilter.swift; sourceTree = "<group>"; };
@@ -766,6 +772,7 @@
 		0BBE48F575F811D54A447525 /* Utils */ = {
 			isa = PBXGroup;
 			children = (
+				72D2A86162DC9AE0BED27272 /* TextDiff.swift */,
 				AE8874EAC1123657CDB78D06 /* TextPlaceholderEngine.swift */,
 			);
 			path = Utils;
@@ -1307,6 +1314,7 @@
 				B7057F1EDC97680EC5B78A83 /* PopupSearchScopeTests.swift */,
 				D17261567A410E583636E381 /* PreferenceTabTests.swift */,
 				4E0824A74806623A75D29570 /* RemoteExtensionInstallerTests.swift */,
+				366BBDDE22A116FFDAF1A755 /* ResultCardModalTests.swift */,
 				92591CBEAFDE51E7D4630274 /* RevealInFinderActionTests.swift */,
 				1E8A40D29BDA7A80DFF5AF4E /* RichPasteboardPayloadTests.swift */,
 				E1A3B31A9407EA4D8E0EBF6E /* RotatingFileLogSinkTests.swift */,
@@ -1324,6 +1332,7 @@
 				CA3C9A8D346CA4461E305F3C /* SubBarPanelControllerTests.swift */,
 				F6D2EFD3816A5D71776023F4 /* SubBarStateTests.swift */,
 				2FB27AADC6E8AFED7FA86F02 /* TestIsolation.swift */,
+				3F550B3391CB67E294AE13EC /* TextDiffTests.swift */,
 				95F4335DD4C3C026D8A6AEBA /* TextPlaceholderEngineTests.swift */,
 				49648502F040834635BBD8ED /* TextRetrieverTests.swift */,
 				25F5B1000D24EE8852A91066 /* TextSanitizerTests.swift */,
@@ -1563,6 +1572,7 @@
 				BF71DCDEFFB5F2E6CE6D9B20 /* PopupSearchScopeTests.swift in Sources */,
 				CF13A312B971DB7D0934DA09 /* PreferenceTabTests.swift in Sources */,
 				2E0CE79B92BCBAD1F615A98E /* RemoteExtensionInstallerTests.swift in Sources */,
+				50D063B985561A99C37509F8 /* ResultCardModalTests.swift in Sources */,
 				470BB95C626E3041E74CA19D /* RevealInFinderActionTests.swift in Sources */,
 				C4916C62F89BF6D9A045286F /* RichPasteboardPayloadTests.swift in Sources */,
 				87B7B3D8AAA1E4C9D01750FE /* RotatingFileLogSinkTests.swift in Sources */,
@@ -1580,6 +1590,7 @@
 				077BDE4E31B68A718C5E5FCF /* SubBarPanelControllerTests.swift in Sources */,
 				50CDF4FBA60DD7E30580869A /* SubBarStateTests.swift in Sources */,
 				2B3E3EB0BC1A9BA0919C017E /* TestIsolation.swift in Sources */,
+				F1F3954D6FA609E1F9A1D41F /* TextDiffTests.swift in Sources */,
 				9A7F163119972B733595F05C /* TextPlaceholderEngineTests.swift in Sources */,
 				9495A826AD2E0BB4ED448280 /* TextRetrieverTests.swift in Sources */,
 				2BA13E2C55DB83FBD4B84666 /* TextSanitizerTests.swift in Sources */,
@@ -1678,6 +1689,7 @@
 				85585652F398636A85EED43F /* ShellProcessRunner.swift in Sources */,
 				92345C4B7E3325E66D6776D2 /* StatusFeedback.swift in Sources */,
 				3D5FA5DD6B43DAB73D609A56 /* SubAction.swift in Sources */,
+				5F17CA4DBAD195FC86891D22 /* TextDiff.swift in Sources */,
 				1FA8CFA55755A2903AE4D934 /* TextPlaceholderEngine.swift in Sources */,
 				76E559C066D1B00D899DB613 /* TextRetrieving.swift in Sources */,
 				14A6CC52EA6A21C758EA932D /* TextSanitizer.swift in Sources */,

--- a/Sources/Core/Utils/TextDiff.swift
+++ b/Sources/Core/Utils/TextDiff.swift
@@ -1,0 +1,212 @@
+// TextDiff.swift
+// OpenClip
+//
+// Character-level diff between an action's input text and the text it produced, used by the
+// result card's change view. Pure domain code: it returns ordered segments (equal / inserted /
+// deleted) and leaves colours, strikethrough and typography to the card.
+//
+// The comparison is a Myers greedy diff over `Character`s (grapheme clusters, so emoji and
+// composed characters are never split), preceded by common prefix/suffix trimming so the usual
+// proofread case — a long text with a couple of edits — only diffs the changed middle. Two
+// budgets keep a pathological input cheap: `maxComparableLength` on the trimmed middle and
+// `maxEditDistance` on the diff's D. Exceeding either yields the honest fallback of "the middle
+// was replaced" (one delete + one insert), which is also the only sensible rendering when the
+// result is a rewrite rather than an edit.
+import Foundation
+
+/// One run of the diff: a stretch of text that survived, was added, or was removed.
+public struct TextDiffSegment: Sendable, Equatable {
+    public enum Kind: Sendable, Equatable {
+        case equal
+        case insert
+        case delete
+    }
+
+    public let kind: Kind
+    public let text: String
+
+    public init(kind: Kind, text: String) {
+        self.kind = kind
+        self.text = text
+    }
+}
+
+public enum TextDiff {
+    /// Combined character budget for the *trimmed* middle. Beyond it the middle is reported as a
+    /// wholesale replacement instead of being diffed.
+    public static let maxComparableLength = 6_000
+    /// Maximum edit distance the Myers search explores before giving up (its cost — and the
+    /// trace it keeps — grow with D², so an unrelated pair of texts must not run unbounded).
+    public static let maxEditDistance = 600
+
+    /// Diffs `old` into `new`, coalescing consecutive characters of the same kind into one segment.
+    public static func segments(from old: String, to new: String) -> [TextDiffSegment] {
+        if old == new {
+            return old.isEmpty ? [] : [TextDiffSegment(kind: .equal, text: old)]
+        }
+
+        let oldChars = Array(old)
+        let newChars = Array(new)
+
+        var prefix = 0
+        while prefix < oldChars.count, prefix < newChars.count, oldChars[prefix] == newChars[prefix] {
+            prefix += 1
+        }
+        var suffix = 0
+        while suffix < oldChars.count - prefix,
+              suffix < newChars.count - prefix,
+              oldChars[oldChars.count - 1 - suffix] == newChars[newChars.count - 1 - suffix] {
+            suffix += 1
+        }
+
+        let oldMiddle = Array(oldChars[prefix..<(oldChars.count - suffix)])
+        let newMiddle = Array(newChars[prefix..<(newChars.count - suffix)])
+
+        let middle: [TextDiffSegment]
+        if oldMiddle.count + newMiddle.count > maxComparableLength {
+            middle = replacement(oldMiddle, newMiddle)
+        } else {
+            middle = myers(oldMiddle, newMiddle) ?? replacement(oldMiddle, newMiddle)
+        }
+
+        var result: [TextDiffSegment] = []
+        if prefix > 0 {
+            result.append(TextDiffSegment(kind: .equal, text: String(oldChars[0..<prefix])))
+        }
+        result.append(contentsOf: middle)
+        if suffix > 0 {
+            result.append(TextDiffSegment(kind: .equal, text: String(oldChars[(oldChars.count - suffix)...])))
+        }
+        return coalesced(result)
+    }
+
+    /// Share of the diffed material that survived unchanged, 0...1 — 1.0 for identical texts and
+    /// near 0 for a full rewrite. The card uses it to decide whether the change view is worth
+    /// showing by default (a rewrite diffs into noise; an edit reads perfectly).
+    public static func equalRatio(of segments: [TextDiffSegment]) -> Double {
+        var equal = 0
+        var total = 0
+        for segment in segments {
+            let count = segment.text.count
+            total += count
+            if segment.kind == .equal { equal += count }
+        }
+        guard total > 0 else { return 1.0 }
+        return Double(equal) / Double(total)
+    }
+
+    // MARK: - Internals
+
+    private static func replacement(_ old: [Character], _ new: [Character]) -> [TextDiffSegment] {
+        var segments: [TextDiffSegment] = []
+        if !old.isEmpty { segments.append(TextDiffSegment(kind: .delete, text: String(old))) }
+        if !new.isEmpty { segments.append(TextDiffSegment(kind: .insert, text: String(new))) }
+        return segments
+    }
+
+    /// Myers greedy diff with a D budget. Returns nil when the texts are further apart than
+    /// `maxEditDistance`, leaving the caller to fall back to a wholesale replacement.
+    private static func myers(_ a: [Character], _ b: [Character]) -> [TextDiffSegment]? {
+        let n = a.count
+        let m = b.count
+        if n == 0 && m == 0 { return [] }
+        if n == 0 { return [TextDiffSegment(kind: .insert, text: String(b))] }
+        if m == 0 { return [TextDiffSegment(kind: .delete, text: String(a))] }
+
+        let bound = min(n + m, maxEditDistance)
+        let offset = bound + 1
+        var v = [Int](repeating: 0, count: 2 * bound + 3)
+        var trace: [[Int]] = []
+        trace.reserveCapacity(bound + 1)
+
+        for d in 0...bound {
+            trace.append(v)
+            var k = -d
+            while k <= d {
+                var x: Int
+                if k == -d || (k != d && v[offset + k - 1] < v[offset + k + 1]) {
+                    x = v[offset + k + 1]
+                } else {
+                    x = v[offset + k - 1] + 1
+                }
+                var y = x - k
+                while x < n && y < m && a[x] == b[y] {
+                    x += 1
+                    y += 1
+                }
+                v[offset + k] = x
+                if x >= n && y >= m {
+                    return backtrack(a, b, trace: trace, offset: offset)
+                }
+                k += 2
+            }
+        }
+        return nil
+    }
+
+    /// Walks the recorded end points backwards, emitting one character per step, then coalesces.
+    private static func backtrack(_ a: [Character], _ b: [Character], trace: [[Int]], offset: Int) -> [TextDiffSegment] {
+        var x = a.count
+        var y = b.count
+        var reversed: [(kind: TextDiffSegment.Kind, character: Character)] = []
+
+        for d in stride(from: trace.count - 1, through: 0, by: -1) {
+            let v = trace[d]
+            let k = x - y
+            let previousK: Int
+            if k == -d || (k != d && v[offset + k - 1] < v[offset + k + 1]) {
+                previousK = k + 1
+            } else {
+                previousK = k - 1
+            }
+            let previousX = v[offset + previousK]
+            let previousY = previousX - previousK
+
+            while x > previousX && y > previousY {
+                x -= 1
+                y -= 1
+                reversed.append((.equal, a[x]))
+            }
+            guard d > 0 else { break }
+            if x == previousX {
+                y -= 1
+                reversed.append((.insert, b[y]))
+            } else {
+                x -= 1
+                reversed.append((.delete, a[x]))
+            }
+        }
+
+        var segments: [TextDiffSegment] = []
+        var currentKind: TextDiffSegment.Kind?
+        var currentText = ""
+        for step in reversed.reversed() {
+            if step.kind == currentKind {
+                currentText.append(step.character)
+            } else {
+                if let currentKind, !currentText.isEmpty {
+                    segments.append(TextDiffSegment(kind: currentKind, text: currentText))
+                }
+                currentKind = step.kind
+                currentText = String(step.character)
+            }
+        }
+        if let currentKind, !currentText.isEmpty {
+            segments.append(TextDiffSegment(kind: currentKind, text: currentText))
+        }
+        return segments
+    }
+
+    /// Merges neighbouring segments of the same kind (the prefix/suffix joints produce them).
+    private static func coalesced(_ segments: [TextDiffSegment]) -> [TextDiffSegment] {
+        var merged: [TextDiffSegment] = []
+        for segment in segments where !segment.text.isEmpty {
+            if let last = merged.last, last.kind == segment.kind {
+                merged[merged.count - 1] = TextDiffSegment(kind: last.kind, text: last.text + segment.text)
+            } else {
+                merged.append(segment)
+            }
+        }
+        return merged
+    }
+}

--- a/Sources/OpenClip/AppDelegate.swift
+++ b/Sources/OpenClip/AppDelegate.swift
@@ -116,6 +116,11 @@ class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCenterDele
         macMonitor.preparePasteProbe = { [weak self] app, policy in
             self?.popupController?.preparePasteProbe(for: app, policy: policy)
         }
+        // The result card is modal: while it is up, selecting text (to edit it under the card,
+        // say) must not open the action bar over it. Closing the card resumes selection triggers.
+        macMonitor.isSuppressed = { [weak self] in
+            self?.popupController?.cardIsModal ?? false
+        }
         selectionMonitor = macMonitor
         guard NSClassFromString("XCTestCase") == nil else { return }
 

--- a/Sources/OpenClip/Platform/MacSelectionMonitor.swift
+++ b/Sources/OpenClip/Platform/MacSelectionMonitor.swift
@@ -1,7 +1,9 @@
 // MacSelectionMonitor.swift
 // OpenClip
 //
-// Monitors macOS mouse and keyboard events to detect text selection actions and trigger OpenClip popup presentation.
+// Monitors macOS mouse and keyboard events to detect text selection actions and trigger OpenClip
+// popup presentation. Every trigger passes the `isSuppressed` gate first (wired to the popup's
+// modal result card by AppDelegate), so while that card is open no selection is read at all.
 import AppKit
 import Core
 
@@ -40,6 +42,12 @@ internal final class MacSelectionMonitor: SelectionMonitoring {
         guard let bundleID else { return false }
         return AppFilter.isExcluded(bundleID: bundleID)
     }
+    /// Suppression gate consulted at every trigger (and again after every debounce/hold sleep,
+    /// since the state can change while the timer runs): while it answers true the monitor
+    /// retrieves nothing and delivers nothing, so no selection is even read. The composition root
+    /// wires it to the popup's result card, which is modal — selecting a word to edit the text
+    /// under an open card must not yank the card away. Defaults to never suppressed.
+    internal var isSuppressed: @MainActor () -> Bool = { false }
     /// Policy resolution for the target app; tests fix it to `.default` so real user rules
     /// (~/.openclip/rules.json) cannot alter gating or force copy-based strategies mid-test.
     internal var policyResolver: @MainActor (String?) -> AppPolicyContext = { bundleID in
@@ -176,6 +184,7 @@ internal final class MacSelectionMonitor: SelectionMonitoring {
         mouseHoldTask?.cancel()
 
         guard settingsStore.get(.pauseUntilTimestamp) <= Date().timeIntervalSince1970 else { return }
+        guard !isSuppressed() else { return }
         guard settingsStore.get(.isMouseHoldEnabled) else { return }
         let holdDuration = settingsStore.get(.mouseHoldDuration)
         guard holdDuration > 0 else { return }
@@ -204,6 +213,7 @@ internal final class MacSelectionMonitor: SelectionMonitoring {
             currentPoint = currentMouseLocation()
             guard Self.holdStationary(downPoint: self.mouseDownLocation, pointer: currentPoint, buttonPressed: self.primaryButtonPressed()) else { return }
 
+            guard !self.isSuppressed() else { return }
             guard let app = frontmostAppProvider() else { return }
             if isExcludedBundle(app.bundleIdentifier) {
                 return
@@ -313,8 +323,10 @@ internal final class MacSelectionMonitor: SelectionMonitoring {
         debounceTask?.cancel()
 
         guard settingsStore.get(.pauseUntilTimestamp) <= Date().timeIntervalSince1970 else { return }
+        guard !isSuppressed() else { return }
 
         debounceTask = Task { @MainActor in
+            guard !self.isSuppressed() else { return }
             if let bundleID = app.bundleIdentifier, AppFilter.isExcluded(bundleID: bundleID) {
                 return
             }
@@ -360,6 +372,7 @@ internal final class MacSelectionMonitor: SelectionMonitoring {
     internal func handleSelectionTrigger(isSelectAll: Bool) {
         debounceTask?.cancel()
         guard settingsStore.get(.pauseUntilTimestamp) <= Date().timeIntervalSince1970 else { return }
+        guard !isSuppressed() else { return }
         debounceTask = Task { @MainActor in
             do {
                 try await Task.sleep(nanoseconds: UInt64(Constants.keyboardSelectionDebounceInterval * 1_000_000_000))
@@ -367,6 +380,7 @@ internal final class MacSelectionMonitor: SelectionMonitoring {
                 return
             }
             if Task.isCancelled { return }
+            guard !self.isSuppressed() else { return }
 
             guard let app = NSWorkspace.shared.frontmostApplication else { return }
 

--- a/Sources/OpenClip/Resources/Localizable.xcstrings
+++ b/Sources/OpenClip/Resources/Localizable.xcstrings
@@ -1737,34 +1737,6 @@
         }
       }
     },
-    "Back to actions (Esc)": {
-      "localizations": {
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "返回动作（Esc）"
-          }
-        },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "返回動作（Esc）"
-          }
-        },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Retour aux actions (Échap)"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "アクションに戻る (Esc)"
-          }
-        }
-      }
-    },
     "Baidu": {
       "localizations": {
         "zh-Hans": {
@@ -2489,6 +2461,62 @@
           "stringUnit": {
             "state": "translated",
             "value": "閉じる"
+          }
+        }
+      }
+    },
+    "Close the card (⎋)": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "关闭卡片 (⎋)"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "關閉卡片 (⎋)"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Fermer la carte (⎋)"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "カードを閉じる (⎋)"
+          }
+        }
+      }
+    },
+    "Close the result card": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "关闭结果卡片"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "關閉結果卡片"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Fermer la carte de résultat"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "結果カードを閉じる"
           }
         }
       }
@@ -3609,6 +3637,34 @@
           "stringUnit": {
             "state": "translated",
             "value": "アイコンをドラッグしてグループに追加"
+          }
+        }
+      }
+    },
+    "Drag to move": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "拖动以移动"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "拖曳以移動"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Faire glisser pour déplacer"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ドラッグして移動"
           }
         }
       }
@@ -9913,6 +9969,62 @@
         }
       }
     },
+    "Show the plain result (⌘D)": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "显示纯文本结果 (⌘D)"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "顯示純文字結果 (⌘D)"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Afficher le résultat simple (⌘D)"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "結果のみを表示 (⌘D)"
+          }
+        }
+      }
+    },
+    "Show what changed (⌘D)": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "显示更改内容 (⌘D)"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "顯示變更內容 (⌘D)"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Afficher les modifications (⌘D)"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "変更点を表示 (⌘D)"
+          }
+        }
+      }
+    },
     "Simplified Chinese (简体中文)": {
       "localizations": {
         "zh-Hans": {
@@ -10525,6 +10637,34 @@
           "stringUnit": {
             "state": "translated",
             "value": "タイトル"
+          }
+        }
+      }
+    },
+    "Toggle change highlighting": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "切换更改高亮"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "切換變更標示"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Activer ou désactiver la mise en évidence des modifications"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "変更のハイライトを切り替える"
           }
         }
       }

--- a/Sources/OpenClip/UI/Popup/PopupModeStore.swift
+++ b/Sources/OpenClip/UI/Popup/PopupModeStore.swift
@@ -44,20 +44,24 @@ public final class PopupModeStore: ObservableObject {
 /// The payload of the native result card: the action's response text, whether it is an
 /// error message (drives the card's styling), the producing action's title and icon, and
 /// streaming state. `icon` is nil for AI streaming deliveries, which fall back to the
-/// card's sparkles glyph.
+/// card's sparkles glyph. `original` is the text the action was run on (the selection), kept so
+/// the card can show a character-level diff of what the action changed; nil when there is
+/// nothing to compare against.
 public struct ResultCardPayload: Sendable, Equatable {
     public let text: String
     public let isError: Bool
     public let title: String
     public let icon: ActionIcon?
     public let isStreaming: Bool
+    public let original: String?
 
-    public init(text: String, isError: Bool, title: String = String(localized: "AI Tools"), icon: ActionIcon? = nil, isStreaming: Bool = false) {
+    public init(text: String, isError: Bool, title: String = String(localized: "AI Tools"), icon: ActionIcon? = nil, isStreaming: Bool = false, original: String? = nil) {
         self.text = text
         self.isError = isError
         self.title = title
         self.icon = icon
         self.isStreaming = isStreaming
+        self.original = original
     }
 }
 

--- a/Sources/OpenClip/UI/Popup/PopupPanel.swift
+++ b/Sources/OpenClip/UI/Popup/PopupPanel.swift
@@ -42,6 +42,12 @@ public class PopupPanel: NSPanel {
         set { horizontalAnchor = newValue ? .center : .none }
     }
 
+    /// True for the duration of a user drag of the panel (result card header). The controller's
+    /// hover tracking stops toggling `ignoresMouseEvents` while it is set: a fast drag can take the
+    /// cursor across the transparent shadow ring, and making the panel ignore mouse events
+    /// mid-drag would strand it under the pointer.
+    public private(set) var isUserDragging = false
+
     public init() {
         super.init(
             contentRect: .zero,
@@ -55,6 +61,22 @@ public class PopupPanel: NSPanel {
         self.isOpaque = false
         self.hasShadow = false   // SwiftUI draws its own shadow; panel shadow causes double artifacts
         self.acceptsMouseMovedEvents = true
+        self.isMovable = true    // borderless, but the result card moves the panel by its header
+    }
+
+    /// Opens a user drag of the panel (the result card's header handle). The move itself is driven
+    /// by `PopupWindowController.handleCardDrag` — AppKit's own `performDrag` is unreachable here,
+    /// since `NSHostingView` answers `hitTest` for the whole card and never lets an AppKit handle
+    /// see the `mouseDown`. The user placing the panel deliberately outranks automatic placement,
+    /// so re-centering on width changes is switched off for the rest of the session (`hide()`
+    /// resets the anchor).
+    public func prepareForUserDrag() {
+        horizontalAnchor = .none
+        isUserDragging = true
+    }
+
+    public func endUserDrag() {
+        isUserDragging = false
     }
 
     override public var canBecomeKey: Bool { allowsKey }

--- a/Sources/OpenClip/UI/Popup/PopupView.swift
+++ b/Sources/OpenClip/UI/Popup/PopupView.swift
@@ -35,6 +35,11 @@ public struct PopupView: View {
     public let onCancelSubBarDwell: (@MainActor () -> Void)?
     /// Called when the AI result card should collapse back to the bar (back chevron).
     public let onExitContent: @MainActor () -> Void
+    /// Called when the result card should close outright (Esc) — the popup goes away rather than
+    /// falling back to the bar.
+    public let onDismissContent: @MainActor () -> Void
+    /// Called as the result card's header handle is dragged, so the controller can move the panel.
+    public let onCardDrag: (@MainActor (ResultCardDragPhase) -> Void)?
     /// The AI result card's Paste/Copy buttons — explicit user requests routed through the
     /// controller's keep-open card-effect door (bypasses the paste-vs-copy re-decision).
     public let onCardEffect: @MainActor (ActionResult) -> Void
@@ -146,6 +151,8 @@ public struct PopupView: View {
         onEnterSearch: @escaping @MainActor (CGRect?) -> Void = { _ in },
         onExitSearch: @escaping @MainActor () -> Void = {},
         onExitContent: @escaping @MainActor () -> Void = {},
+        onDismissContent: (@MainActor () -> Void)? = nil,
+        onCardDrag: (@MainActor (ResultCardDragPhase) -> Void)? = nil,
         onCardEffect: @escaping @MainActor (ActionResult) -> Void = { _ in },
         onResult: @escaping @MainActor (ActionResult) -> Void,
         onContentSizeChange: (@MainActor (CGSize) -> Void)? = nil,
@@ -176,6 +183,8 @@ public struct PopupView: View {
         self.onRequestSubBarDwell = onRequestSubBarDwell
         self.onCancelSubBarDwell = onCancelSubBarDwell
         self.onExitContent = onExitContent
+        self.onDismissContent = onDismissContent ?? onExitContent
+        self.onCardDrag = onCardDrag
         self.onCardEffect = onCardEffect
         self.onHoveredActionChanged = onHoveredActionChanged
         self.onEnteredScopedSearch = onEnteredScopedSearch
@@ -358,7 +367,7 @@ public struct PopupView: View {
     /// of the bar (content mode). Paste/Copy are explicit user requests routed through
     /// onCardEffect (bypassing the paste-vs-copy re-decision) that both dismiss the popup; the
     /// Paste button is hidden when the target app can't paste; the back chevron collapses back to
-    /// the bar.
+    /// the bar and Esc closes the card outright.
     @ViewBuilder
     private var resultCard: some View {
         if let payload = modeStore.resultCard {
@@ -366,8 +375,10 @@ public struct PopupView: View {
                 payload: payload,
                 canPaste: modeStore.canPaste,
                 onExit: { onExitContent() },
+                onDismiss: { onDismissContent() },
                 onPaste: { onCardEffect(.paste(payload.text)) },
-                onCopy: { onCardEffect(.copy(payload.text)) }
+                onCopy: { onCardEffect(.copy(payload.text)) },
+                onDrag: { phase in onCardDrag?(phase) }
             )
             .environment(\.colorScheme, effectiveColorScheme)
             .environment(\.popupEffectiveTheme, effectiveTheme)

--- a/Sources/OpenClip/UI/Popup/PopupWindowController.swift
+++ b/Sources/OpenClip/UI/Popup/PopupWindowController.swift
@@ -7,7 +7,9 @@
 // previous app on exit; content mode renders the result card inline on the panel and — since
 // Task 14 — is also key, reusing the same enterKeyMode()/exitKeyMode() primitives as search, with
 // Esc owned by the SwiftUI card (the controller-level key monitor stays observation-only in
-// content mode).
+// content mode, bar the one case where the card lost key). Content mode is also the one mode that
+// survives everything but an explicit answer: `cardIsModal` suppresses every automatic dismissal
+// (outside click, scroll, cursor distance, app switch) so the card lives until Copy, Paste or Esc.
 // Implements the decision-8 ActionResult tree-walk (handleActionResult): presentation results render
 // here, leaf effects route to DefaultActionResultHandler, and dismissal is decided once via
 // ActionResult.dismissesPopup.
@@ -254,6 +256,8 @@ public class PopupWindowController {
             onEnterSearch: { [weak self] frame in self?.enterSearch(buttonLocalFrame: frame) },
             onExitSearch: { [weak self] in self?.exitSearch() },
             onExitContent: { [weak self] in self?.exitContent() },
+            onDismissContent: { [weak self] in self?.hide() },
+            onCardDrag: { [weak self] phase in self?.handleCardDrag(phase) },
             onCardEffect: { [weak self] result in
                 self?.performCardEffect(result)
             },
@@ -499,6 +503,14 @@ public class PopupWindowController {
 
     // MARK: - AI Result Card
 
+    /// True while the result card is on screen. The card is deliberately modal-ish: once a result
+    /// is showing, only Copy, Paste or Esc take it away — an outside click, a scroll, a switch to
+    /// another app or the cursor wandering off must all leave it up, so the user can read the
+    /// response (and its diff) while working in the source app. `MacSelectionMonitor` reads this
+    /// as its suppression gate (wired in AppDelegate), so a selection made while the card is open
+    /// never re-opens the action bar over it.
+    public var cardIsModal: Bool { modeStore.mode == .content }
+
     /// Applies a streaming "processing" flag update, but only for the session the update
     /// belongs to. A stale stream (popup dismissed mid-stream, superseded by a new selection)
     /// must never re-stick isProcessingAI after hide() cleared it.
@@ -512,8 +524,10 @@ public class PopupWindowController {
     /// renders here — AI presets stream into it via `onAIResult`, extensions land via the
     /// delivery snapshot with their own icon. Paste/Copy are explicit user requests routed
     /// through `performCardEffect`, so they bypass the paste-vs-copy re-decision — an explicit
-    /// Paste always pastes. Probes (AX) whether the target app can paste so the card can hide its
-    /// Paste button; the probe targets the captured source app, never OpenClip itself. Deliveries
+    /// Paste always pastes. The selection the action ran on is carried in the payload so the card
+    /// can render a character-level diff of what changed. Probes (AX) whether the target app can
+    /// paste so the card can hide its Paste button; the probe targets the captured source app,
+    /// never OpenClip itself. Deliveries
     /// are session-stamped: a chunk from an abandoned stream is dropped instead of hijacking the
     /// current popup into content mode. Internal for tests.
     func showResultCard(text: String, isError: Bool, title: String, icon: ActionIcon? = nil, isStreaming: Bool = false, session: UUID) {
@@ -522,7 +536,15 @@ public class PopupWindowController {
             toastController.hide()
         }
         modeStore.isProcessingAI = isStreaming
-        modeStore.resultCard = ResultCardPayload(text: text, isError: isError, title: title, icon: icon, isStreaming: isStreaming)
+        // The selection the action ran on rides along so the card can diff input → output.
+        modeStore.resultCard = ResultCardPayload(
+            text: text,
+            isError: isError,
+            title: title,
+            icon: icon,
+            isStreaming: isStreaming,
+            original: currentActionContext?.selection.text
+        )
         if modeStore.mode != .content {
             panel?.pinBottomEdgeOnResize = modeStore.searchResultsAbove
             panel?.horizontalAnchor = .center
@@ -562,6 +584,32 @@ public class PopupWindowController {
                 let size = self.sanitizedPopupSize(fittingSize)
                 self.resizePanel(to: size)
             }
+        }
+    }
+
+    /// Where the panel sat, and where the cursor was, when the current card drag began. Nil while
+    /// no drag is in flight.
+    private var cardDragAnchor: (mouse: CGPoint, origin: CGPoint)?
+
+    /// Moves the panel with the cursor while the card's header handle is dragged. The move is
+    /// computed from the *absolute* cursor position against the anchor taken at `.began`, never
+    /// from the gesture's own translation: the window moves out from under the pointer, so a
+    /// translation-based move would fight itself and crawl. `mouseLocation` is injectable so the
+    /// geometry is testable without a real cursor. Internal for tests.
+    func handleCardDrag(_ phase: ResultCardDragPhase, mouseLocation: CGPoint? = nil) {
+        guard let panel else { return }
+        let mouse = mouseLocation ?? NSEvent.mouseLocation
+        switch phase {
+        case .began:
+            panel.prepareForUserDrag()
+            cardDragAnchor = (mouse: mouse, origin: panel.frame.origin)
+        case .changed:
+            guard let anchor = cardDragAnchor else { return }
+            panel.setFrameOrigin(CGPoint(x: anchor.origin.x + (mouse.x - anchor.mouse.x),
+                                         y: anchor.origin.y + (mouse.y - anchor.mouse.y)))
+        case .ended:
+            cardDragAnchor = nil
+            panel.endUserDrag()
         }
     }
 
@@ -672,6 +720,8 @@ public class PopupWindowController {
         modeStore.scope = nil
         panel?.pinBottomEdgeOnResize = false
         panel?.horizontalAnchor = .none
+        panel?.endUserDrag()
+        cardDragAnchor = nil
         preSearchFrame = nil
         openedDirectlyInSearch = false
         panel?.ignoresMouseEvents = false // clear any hover-driven click-through from the last session
@@ -806,7 +856,7 @@ public class PopupWindowController {
             // SwiftUI Button) delivers as a copy when ⇧ is held.
             let isShift = event.modifierFlags.contains(.shift)
             pendingClickIntent = isShift ? .secondary : .primary
-            if !inMain && !inSub {
+            if !inMain && !inSub && !cardIsModal {
                 hide()
             }
         case .rightMouseDown:
@@ -820,7 +870,7 @@ public class PopupWindowController {
                 isRightClickInProgress = true
             } else {
                 isRightClickInProgress = false
-                hide()
+                if !cardIsModal { hide() }
             }
         case .rightMouseUp:
             guard isRightClickInProgress else { break }
@@ -871,8 +921,14 @@ public class PopupWindowController {
             // SwiftUI (M8).
             if modeStore.mode == .search { break }
             if modeStore.mode == .content {
-                return   // Esc belongs to the card component (SwiftUI .onKeyPress);
-                         // the global monitor stays observation-only — do NOT handle Esc here (M8)
+                // Esc belongs to the card component (SwiftUI .onKeyPress) — do NOT handle it here
+                // while the panel is key, or it double-fires on top of SwiftUI (M8). The card now
+                // survives a click into another app, though, and a panel that lost key never sees
+                // the keystroke: that is the one case the monitor answers Esc itself.
+                if event.keyCode == 53, panel?.isKeyWindow != true {
+                    hide()
+                }
+                return
             }
             // Sub-bar Escape: when a sub-bar is open, Escape closes it instead of
             // dismissing the entire popup. The next Escape will dismiss the popup.
@@ -918,7 +974,7 @@ public class PopupWindowController {
         // without it the local monitor is the only way to notice the pointer re-entering the
         // content area, and ignoring events would strand the panel permanently inert.
         let overContent = isOverPanelContent(screenLocation)
-        if PopupHoverState.shared.usesGlobalMouseMonitoring {
+        if PopupHoverState.shared.usesGlobalMouseMonitoring, !panel.isUserDragging {
             panel.ignoresMouseEvents = !overContent
         }
         if overContent {
@@ -1017,8 +1073,9 @@ public class PopupWindowController {
     
     @objc private func appDidDeactivate() {
         // A right-click fires didResignActiveNotification before rightMouseUp arrives; suppressing
-        // hide() here lets the right-click path complete on mouse-up as intended.
-        if !isMenuTracking && !isRightClickInProgress {
+        // hide() here lets the right-click path complete on mouse-up as intended. The result card
+        // outlives focus changes entirely (`cardIsModal`).
+        if !isMenuTracking && !isRightClickInProgress && !cardIsModal {
             hide()
         }
     }
@@ -1031,7 +1088,7 @@ public class PopupWindowController {
            app.bundleIdentifier == sourceBundleID {
             return
         }
-        if !isRightClickInProgress {
+        if !isRightClickInProgress && !cardIsModal {
             hide()
         }
     }

--- a/Sources/OpenClip/UI/Popup/ResultCardView.swift
+++ b/Sources/OpenClip/UI/Popup/ResultCardView.swift
@@ -2,14 +2,22 @@
 // OpenClip
 //
 // The native result card rendered in content mode in place of the bar: a header (back chevron,
-// producing action's icon or sparkles + title), a scrollable response body (error-styled when the
-// action failed), and a Copy/Paste footer (hidden on error; Paste hidden when the target app can't
+// producing action's icon or sparkles + title, diff toggle), a scrollable response body
+// (error-styled when the action failed), and a footer carrying Close (⎋) plus Copy/Paste (both
+// absent on an error card, which offers only Close; Paste also hidden when the target app can't
 // paste). Any action whose resolved outcome is text renders here, not just AI presets.
 // Paste/Copy are explicit user requests routed through performCardEffect, so an explicit Paste
 // always pastes, and both dismiss the popup (Copy like Paste). The panel is key while the card
-// shows (Task 14) and the card owns the keys (SwiftUI .onKeyPress): Esc collapses, Return pastes,
-// Shift+Return copies — the controller-level key monitor stays observation-only in content mode.
+// shows (Task 14) and the card owns the keys (SwiftUI .onKeyPress): Esc dismisses the card,
+// Return pastes, Shift+Return copies, ⌘D toggles the diff — the controller-level key monitor
+// stays observation-only in content mode.
+// The card is modal-ish by design: it stays up until Copy, Paste or Esc (see
+// PopupWindowController.handleEvent), and its header doubles as a drag handle (a SwiftUI
+// DragGesture reported to PopupWindowController.handleCardDrag) so it can be moved out of the way
+// of the text underneath.
 import SwiftUI
+import AppKit
+import Core
 
 // MARK: - Effective Theme Injection
 
@@ -26,6 +34,23 @@ extension EnvironmentValues {
     }
 }
 
+// MARK: - Card Drag
+
+/// Phases of a drag on the card's header handle. The card only reports them; the controller owns
+/// the panel and does the moving.
+///
+/// AppKit dragging is not an option here: the panel is borderless (no title bar),
+/// `isMovableByWindowBackground` never fires because the SwiftUI hosting view consumes the press,
+/// and an `NSViewRepresentable` handle never receives `mouseDown` either — `NSHostingView` answers
+/// `hitTest` with itself for the whole card and dispatches through SwiftUI's own gesture system.
+/// So the handle is a SwiftUI `DragGesture`, and the move is computed from the absolute cursor
+/// position (never the gesture's translation, which would fight the window moving under it).
+public enum ResultCardDragPhase: Sendable {
+    case began
+    case changed
+    case ended
+}
+
 // MARK: - Result Card
 
 public struct ResultCardView: View {
@@ -33,26 +58,44 @@ public struct ResultCardView: View {
     /// Paste availability of the target app (from the AX probe); `false` hides the Paste button.
     public let canPaste: Bool?
     public let onExit: @MainActor () -> Void
+    /// Esc: closes the card outright (the popup goes away) rather than falling back to the bar.
+    public let onDismiss: @MainActor () -> Void
     public let onPaste: @MainActor () -> Void
     public let onCopy: @MainActor () -> Void
+    /// Reports a drag of the header handle so the owner can move the panel.
+    public let onDrag: @MainActor (ResultCardDragPhase) -> Void
 
     @Environment(\.colorScheme) private var colorScheme
     @Environment(\.popupEffectiveTheme) private var effectiveTheme
     @FocusState private var isCardFocused: Bool
     @State private var isChevronHovered = false
+    @State private var isDiffHovered = false
+    /// The diff of `payload.original` → `payload.text`, recomputed only when the payload settles
+    /// (never per body evaluation, and never mid-stream on a half-written response).
+    @State private var diffSegments: [TextDiffSegment] = []
+    @State private var showsDiff = false
+    /// Set once the user works the toggle, so a later payload update can't override their choice.
+    @State private var didChooseDiffMode = false
+    /// True between the drag gesture crossing its threshold and its end, so `.began` is reported
+    /// exactly once per drag.
+    @State private var isDraggingCard = false
 
     public init(
         payload: ResultCardPayload,
         canPaste: Bool? = nil,
         onExit: @escaping @MainActor () -> Void,
+        onDismiss: (@MainActor () -> Void)? = nil,
         onPaste: @escaping @MainActor () -> Void,
-        onCopy: @escaping @MainActor () -> Void
+        onCopy: @escaping @MainActor () -> Void,
+        onDrag: @escaping @MainActor (ResultCardDragPhase) -> Void = { _ in }
     ) {
         self.payload = payload
         self.canPaste = canPaste
         self.onExit = onExit
+        self.onDismiss = onDismiss ?? onExit
         self.onPaste = onPaste
         self.onCopy = onCopy
+        self.onDrag = onDrag
     }
 
     public var body: some View {
@@ -60,9 +103,7 @@ public struct ResultCardView: View {
             VStack(spacing: 0) {
                 header
                 bodyScroll
-                if !payload.isError {
-                    footer
-                }
+                footer
             }
         }
         .frame(width: dynamicCardWidth)
@@ -71,9 +112,18 @@ public struct ResultCardView: View {
         .focused($isCardFocused)
         .onAppear {
             isCardFocused = true
+            refreshDiff()
+        }
+        .onChange(of: payload) { _, _ in
+            refreshDiff()
         }
         .onKeyPress(.escape) {
-            onExit()
+            onDismiss()
+            return .handled
+        }
+        .onKeyPress(keys: ["d"], phases: .down) { press in
+            guard press.modifiers.contains(.command), hasDiff else { return .ignored }
+            toggleDiff()
             return .handled
         }
         .onKeyPress(.return, phases: .down) { press in
@@ -86,6 +136,76 @@ public struct ResultCardView: View {
             }
             return .handled
         }
+    }
+
+    // MARK: Diff
+
+    private var hasDiff: Bool { !diffSegments.isEmpty }
+
+    /// Recomputes the diff for the current payload and picks the default view for it: a light edit
+    /// (proofread, tone change) opens on the diff, a wholesale rewrite (translate, summarize)
+    /// opens on the plain result — the toggle is always there either way. A response still
+    /// streaming is never diffed: the comparison would be against a half-written text.
+    private func refreshDiff() {
+        guard !payload.isError, !payload.isStreaming,
+              let original = payload.original else {
+            diffSegments = []
+            showsDiff = false
+            return
+        }
+        let source = original.trimmingCharacters(in: .whitespacesAndNewlines)
+        let result = payload.text.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !source.isEmpty, !result.isEmpty, source != result else {
+            diffSegments = []
+            showsDiff = false
+            return
+        }
+        let segments = TextDiff.segments(from: source, to: result)
+        guard segments.contains(where: { $0.kind != .equal }) else {
+            diffSegments = []
+            showsDiff = false
+            return
+        }
+        diffSegments = segments
+        if !didChooseDiffMode {
+            showsDiff = TextDiff.equalRatio(of: segments) >= 0.5
+        }
+    }
+
+    private func toggleDiff() {
+        didChooseDiffMode = true
+        showsDiff.toggle()
+    }
+
+    private var insertionColor: Color {
+        colorScheme == .dark ? Color(red: 0.35, green: 0.82, blue: 0.50) : Color(red: 0.11, green: 0.53, blue: 0.24)
+    }
+
+    private var deletionColor: Color {
+        colorScheme == .dark ? Color(red: 0.98, green: 0.47, blue: 0.47) : Color(red: 0.74, green: 0.15, blue: 0.15)
+    }
+
+    /// The diff as one attributed run stream: removed characters in red with a strikethrough,
+    /// added characters in green, everything else in the body's normal colour. Both get a tinted
+    /// background so a changed space or newline is still visible.
+    private var diffAttributedText: AttributedString {
+        var output = AttributedString()
+        for segment in diffSegments {
+            var run = AttributedString(segment.text)
+            switch segment.kind {
+            case .equal:
+                run.foregroundColor = Color.primary.opacity(0.85)
+            case .insert:
+                run.foregroundColor = insertionColor
+                run.backgroundColor = insertionColor.opacity(colorScheme == .dark ? 0.20 : 0.14)
+            case .delete:
+                run.foregroundColor = deletionColor
+                run.backgroundColor = deletionColor.opacity(colorScheme == .dark ? 0.20 : 0.12)
+                run.strikethroughStyle = Text.LineStyle.single
+            }
+            output.append(run)
+        }
+        return output
     }
 
     // MARK: Chrome
@@ -138,26 +258,38 @@ public struct ResultCardView: View {
                     .contentShape(Rectangle())
             }
             .buttonStyle(.plain)
-            .help("Back to actions (Esc)")
+            .help("Back to actions")
             .accessibilityLabel("Back to actions")
             .onHover { isChevronHovered = $0 }
 
-            if let icon = payload.icon {
-                // The producing action's own icon (bar-resolution: honors user overrides),
-                // so extension results keep their identity in the card.
-                ActionIconView(icon: icon, size: 13)
-                    .foregroundColor(.accentColor)
-            } else {
-                Image(systemName: "sparkles")
-                    .font(.system(size: 13, weight: .medium))
-                    .foregroundColor(.accentColor)
+            // Everything between the buttons is the drag handle, so the card can be pulled off the
+            // text it covers. The handle sits *behind* this row, clear of the two buttons.
+            HStack(spacing: 8) {
+                if let icon = payload.icon {
+                    // The producing action's own icon (bar-resolution: honors user overrides),
+                    // so extension results keep their identity in the card.
+                    ActionIconView(icon: icon, size: 13)
+                        .foregroundColor(.accentColor)
+                } else {
+                    Image(systemName: "sparkles")
+                        .font(.system(size: 13, weight: .medium))
+                        .foregroundColor(.accentColor)
+                }
+                Text(payload.title)
+                    .font(.system(size: 13, weight: .semibold))
+                    .foregroundColor(PopupThemeModel.restForeground(for: effectiveTheme))
+                    .lineLimit(1)
+                    .truncationMode(.tail)
+                Spacer(minLength: 0)
             }
-            Text(payload.title)
-                .font(.system(size: 13, weight: .semibold))
-                .foregroundColor(PopupThemeModel.restForeground(for: effectiveTheme))
-                .lineLimit(1)
-                .truncationMode(.tail)
-            Spacer(minLength: 0)
+            .frame(maxWidth: .infinity)
+            .contentShape(Rectangle())
+            .gesture(headerDragGesture)
+            .help("Drag to move")
+
+            if hasDiff {
+                diffToggle
+            }
         }
         .padding(.horizontal, 10)
         .padding(.vertical, 8)
@@ -168,25 +300,82 @@ public struct ResultCardView: View {
         )
     }
 
+    /// A small threshold keeps a plain click on the header (which makes the panel key again after
+    /// the user worked in another app) from being read as a drag.
+    private var headerDragGesture: some Gesture {
+        DragGesture(minimumDistance: 2)
+            .onChanged { _ in
+                if !isDraggingCard {
+                    isDraggingCard = true
+                    onDrag(.began)
+                }
+                onDrag(.changed)
+            }
+            .onEnded { _ in
+                guard isDraggingCard else { return }
+                isDraggingCard = false
+                onDrag(.ended)
+            }
+    }
+
+    private var diffToggle: some View {
+        Button {
+            toggleDiff()
+        } label: {
+            Image(systemName: "plus.forwardslash.minus")
+                .font(.system(size: 10, weight: .bold))
+                .foregroundColor(showsDiff ? .accentColor : PopupThemeModel.restForeground(for: effectiveTheme).opacity(isDiffHovered ? 0.9 : 0.6))
+                .frame(width: 24, height: 20)
+                .background(
+                    showsDiff ? Color.accentColor.opacity(0.14) : (isDiffHovered ? Color.primary.opacity(0.08) : Color.clear),
+                    in: RoundedRectangle(cornerRadius: 6, style: .continuous)
+                )
+                .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .help(showsDiff ? "Show the plain result (⌘D)" : "Show what changed (⌘D)")
+        .accessibilityLabel("Toggle change highlighting")
+        .onHover { isDiffHovered = $0 }
+    }
+
     // MARK: Dynamic Dimensions
 
+    /// What the body actually renders — the diff is longer than the result (it keeps the removed
+    /// characters), so the card must be measured against it, not against `payload.text`.
+    private var measuredText: String {
+        if showsDiff, hasDiff {
+            return diffSegments.map(\.text).joined()
+        }
+        return payload.text
+    }
+
+    /// Width the footer's buttons need before they start squeezing each other. The card's width is
+    /// forced (a `ScrollView` of text has no useful ideal width), so the text-driven buckets below
+    /// are floored by this instead of letting the row compress.
+    private var minimumFooterWidth: CGFloat {
+        if payload.isError { return 190 }            // Close alone
+        return canPaste == false ? 250 : 320         // Close + Copy (+ Paste)
+    }
+
     private var dynamicCardWidth: CGFloat {
-        let trimmed = payload.text.trimmingCharacters(in: .whitespacesAndNewlines)
+        let trimmed = measuredText.trimmingCharacters(in: .whitespacesAndNewlines)
         let lines = trimmed.components(separatedBy: .newlines)
         let maxLineLength = lines.map(\.count).max() ?? trimmed.count
         let charCount = trimmed.count
 
+        let textWidth: CGFloat
         if maxLineLength <= 18 && charCount <= 30 {
-            return PopupMetrics.aiCardMinWidth // 220
+            textWidth = PopupMetrics.aiCardMinWidth // 220
         } else if maxLineLength <= 35 && charCount <= 80 {
-            return 260
+            textWidth = 260
         } else {
-            return PopupMetrics.aiCardIdealWidth // 300
+            textWidth = PopupMetrics.aiCardIdealWidth // 300
         }
+        return max(textWidth, minimumFooterWidth)
     }
 
     private var dynamicBodyHeight: CGFloat {
-        let trimmed = payload.text.trimmingCharacters(in: .whitespacesAndNewlines)
+        let trimmed = measuredText.trimmingCharacters(in: .whitespacesAndNewlines)
         let lines = trimmed.components(separatedBy: .newlines)
         let lineCount = lines.count
         let charCount = trimmed.count
@@ -209,7 +398,7 @@ public struct ResultCardView: View {
     // MARK: Body
 
     private var textTypography: (fontSize: CGFloat, fontWeight: Font.Weight, lineSpacing: CGFloat) {
-        let trimmed = payload.text.trimmingCharacters(in: .whitespacesAndNewlines)
+        let trimmed = measuredText.trimmingCharacters(in: .whitespacesAndNewlines)
         let lineCount = trimmed.components(separatedBy: .newlines).count
         let charCount = trimmed.count
 
@@ -228,17 +417,26 @@ public struct ResultCardView: View {
         let typography = textTypography
         let bodyHeight = dynamicBodyHeight
         return ScrollView {
-            Text(payload.text)
+            bodyText
                 .font(.system(size: typography.fontSize, weight: typography.fontWeight))
                 .lineSpacing(typography.lineSpacing)
                 .multilineTextAlignment(.leading)
-                .foregroundColor(payload.isError ? Color.red : Color.primary)
                 .frame(maxWidth: .infinity, alignment: .topLeading)
                 .textSelection(.enabled)
                 .padding(.horizontal, 14)
                 .padding(.vertical, 10)
         }
         .frame(height: bodyHeight)
+    }
+
+    @ViewBuilder
+    private var bodyText: some View {
+        if showsDiff, hasDiff {
+            Text(diffAttributedText)
+        } else {
+            Text(payload.text)
+                .foregroundColor(payload.isError ? Color.red : Color.primary)
+        }
     }
 
     // MARK: Footer
@@ -249,8 +447,51 @@ public struct ResultCardView: View {
 
     private var footer: some View {
         HStack(spacing: 8) {
+            Button {
+                onDismiss()
+            } label: {
+                HStack(spacing: 5) {
+                    Text("Close")
+                    Image(systemName: "escape")
+                        .font(.system(size: 10, weight: .semibold, design: .rounded))
+                        .opacity(0.8)
+                }
+                .font(.system(size: 12, weight: .medium))
+                .lineLimit(1)
+                .fixedSize()
+                .foregroundColor(PopupThemeModel.restForeground(for: effectiveTheme).opacity(0.85))
+                .padding(.horizontal, 10)
+                .padding(.vertical, 5)
+                .background(
+                    Color.primary.opacity(0.06),
+                    in: RoundedRectangle(cornerRadius: 6, style: .continuous)
+                )
+                .contentShape(Rectangle())
+            }
+            .buttonStyle(.plain)
+            .help("Close the card (⎋)")
+            .accessibilityLabel("Close the result card")
+
             Spacer(minLength: 0)
 
+            if !payload.isError {
+                resultButtons
+            }
+        }
+        .padding(.horizontal, 10)
+        .padding(.vertical, 8)
+        .background(
+            Rectangle().fill(PopupThemeModel.dividerColor(for: effectiveTheme))
+                .frame(height: 0.6),
+            alignment: .top
+        )
+    }
+
+    /// Copy / Paste — the answers that consume the result. Absent on an error card, which only
+    /// offers Close.
+    @ViewBuilder
+    private var resultButtons: some View {
+        Group {
             Button {
                 onCopy()
             } label: {
@@ -271,6 +512,8 @@ public struct ResultCardView: View {
                     }
                 }
                 .font(.system(size: 12, weight: isCopyPrimary ? .semibold : .medium))
+                .lineLimit(1)
+                .fixedSize()
                 .foregroundColor(isCopyPrimary ? .white : PopupThemeModel.restForeground(for: effectiveTheme))
                 .padding(.horizontal, isCopyPrimary ? 12 : 10)
                 .padding(.vertical, 5)
@@ -294,6 +537,8 @@ public struct ResultCardView: View {
                             .opacity(0.8)
                     }
                     .font(.system(size: 12, weight: .semibold))
+                    .lineLimit(1)
+                    .fixedSize()
                     .foregroundColor(.white)
                     .padding(.horizontal, 12)
                     .padding(.vertical, 5)
@@ -304,12 +549,5 @@ public struct ResultCardView: View {
                 .accessibilityLabel("Paste response over selection")
             }
         }
-        .padding(.horizontal, 10)
-        .padding(.vertical, 8)
-        .background(
-            Rectangle().fill(PopupThemeModel.dividerColor(for: effectiveTheme))
-                .frame(height: 0.6),
-            alignment: .top
-        )
     }
 }

--- a/Tests/OpenClipTests/MacSelectionMonitorTests.swift
+++ b/Tests/OpenClipTests/MacSelectionMonitorTests.swift
@@ -154,6 +154,30 @@ final class MacSelectionMonitorTests: XCTestCase {
         monitor.debounceTask?.cancel()
     }
 
+    /// While the result card is open the monitor must not read a selection at all: selecting a
+    /// word to edit the text under the card used to fire a fresh popup, which replaced the card.
+    /// Closing the card (the gate goes false) resumes the ordinary behaviour.
+    func testResultCardSuppressesSelectionTriggers() {
+        let store = MemorySettingsStore()
+        let monitor = MacSelectionMonitor(settingsStore: store)
+        var cardIsOpen = true
+        monitor.isSuppressed = { cardIsOpen }
+
+        monitor.handleSelectionTrigger(isSelectAll: false)
+        XCTAssertNil(monitor.debounceTask, "keyboard selection must not trigger while the card is open")
+
+        monitor.handleMouseDown(at: CGPoint(x: 100, y: 100))
+        XCTAssertNil(monitor.mouseHoldTask, "hold-to-popup must not arm while the card is open")
+
+        monitor.handleMouseUp(app: NSRunningApplication(), cursor: CGPoint(x: 100, y: 100), clickCount: 2)
+        XCTAssertNil(monitor.debounceTask, "double-click selection must not trigger while the card is open")
+
+        cardIsOpen = false
+        monitor.handleSelectionTrigger(isSelectAll: false)
+        XCTAssertNotNil(monitor.debounceTask, "closing the card must resume selection triggers")
+        monitor.debounceTask?.cancel()
+    }
+
     func testStopCancelsPendingMouseHoldTask() {
         let store = MemorySettingsStore()
         store.set(.mouseHoldDuration, value: 0.3)

--- a/Tests/OpenClipTests/ResultCardModalTests.swift
+++ b/Tests/OpenClipTests/ResultCardModalTests.swift
@@ -1,0 +1,313 @@
+import XCTest
+import AppKit
+import SwiftUI
+import Core
+@testable import OpenClip
+
+/// The result card is deliberately modal-ish: once a result shows, only Copy, Paste or Esc takes
+/// it away. Everything that dismisses the bar — an outside click, a right-click elsewhere, the
+/// cursor wandering off, another app coming forward — must leave the card up, so the user can read
+/// the response (and its diff) while working in the source app.
+@MainActor
+final class ResultCardModalTests: XCTestCase {
+
+    private func makeController() -> PopupWindowController {
+        let isolatedPasteboard = NSPasteboard(name: NSPasteboard.Name("OpenClipTest-\(UUID().uuidString)"))
+        let controller = PopupWindowController(resultHandler: DefaultActionResultHandler(pasteboard: isolatedPasteboard))
+        let panel = PopupPanel()
+        panel.setFrame(NSRect(x: 100, y: 100, width: 300, height: 120), display: false)
+        controller.panel = panel
+        controller.startTestSession(for: SelectionContext(
+            text: "hey how are you doing",
+            sourceApp: AppIdentity(bundleIdentifier: "com.test", localizedName: "Test"),
+            cursorPosition: CGPoint(x: 400, y: 400),
+            timestamp: Date(),
+            appPolicy: .default
+        ))
+        return controller
+    }
+
+    private func mouseEvent(_ type: NSEvent.EventType, at location: CGPoint) throws -> NSEvent {
+        try XCTUnwrap(NSEvent.mouseEvent(
+            with: type,
+            location: location,
+            modifierFlags: [],
+            timestamp: 0,
+            windowNumber: 0,
+            context: nil,
+            eventNumber: 0,
+            clickCount: 1,
+            pressure: 0
+        ))
+    }
+
+    private func escapeEvent() throws -> NSEvent {
+        try XCTUnwrap(NSEvent.keyEvent(
+            with: .keyDown,
+            location: .zero,
+            modifierFlags: [],
+            timestamp: 0,
+            windowNumber: 0,
+            context: nil,
+            characters: "\u{1b}",
+            charactersIgnoringModifiers: "\u{1b}",
+            isARepeat: false,
+            keyCode: 53
+        ))
+    }
+
+    func testContentModeIsModal() {
+        let controller = makeController()
+        defer { controller.hide() }
+        XCTAssertFalse(controller.cardIsModal, "the bar is not modal")
+        controller.modeStore.mode = .content
+        XCTAssertTrue(controller.cardIsModal)
+    }
+
+    func testOutsideClickKeepsTheCardButStillDismissesTheBar() throws {
+        let controller = makeController()
+        defer { controller.hide() }
+        let far = CGPoint(x: 2_000, y: 2_000)
+
+        controller.modeStore.mode = .content
+        controller.handleEvent(try mouseEvent(.leftMouseDown, at: far))
+        XCTAssertTrue(controller.isVisible, "a click outside must not take the result card away")
+
+        controller.modeStore.mode = .actions
+        controller.handleEvent(try mouseEvent(.leftMouseDown, at: far))
+        XCTAssertFalse(controller.isVisible, "the bar still dismisses on an outside click")
+    }
+
+    func testOutsideRightClickKeepsTheCard() throws {
+        let controller = makeController()
+        defer { controller.hide() }
+        controller.modeStore.mode = .content
+        controller.handleEvent(try mouseEvent(.rightMouseDown, at: CGPoint(x: 2_000, y: 2_000)))
+        XCTAssertTrue(controller.isVisible)
+    }
+
+    func testCursorDistanceKeepsTheCard() throws {
+        let controller = makeController()
+        defer { controller.hide() }
+        controller.modeStore.mode = .content
+        let panelFrame = try XCTUnwrap(controller.panel).frame
+        let far = CGPoint(x: panelFrame.maxX + PopupMetrics.popupDismissalDistance + 400,
+                          y: panelFrame.maxY + PopupMetrics.popupDismissalDistance + 400)
+        controller.handleEvent(try mouseEvent(.mouseMoved, at: far))
+        XCTAssertTrue(controller.isVisible)
+    }
+
+    /// The card owns Esc through SwiftUI while the panel is key; the monitor answers it only when
+    /// the panel lost key (the user clicked into another app), so the two can never double-fire.
+    func testEscapeDismissesTheCardWhenThePanelIsNotKey() throws {
+        let controller = makeController()
+        defer { controller.hide() }
+        controller.modeStore.mode = .content
+        XCTAssertFalse(try XCTUnwrap(controller.panel).isKeyWindow)
+        controller.handleEvent(try escapeEvent())
+        XCTAssertFalse(controller.isVisible, "Esc must close the card outright")
+    }
+
+    func testNonEscapeKeysNeverCloseTheCard() throws {
+        let controller = makeController()
+        defer { controller.hide() }
+        controller.modeStore.mode = .content
+        let typing = try XCTUnwrap(NSEvent.keyEvent(
+            with: .keyDown, location: .zero, modifierFlags: [], timestamp: 0, windowNumber: 0,
+            context: nil, characters: "a", charactersIgnoringModifiers: "a", isARepeat: false, keyCode: 0
+        ))
+        controller.handleEvent(typing)
+        XCTAssertTrue(controller.isVisible, "typing in the source app must not disturb the card")
+    }
+
+    /// The card diffs input → output, so the selection the action ran on has to reach the payload.
+    func testResultCardCarriesTheOriginalSelection() {
+        let controller = makeController()
+        defer { controller.hide() }
+        controller.showResultCard(text: "Hey, how are you doing?", isError: false, title: "Proofread", session: controller.aiSessionID)
+        XCTAssertEqual(controller.modeStore.resultCard?.original, "hey how are you doing")
+        XCTAssertEqual(controller.modeStore.resultCard?.text, "Hey, how are you doing?")
+    }
+
+    // MARK: - Dragging
+
+    /// The header handle must actually receive the drag. An `NSViewRepresentable` handle does not:
+    /// `NSHostingView` answers `hitTest` with itself for the whole card, so an AppKit subview never
+    /// sees the `mouseDown` (which is exactly how the first implementation failed). This drives a
+    /// real panel with synthetic mouse events and pins that the SwiftUI gesture is delivered.
+    func testHeaderDragGestureReachesTheCard() throws {
+        final class Recorder { var phases: [ResultCardDragPhase] = [] }
+        let recorder = Recorder()
+        let card = ResultCardView(
+            payload: ResultCardPayload(text: "Hey, how are you doing?", isError: false, title: "Proofread", original: "hey how are you doing"),
+            canPaste: true,
+            onExit: {}, onPaste: {}, onCopy: {},
+            onDrag: { recorder.phases.append($0) }
+        ).environment(\.colorScheme, .dark)
+
+        let host = NSHostingView(rootView: AnyView(card))
+        host.layoutSubtreeIfNeeded()
+        let size = host.fittingSize
+        let panel = PopupPanel()
+        panel.allowsKey = true
+        panel.contentView = host
+        panel.setFrame(NSRect(x: 300, y: 300, width: size.width, height: size.height), display: true)
+        panel.makeKeyAndOrderFront(nil)
+        defer { panel.orderOut(nil) }
+        RunLoop.current.run(until: Date().addingTimeInterval(0.4))
+
+        func send(_ type: NSEvent.EventType, _ point: NSPoint) throws {
+            let event = try XCTUnwrap(NSEvent.mouseEvent(
+                with: type, location: point, modifierFlags: [], timestamp: ProcessInfo.processInfo.systemUptime,
+                windowNumber: panel.windowNumber, context: nil, eventNumber: 0, clickCount: 1,
+                pressure: type == .leftMouseUp ? 0 : 1
+            ))
+            panel.sendEvent(event)
+            RunLoop.current.run(until: Date().addingTimeInterval(0.05))
+        }
+
+        // Window coordinates are bottom-left origin, so the header band is at the top.
+        let start = NSPoint(x: panel.frame.width / 2, y: panel.frame.height - 20)
+        try send(.leftMouseDown, start)
+        for step in 1...5 {
+            try send(.leftMouseDragged, NSPoint(x: start.x + CGFloat(step) * 8, y: start.y))
+        }
+        try send(.leftMouseUp, NSPoint(x: start.x + 40, y: start.y))
+
+        XCTAssertTrue(recorder.phases.contains(.began), "header drag never reached the card: \(recorder.phases)")
+        XCTAssertTrue(recorder.phases.contains(.changed), "drag updates never reached the card: \(recorder.phases)")
+        XCTAssertTrue(recorder.phases.contains(.ended), "drag end never reported: \(recorder.phases)")
+    }
+
+    /// The panel follows the cursor one-for-one, from the absolute pointer position rather than the
+    /// gesture translation (which would fight the window moving out from under the pointer).
+    func testCardDragMovesThePanelWithTheCursor() throws {
+        let controller = makeController()
+        defer { controller.hide() }
+        let panel = try XCTUnwrap(controller.panel)
+        controller.modeStore.mode = .content
+        let origin = panel.frame.origin
+
+        controller.handleCardDrag(.began, mouseLocation: CGPoint(x: 500, y: 500))
+        controller.handleCardDrag(.changed, mouseLocation: CGPoint(x: 540, y: 470))
+        XCTAssertEqual(panel.frame.origin.x, origin.x + 40, accuracy: 0.5)
+        XCTAssertEqual(panel.frame.origin.y, origin.y - 30, accuracy: 0.5)
+
+        controller.handleCardDrag(.changed, mouseLocation: CGPoint(x: 560, y: 470))
+        XCTAssertEqual(panel.frame.origin.x, origin.x + 60, accuracy: 0.5,
+                       "moves must stay absolute, not accumulate per update")
+
+        controller.handleCardDrag(.ended, mouseLocation: CGPoint(x: 560, y: 470))
+        XCTAssertFalse(panel.isUserDragging)
+        // A stale anchor must not move the panel after the drag ended.
+        controller.handleCardDrag(.changed, mouseLocation: CGPoint(x: 900, y: 900))
+        XCTAssertEqual(panel.frame.origin.x, origin.x + 60, accuracy: 0.5)
+    }
+
+    /// A user-placed card must stay where it was put: dragging drops the re-centering anchor that
+    /// content-driven width changes would otherwise apply.
+    func testUserDragStopsAutomaticRecentering() {
+        let panel = PopupPanel()
+        panel.setFrame(NSRect(x: 100, y: 100, width: 300, height: 120), display: false)
+        panel.horizontalAnchor = .center
+        XCTAssertFalse(panel.isUserDragging)
+
+        panel.prepareForUserDrag()
+        XCTAssertTrue(panel.isUserDragging, "hover tracking reads this to stop toggling click-through mid-drag")
+        XCTAssertEqual(panel.horizontalAnchor, .none, "a placed card must not be re-centered afterwards")
+
+        panel.endUserDrag()
+        XCTAssertFalse(panel.isUserDragging, "the drag flag must clear when AppKit's drag loop returns")
+        XCTAssertEqual(panel.horizontalAnchor, .none, "the placement outlives the drag")
+    }
+
+    /// A dragged card keeps its origin when the content resizes it (toggling the diff on changes
+    /// the card's width), instead of snapping back to the cursor-centred placement.
+    func testDraggedPanelKeepsItsOriginAcrossAWidthChange() {
+        let panel = PopupPanel()
+        panel.setFrame(NSRect(x: 400, y: 300, width: 300, height: 120), display: false)
+        panel.horizontalAnchor = .center
+        panel.prepareForUserDrag()
+        panel.endUserDrag()
+
+        panel.setFrame(NSRect(x: 400, y: 300, width: 220, height: 160), display: false)
+        XCTAssertEqual(panel.frame.minX, 400, accuracy: 0.5)
+    }
+
+    // MARK: - Footer
+
+    private func fittingSize(_ payload: ResultCardPayload, canPaste: Bool? = true) -> CGSize {
+        let card = ResultCardView(payload: payload, canPaste: canPaste, onExit: {}, onPaste: {}, onCopy: {})
+            .environment(\.colorScheme, .dark)
+        let host = NSHostingView(rootView: AnyView(card))
+        host.layoutSubtreeIfNeeded()
+        return host.fittingSize
+    }
+
+    /// The card's width is forced from the text, so a short response used to leave the footer's
+    /// three buttons fighting for room — "Copy" wrapped onto two lines. The width floor keeps the
+    /// whole row on one line.
+    func testShortResultStillFitsCloseCopyAndPaste() {
+        let size = fittingSize(ResultCardPayload(text: "Hi.", isError: false, title: "Proofread"))
+        XCTAssertGreaterThanOrEqual(size.width, 320, "footer row would be squeezed at \(size.width)pt")
+        XCTAssertLessThanOrEqual(size.width, PopupMetrics.aiCardMaxWidth)
+    }
+
+    /// An error card carries no Copy/Paste, but it still needs the Close button — it is just as
+    /// modal as a successful one.
+    func testErrorCardKeepsTheCloseFooter() {
+        let ok = fittingSize(ResultCardPayload(text: "All good", isError: false, title: "Proofread"))
+        let failed = fittingSize(ResultCardPayload(text: "All good", isError: true, title: "Proofread"))
+        XCTAssertEqual(failed.height, ok.height, accuracy: 8,
+                       "error card lost its footer: \(failed.height) vs \(ok.height)")
+    }
+
+    // MARK: - Diff rendering
+
+    /// Evidence that the diff actually reaches the pixels: a proofread-shaped edit must open on
+    /// the diff (its equal ratio is high) and paint both a red run for the removed characters and
+    /// a green run for the added ones.
+    func testProofreadResultRendersRedAndGreenRuns() throws {
+        let card = ResultCardView(
+            payload: ResultCardPayload(
+                text: "Hey, how are you doing?",
+                isError: false,
+                title: "Proofread",
+                original: "hey how are you doing"
+            ),
+            canPaste: true,
+            onExit: {},
+            onPaste: {},
+            onCopy: {}
+        )
+        .environment(\.colorScheme, .dark)
+
+        let host = NSHostingView(rootView: AnyView(card))
+        host.frame = NSRect(x: 0, y: 0, width: 320, height: 220)
+        let window = NSWindow(contentRect: host.frame, styleMask: [.borderless], backing: .buffered, defer: false)
+        window.contentView = host
+        window.orderBack(nil)
+        defer { window.orderOut(nil) }
+
+        // onAppear (which computes the diff) needs a run-loop turn after the view is hosted.
+        RunLoop.current.run(until: Date().addingTimeInterval(0.4))
+        host.layoutSubtreeIfNeeded()
+
+        let rep = try XCTUnwrap(host.bitmapImageRepForCachingDisplay(in: host.bounds))
+        host.cacheDisplay(in: host.bounds, to: rep)
+
+        var reddish = 0
+        var greenish = 0
+        for y in stride(from: 0, to: rep.pixelsHigh, by: 1) {
+            for x in stride(from: 0, to: rep.pixelsWide, by: 1) {
+                guard let color = rep.colorAt(x: x, y: y), color.alphaComponent > 0.2 else { continue }
+                guard let rgb = color.usingColorSpace(.sRGB) else { continue }
+                let r = rgb.redComponent, g = rgb.greenComponent, b = rgb.blueComponent
+                if r > g + 0.18 && r > b + 0.18 { reddish += 1 }
+                if g > r + 0.18 && g > b + 0.18 { greenish += 1 }
+            }
+        }
+        XCTAssertGreaterThan(reddish, 2, "removed characters must render in red")
+        XCTAssertGreaterThan(greenish, 2, "added characters must render in green")
+    }
+}

--- a/Tests/OpenClipTests/TextDiffTests.swift
+++ b/Tests/OpenClipTests/TextDiffTests.swift
@@ -1,0 +1,116 @@
+import XCTest
+import Core
+
+final class TextDiffTests: XCTestCase {
+
+    private func rendered(_ segments: [TextDiffSegment], kind: TextDiffSegment.Kind) -> String {
+        segments.filter { $0.kind == kind }.map(\.text).joined()
+    }
+
+    /// The old text must be reconstructible from equal+delete and the new one from equal+insert —
+    /// the property that makes the card's rendering honest.
+    private func assertRoundTrip(_ old: String, _ new: String, file: StaticString = #filePath, line: UInt = #line) {
+        let segments = TextDiff.segments(from: old, to: new)
+        let reconstructedOld = segments.filter { $0.kind != .insert }.map(\.text).joined()
+        let reconstructedNew = segments.filter { $0.kind != .delete }.map(\.text).joined()
+        XCTAssertEqual(reconstructedOld, old, "delete+equal must rebuild the original", file: file, line: line)
+        XCTAssertEqual(reconstructedNew, new, "insert+equal must rebuild the result", file: file, line: line)
+    }
+
+    func testIdenticalTextIsOneEqualSegment() {
+        let segments = TextDiff.segments(from: "hey how are you", to: "hey how are you")
+        XCTAssertEqual(segments, [TextDiffSegment(kind: .equal, text: "hey how are you")])
+        XCTAssertEqual(TextDiff.equalRatio(of: segments), 1.0)
+    }
+
+    func testEmptyInputs() {
+        XCTAssertEqual(TextDiff.segments(from: "", to: ""), [])
+        XCTAssertEqual(TextDiff.segments(from: "", to: "added"), [TextDiffSegment(kind: .insert, text: "added")])
+        XCTAssertEqual(TextDiff.segments(from: "gone", to: ""), [TextDiffSegment(kind: .delete, text: "gone")])
+    }
+
+    /// The proofread case from the card: capitalization + punctuation edits show as small
+    /// insert/delete runs inside a mostly-equal body.
+    func testProofreadEditProducesCharacterLevelRuns() {
+        let old = "hey how are you doing"
+        let new = "Hey, how are you doing?"
+        let segments = TextDiff.segments(from: old, to: new)
+        assertRoundTrip(old, new)
+        XCTAssertEqual(rendered(segments, kind: .delete), "h")
+        XCTAssertEqual(rendered(segments, kind: .insert), "H,?")
+        XCTAssertGreaterThan(TextDiff.equalRatio(of: segments), 0.8,
+                             "a light edit must read as mostly-equal so the card opens on the diff")
+    }
+
+    func testPureInsertionAndDeletionKeepSurroundingTextEqual() {
+        let inserted = TextDiff.segments(from: "the cat sat", to: "the black cat sat")
+        assertRoundTrip("the cat sat", "the black cat sat")
+        XCTAssertEqual(rendered(inserted, kind: .insert), "black ")
+        XCTAssertTrue(inserted.allSatisfy { $0.kind != .delete })
+
+        let deleted = TextDiff.segments(from: "the black cat sat", to: "the cat sat")
+        assertRoundTrip("the black cat sat", "the cat sat")
+        XCTAssertEqual(rendered(deleted, kind: .delete), "black ")
+        XCTAssertTrue(deleted.allSatisfy { $0.kind != .insert })
+    }
+
+    func testSegmentsAreCoalescedNotPerCharacter() {
+        let segments = TextDiff.segments(from: "abcdef", to: "abXYZdef")
+        XCTAssertEqual(segments, [
+            TextDiffSegment(kind: .equal, text: "ab"),
+            TextDiffSegment(kind: .delete, text: "c"),
+            TextDiffSegment(kind: .insert, text: "XYZ"),
+            TextDiffSegment(kind: .equal, text: "def")
+        ])
+    }
+
+    func testGraphemeClustersAreNeverSplit() {
+        let old = "ship it 🙂"
+        let new = "ship it 👍🏽"
+        let segments = TextDiff.segments(from: old, to: new)
+        assertRoundTrip(old, new)
+        XCTAssertEqual(rendered(segments, kind: .delete), "🙂")
+        XCTAssertEqual(rendered(segments, kind: .insert), "👍🏽")
+    }
+
+    func testUnrelatedRewriteFallsBackToWholesaleReplacement() {
+        // Far beyond `maxEditDistance`: the honest answer is "this was replaced", not a shredded
+        // character salad — and it must still round-trip.
+        let old = String(repeating: "a", count: 1_200)
+        let new = String(repeating: "b", count: 1_200)
+        let segments = TextDiff.segments(from: old, to: new)
+        assertRoundTrip(old, new)
+        XCTAssertEqual(segments.count, 2)
+        XCTAssertEqual(segments.first?.kind, .delete)
+        XCTAssertEqual(segments.last?.kind, .insert)
+        XCTAssertEqual(TextDiff.equalRatio(of: segments), 0.0)
+    }
+
+    func testLongTextWithSmallEditStillDiffsThroughPrefixSuffixTrim() {
+        let filler = String(repeating: "lorem ipsum dolor sit amet. ", count: 400) // ~11k chars
+        let old = filler + "teh end"
+        let new = filler + "the end"
+        let segments = TextDiff.segments(from: old, to: new)
+        assertRoundTrip(old, new)
+        XCTAssertGreaterThan(TextDiff.equalRatio(of: segments), 0.99,
+                             "prefix/suffix trimming must keep a long text diffable")
+        XCTAssertLessThanOrEqual(rendered(segments, kind: .delete).count, 3)
+    }
+
+    func testOversizedComparisonStaysBounded() {
+        let old = String(repeating: "x", count: 20_000)
+        let new = String(repeating: "y", count: 20_000)
+        let started = Date()
+        let segments = TextDiff.segments(from: old, to: new)
+        XCTAssertLessThan(Date().timeIntervalSince(started), 1.0, "the length budget must short-circuit")
+        assertRoundTrip(old, new)
+        XCTAssertEqual(segments.count, 2)
+    }
+
+    func testEqualRatioSeparatesEditsFromRewrites() {
+        let edit = TextDiff.segments(from: "hey how are you doing", to: "Hey, how are you doing?")
+        let rewrite = TextDiff.segments(from: "hey how are you doing", to: "Bonjour, comment allez-vous ?")
+        XCTAssertGreaterThanOrEqual(TextDiff.equalRatio(of: edit), 0.5)
+        XCTAssertLessThan(TextDiff.equalRatio(of: rewrite), 0.5)
+    }
+}

--- a/docs/architecture/directory-structure.md
+++ b/docs/architecture/directory-structure.md
@@ -105,6 +105,7 @@ Sources/
 │   │   ├── SettingKey.swift                  # Strongly-typed setting keys
 │   │   └── SettingsStore.swift               # Central SettingsStore protocol + DefaultSettingsStore adapter
 │   └── Utils/
+│       ├── TextDiff.swift                    # Character-level Myers diff (input → result) behind the result card's diff view
 │       └── TextPlaceholderEngine.swift       # Dynamic text template engine ({text}, {query}, {html}, {rtf}, {matched}, {captureN}, {bundleID})
 └── OpenClip/                                 # App Target (macOS App / AppKit / SwiftUI)
     ├── AppDelegate.swift                     # Reads isAppEnabled / hasCompletedOnboarding via DefaultSettingsStore (SettingKey)
@@ -218,7 +219,7 @@ Sources/
         │   ├── PopupThemeSelector.swift      # Theme control: two rows (Classic|Glass, then System/Light/Dark); storage popupTheme + popupThemeColor
         │   ├── PopupView.swift               # SwiftUI popup bar (action bar / AI / completions / search-mode / content result-card branch + ⌘ affordance)
         │   ├── PopupWindowController.swift   # Window lifecycle + mode state machine (bar/search/content) + event monitoring
-        │   ├── ResultCardView.swift          # Native result card (back chevron + action icon/sparkles + title header, scrollable body, Copy/Paste footer) for .content mode
+        │   ├── ResultCardView.swift          # Native result card (back chevron + action icon/sparkles + title + diff toggle header, header-drag gesture, scrollable body/diff, Close/Copy/Paste footer) for .content mode
         │   ├── SearchHoverSupport.swift      # Search-palette hover-target/frame preference keys
         │   ├── SubBarPanel.swift             # Sub-action menu floating NSPanel
         │   ├── SubBarPanelController.swift   # Controller managing the sub-action bar panel lifecycle

--- a/docs/architecture/popup-window.md
+++ b/docs/architecture/popup-window.md
@@ -28,8 +28,8 @@ The floating popup panel subsystem presents contextual actions near the user's c
 ### 2. [`PopupWindowController`](../../Sources/OpenClip/UI/Popup/PopupWindowController.swift)
 - **Responsibility**: Controls window creation, display lifecycle, event monitoring, hover tracking, and the popup mode state machine (actions bar ↔ search palette ↔ content/AI-card).
 - **Event Handling**: Sets up local and global `NSEvent` monitors (`.leftMouseDown`, `.mouseMoved`, `.scrollWheel`, `.keyDown`). The local monitor sees mouse events over the panel; the global monitor sees events system-wide.
-- **Dismissal Threshold**: Automatically dismisses the popup if the cursor moves beyond `PopupMetrics.popupDismissalDistance` (suspended in search mode and while a content/AI-card is open).
-- **Keyboard Dismissal**: Requires Accessibility permission (the global monitor). In actions mode any key — including `Escape` — dismisses the popup; the global monitor is observation-only, so the keystroke still lands in the source app's document and the panel never needs to become key. In search mode the panel *is* key, so keys go to the search field (`Escape` clears a scoped query, then exits). In content mode the panel is *also* key: the AI result card owns all keys via SwiftUI `.onKeyPress`, `Escape` collapses the card back to the bar (`exitContent()`), and the controller monitor stays observation-only so it never double-fires Esc.
+- **Dismissal Threshold**: Automatically dismisses the popup if the cursor moves beyond `PopupMetrics.popupDismissalDistance` (suspended in search mode and while a content/AI-card is open). The result card goes further: `cardIsModal` suppresses *every* automatic dismissal (outside click, scroll, app switch), so it stays up until Copy, Paste or Esc.
+- **Keyboard Dismissal**: Requires Accessibility permission (the global monitor). In actions mode any key — including `Escape` — dismisses the popup; the global monitor is observation-only, so the keystroke still lands in the source app's document and the panel never needs to become key. In search mode the panel *is* key, so keys go to the search field (`Escape` clears a scoped query, then exits). In content mode the panel is *also* key: the AI result card owns all keys via SwiftUI `.onKeyPress`, `Escape` closes the card (`hide()`), and the controller monitor stays observation-only so it never double-fires Esc — bar the one case where the panel has lost key (the card outlives clicks into other apps), where the monitor answers Esc itself.
 
 ---
 
@@ -84,24 +84,63 @@ that replaced the former interactive canvas.
   `PopupWindowController.showResultCard`; any other text-returning action (e.g. a shell/JS extension)
   lands there through the delivery snapshot in `handleEffect`, which passes the performing action's
   customization-resolved icon alongside its title. Both set `modeStore.resultCard`
-  (`ResultCardPayload { text, isError, title, icon, isStreaming }`), `modeStore.mode = .content`,
-  and enter key mode.
+  (`ResultCardPayload { text, isError, title, icon, isStreaming, original }` — `original` is the
+  selection the action ran on, carried so the card can diff it against the result),
+  `modeStore.mode = .content`, and enter key mode.
   The card's chrome header (back chevron + the producing action's icon — sparkles when none,
-  e.g. AI streaming — + title) is rendered by `ResultCardView`
+  e.g. AI streaming — + title + diff toggle) is rendered by `ResultCardView`
   (`Sources/OpenClip/UI/Popup/ResultCardView.swift`), with the back chevron wired to
-  `PopupView.onExitContent` → `PopupWindowController.exitContent()`.
-- **Card surface**: the card renders a scrollable body plus a Copy/Paste footer (hidden when
-  `isError`; Paste also hidden while `modeStore.canPaste == false`), sized by `PopupMetrics`
+  `PopupView.onExitContent` → `PopupWindowController.exitContent()` and Esc wired to
+  `PopupView.onDismissContent` → `hide()`.
+- **Card surface**: the card renders a scrollable body plus a Close/Copy/Paste footer (Copy and Paste hidden when
+  `isError`, where only Close remains; Paste also hidden while `modeStore.canPaste == false`), sized by `PopupMetrics`
   (`aiCardMinWidth 220` / `aiCardIdealWidth 300` /
-  `aiCardMaxWidth 360` / `aiCardBodyHeight 120`). Content mode is **key exactly like search**:
+  `aiCardMaxWidth 360` / `aiCardBodyHeight 120`), measured against whichever body is showing
+  (the diff is longer than the plain result). Content mode is **key exactly like search**:
   the panel becomes key through the same `enterKeyMode()` primitive, and the card owns all keys
-  via SwiftUI `.onKeyPress` — Esc collapses the card back to the bar (`exitContent()`); Return
-  pastes and Shift+Return copies (Return falls back to copy when paste is unavailable); the
-  controller monitor observes content Esc only so non-key transitions still collapse.
-- **Copy/Paste footer**: Paste (right) and Copy (left of it) both route through
+  via SwiftUI `.onKeyPress` — Esc closes the card outright (`hide()`, *not* a collapse back to the
+  bar — the back chevron is what collapses); Return pastes and Shift+Return copies (Return falls
+  back to copy when paste is unavailable); ⌘D toggles the diff. The controller monitor stays
+  observation-only, with one exception: once the panel has lost key (the user clicked into another
+  app while the card stayed up) it answers Esc itself, so the two can never double-fire.
+- **Diff view**: `Core/Utils/TextDiff.swift` (pure domain) diffs `original` → `text` at character
+  level — a Myers greedy diff over grapheme clusters, preceded by common prefix/suffix trimming,
+  bounded by `maxComparableLength` (6 000 chars of changed middle) and `maxEditDistance` (600);
+  exceeding either degrades to one delete + one insert. The card renders the segments as one
+  attributed string: removed characters red + struck through, added characters green, both on a
+  tinted background so a changed space is still visible. The header toggle (and ⌘D) switches
+  between the diff and the plain result; the default is picked from `TextDiff.equalRatio` — a light
+  edit (proofread, tone) opens on the diff, a wholesale rewrite (translate, summarize) opens on the
+  result — and a manual toggle is never overridden afterwards. A streaming response is never
+  diffed; the comparison waits for the final text.
+- **Modal until answered**: `PopupWindowController.cardIsModal` (true in `.content`) suppresses
+  every automatic dismissal — outside click, outside right-click, scroll, cursor distance, app
+  deactivation, another app coming forward. The card lives until Copy, Paste, Close or Esc. The
+  same flag is `MacSelectionMonitor.isSuppressed` (wired in `AppDelegate`): while the card is up
+  the monitor reads no selection at all, so selecting a word in the source app to edit it by hand
+  cannot pop the action bar over the card. Every trigger checks the gate — mouse-up, hold-arming,
+  keyboard selection — and each re-checks after its debounce/hold sleep, since the card can open
+  while a timer is pending. Closing the card resumes triggers with no extra bookkeeping.
+- **Draggable**: the header between the chevron and the diff toggle carries a SwiftUI
+  `DragGesture` that reports `ResultCardDragPhase` (`began`/`changed`/`ended`) to
+  `PopupWindowController.handleCardDrag`, which moves the panel. AppKit dragging is **not**
+  available here and three obvious routes are dead ends: the panel has no title bar,
+  `isMovableByWindowBackground` never fires because the SwiftUI hosting view consumes the press,
+  and an `NSViewRepresentable` handle never receives `mouseDown` either — `NSHostingView` answers
+  `hitTest` with *itself* for the whole card and dispatches through SwiftUI's gesture system
+  (`ResultCardModalTests.testHeaderDragGestureReachesTheCard` pins this). The move is computed from
+  the **absolute** cursor position against an anchor taken at `began`, never from the gesture's
+  translation: the window moves out from under the pointer, so a translation-based move fights
+  itself. `prepareForUserDrag` sets `horizontalAnchor = .none`, so a later width change (the diff
+  toggle resizes the card) keeps the user's placement instead of re-centering, and raises
+  `isUserDragging`, which stops `updatePopupHover` from toggling `ignoresMouseEvents` mid-drag.
+- **Footer**: Close (⎋, left) calls the same `onDismiss` path as Esc. Paste (right) and Copy (left of it) both route through
   `PopupView.onCardEffect` → `PopupWindowController.performCardEffect` — an explicit request that
   bypasses the paste-vs-copy re-decision. Both dismiss the popup and perform (Paste pastes over
-  the selection, Copy copies to the clipboard) — Copy behaves like Paste and closes too.
+  the selection, Copy copies to the clipboard) — Copy behaves like Paste and closes too. An error
+  card drops Copy/Paste but keeps the Close button, since it is just as modal. The card's width is
+  forced from its text, so `minimumFooterWidth` floors it: without that floor the three buttons
+  squeeze and "Copy" wraps onto two lines.
 - **Paste availability gating**: the trigger sites (hotkey handler, `MacSelectionMonitor`) start
   `PopupWindowController.preparePasteProbe(for:policy:)` in parallel with selection retrieval and hand the
   awaited result to `show(for:pasteAvailable:)`, which stores `modeStore.canPaste` before the first
@@ -143,7 +182,8 @@ already visible; the bar's command-glyph button enters search via `onEnterSearch
 
 - **Mode state**: [`PopupModeStore`](../../Sources/OpenClip/UI/Popup/PopupModeStore.swift) holds
   `mode` (`.actions`/`.search`/`.content`), `searchResultsAbove` (set from `cardAbove` in
-  `show(for:)`), plus the content payload `resultCard`. Statuses live in the floating toast, not the
+  `show(for:)`), plus the content payload `resultCard` (which carries the `original` selection for
+  the card's diff). Statuses live in the floating toast, not the
   store. `PopupView` branches on `modeStore.mode` in `unifiedHStack` and renders
   `PopupSearchView` — the field + result list rendered as **one surface** with the bar, results
   above or below the field by `searchResultsAbove`.

--- a/scripts/translations/fr.json
+++ b/scripts/translations/fr.json
@@ -392,7 +392,6 @@
   "OpenClip could not remove extension: %@": "OpenClip n’a pas pu supprimer l’extension : %@",
   "Invalid download URL.": "URL de téléchargement non valide.",
   "Exit search": "Quitter la recherche",
-  "Back to actions (Esc)": "Retour aux actions (Échap)",
   "Paste the response over the selection (⏎)": "Coller la réponse sur la sélection (⏎)",
   "Open AI settings": "Ouvrir les réglages d’IA",
   "Fetch available models live from API": "Récupérer les modèles disponibles en direct depuis l’API",
@@ -426,5 +425,11 @@
   "Pause in %@": "Mettre en pause dans %@",
   "Paused in %@": "En pause dans %@",
   "Pause in App": "Mettre en pause dans l'application",
-  "Resume OpenClip (%lldm left)": "Reprendre OpenClip (%lld min restantes)"
+  "Resume OpenClip (%lldm left)": "Reprendre OpenClip (%lld min restantes)",
+  "Show what changed (⌘D)": "Afficher les modifications (⌘D)",
+  "Show the plain result (⌘D)": "Afficher le résultat simple (⌘D)",
+  "Toggle change highlighting": "Activer ou désactiver la mise en évidence des modifications",
+  "Drag to move": "Faire glisser pour déplacer",
+  "Close the card (⎋)": "Fermer la carte (⎋)",
+  "Close the result card": "Fermer la carte de résultat"
 }

--- a/scripts/translations/ja.json
+++ b/scripts/translations/ja.json
@@ -392,7 +392,6 @@
   "OpenClip could not remove extension: %@": "OpenClipは拡張機能を削除できませんでした: %@",
   "Invalid download URL.": "ダウンロードURLが無効です。",
   "Exit search": "検索を終了",
-  "Back to actions (Esc)": "アクションに戻る (Esc)",
   "Paste the response over the selection (⏎)": "選択範囲に応答をペースト (⏎)",
   "Open AI settings": "AI設定を開く",
   "Fetch available models live from API": "APIから利用可能なモデルをライブ取得",
@@ -426,5 +425,11 @@
   "Pause in %@": "%@ で一時停止",
   "Paused in %@": "%@ で一時停止中",
   "Pause in App": "アプリで一時停止",
-  "Resume OpenClip (%lldm left)": "OpenClip を再開 (残り %lld 分)"
+  "Resume OpenClip (%lldm left)": "OpenClip を再開 (残り %lld 分)",
+  "Show what changed (⌘D)": "変更点を表示 (⌘D)",
+  "Show the plain result (⌘D)": "結果のみを表示 (⌘D)",
+  "Toggle change highlighting": "変更のハイライトを切り替える",
+  "Drag to move": "ドラッグして移動",
+  "Close the card (⎋)": "カードを閉じる (⎋)",
+  "Close the result card": "結果カードを閉じる"
 }

--- a/scripts/translations/zh-Hans.json
+++ b/scripts/translations/zh-Hans.json
@@ -392,7 +392,6 @@
   "OpenClip could not remove extension: %@": "OpenClip 无法移除扩展：%@",
   "Invalid download URL.": "下载地址无效。",
   "Exit search": "退出搜索",
-  "Back to actions (Esc)": "返回动作（Esc）",
   "Paste the response over the selection (⏎)": "将回复粘贴到选中内容上（⏎）",
   "Open AI settings": "打开 AI 设置",
   "Fetch available models live from API": "从 API 实时获取可用模型",
@@ -426,5 +425,11 @@
   "Pause in %@": "在 %@ 中暂停",
   "Paused in %@": "已在 %@ 中暂停",
   "Pause in App": "在应用中暂停",
-  "Resume OpenClip (%lldm left)": "恢复 OpenClip (剩余 %lld 分钟)"
+  "Resume OpenClip (%lldm left)": "恢复 OpenClip (剩余 %lld 分钟)",
+  "Show what changed (⌘D)": "显示更改内容 (⌘D)",
+  "Show the plain result (⌘D)": "显示纯文本结果 (⌘D)",
+  "Toggle change highlighting": "切换更改高亮",
+  "Drag to move": "拖动以移动",
+  "Close the card (⎋)": "关闭卡片 (⎋)",
+  "Close the result card": "关闭结果卡片"
 }

--- a/scripts/translations/zh-Hant.json
+++ b/scripts/translations/zh-Hant.json
@@ -392,7 +392,6 @@
   "OpenClip could not remove extension: %@": "OpenClip 無法移除擴充功能：%@",
   "Invalid download URL.": "下載網址無效。",
   "Exit search": "結束搜尋",
-  "Back to actions (Esc)": "返回動作（Esc）",
   "Paste the response over the selection (⏎)": "將回覆貼上並取代選取內容（⏎）",
   "Open AI settings": "打開 AI 設定",
   "Fetch available models live from API": "從 API 即時取得可用模型",
@@ -426,5 +425,11 @@
   "Pause in %@": "在 %@ 中暫停",
   "Paused in %@": "已在 %@ 中暫停",
   "Pause in App": "在應用中暫停",
-  "Resume OpenClip (%lldm left)": "恢復 OpenClip (剩餘 %lld 分鐘)"
+  "Resume OpenClip (%lldm left)": "恢復 OpenClip (剩餘 %lld 分鐘)",
+  "Show what changed (⌘D)": "顯示變更內容 (⌘D)",
+  "Show the plain result (⌘D)": "顯示純文字結果 (⌘D)",
+  "Toggle change highlighting": "切換變更標示",
+  "Drag to move": "拖曳以移動",
+  "Close the card (⎋)": "關閉卡片 (⎋)",
+  "Close the result card": "關閉結果卡片"
 }


### PR DESCRIPTION
## Thinking Path

- I am user familiar with Raycast and it's AI fixing tooling
- I look for alternatives due to recent pricing changes to Raycast
- I find OpenClip and try it's AI proofread feature
- I notice OpenClip is missing diff viewer for AI changes

## Why AI text changes diff is important

It remains important that communication between humans is done witout AI. Mom, colleague or boss, it simply doesnt feel right to get AI-like message from people chatting with you.

With changes in this PR, following flows become possible, and much simpler:

1. Make sure all changes are expected, and fixes are one-char or one-word, not entire rewrite
2. Dont trust AI at all, just look at diff visually and manually apply fixes that feel important to you. Sometimes you want unprofessional tone, but you never want grammar mistake - only take those suggesions manually

## Development process

PR was made with agents, I am not familiar with Swift programming language.

<details>

<summary>Prompts</summary>

## Prompts

```
After running AI tool, it shows "generating" for a moment, and then shows the result.

Implement diff viewer into this

The diff viewer should show what characters were removed (red) and what were added (green).

Also make it so result card can be moved around (by dragging), and also remains open until either of the action is done - copy or paste. But also track  a new keypress - ESC, to simply close the card
```

```
 I have OpenClip already installed. Update my loally installed version with the version including our changes.
 ```

 ```
  I dont seem to be able to drag the card around. Can you double check the implementation?
  ```

  ```
   There is an interaction bug, notice this journey:

  1. I select text
  2. I choose AI "proofread"
  3. Card opens with the diff
  4. I move card out of the way so I can manually do the edits
  5. I double-click word to select it, with intention to remove it and write it again
  6. Card closes because options re-open with action selection

  Make sure that selecting text to open action selection is temporarly disabled while the result card with diff is open. Once I close the card (ESC), it will resume working as usual.

  On a separate note, please add "Close" button to the card too, at bottom, with ESC shortcut indication.
  ```


```
Submit a draft PR towards the official repository - mine is just a fork.

Only include very short PR description summary, and follow template, if any.

I will finalize the PR afterwrads. Make sure its draft PR
```
</details>

## Summary

Makes the result card usable as a workspace: it shows a character-level diff of what the action changed (removed red + struck through, added green; header toggle or ⌘D for the plain result), can be dragged by its header, and stays up until Copy, Paste, Close (⎋) or Esc instead of vanishing on the next click. While it is open the selection monitor is gated off, so selecting a word to edit the text under the card no longer pops the action bar over it.

Fixes # <!-- no linked issue -->

---

## Type of Change
- [ ] Bug fix (non-breaking change fixing an issue)
- [x] New feature (non-breaking change adding functionality)
- [ ] Extension Runtime / Bridge update (JS host, AppleScript runner, Shell executor)
- [ ] UI / Theme / Accessibility improvement
- [ ] Performance / Concurrency optimization
- [ ] Localization (`Localizable.xcstrings`)
- [ ] Documentation update
- [ ] Build tooling / CI / Scripts

---

## Testing & Verification

### Environment Tested:
- **macOS Version:** macOS 26.5.1
- **Architecture:** Apple Silicon
- **Target Apps Verified:** Release build installed locally and exercised by hand; card rendering verified from bitmap snapshots in tests

### Test Execution:
- [x] Ran `./scripts/test.sh core` (< 1s domain test suite)
- [x] Ran `./scripts/test.sh` — 1082 tests. **Not 0 failures on this machine:** 4 failures, all pre-existing and unrelated (3 locale-dependent `CalculateActionTests`, 1 mouse-position-dependent `testEnterSearchWithButtonAnchorCentersSearchOnButton`); confirmed identical on a clean checkout of `main`.
- [x] Tested live in app via `./scripts/dev_run.sh` — used a Release build installed to `/Applications` instead.

New tests: `TextDiffTests` (diff engine, round-trip, budgets), `ResultCardModalTests` (modality, Esc, drag delivery + geometry, footer layout, red/green pixels actually painted), `MacSelectionMonitorTests.testResultCardSuppressesSelectionTriggers`.

---

## Screenshots / Screen Recordings (if applicable)
<!-- To add before merging. -->

Before:


https://github.com/user-attachments/assets/bab073ee-4ac3-4e88-8928-ba6665c313e5


After:

https://github.com/user-attachments/assets/8a8e2a3e-1784-4b76-aa94-d8c8ae8c13d7

---

## Architectural & Code Checklist
- [x] **Swift 6 Concurrency:** builds clean under `SWIFT_STRICT_CONCURRENCY: complete`.
- [x] **Core Purity:** `Sources/Core/Utils/TextDiff.swift` imports `Foundation` only.
- [x] **Settings & Secrets:** no new `UserDefaults.standard`.
- [x] **Subprocess Safety:** n/a — no new subprocesses.
- [x] **Dual-Sink Logging:** no `print()` / ad-hoc `Logger()` added.
- [x] **Localization:** new strings via the catalog + `scripts/translations/*.json`, regenerated with `scripts/generate_localizable.py`.

Docs updated: `docs/architecture/popup-window.md`, `docs/architecture/directory-structure.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Nd1NMfeR42YrKgAkxMtic6


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Result cards now show character-level changes between the original selection and the result, with a shortcut to toggle highlighting.
  - Result cards can be dragged by their headers and remain open until explicitly closed, copied, or pasted.
  - Added clearer Close controls and improved error-card layouts.
- **Bug Fixes**
  - Selection triggers are suppressed while a result card is open, preventing unintended overlays.
  - Improved card sizing and positioning during dragging and resizing.
- **Localization**
  - Added translated labels for change highlighting, dragging, and result-card controls in supported languages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->