### PR TITLE
fix(actions): keep packaged file icons on inline shell and snippet actions

### DIFF
--- a/Sources/Core/Actions/CustomAction.swift
+++ b/Sources/Core/Actions/CustomAction.swift
@@ -20,17 +20,27 @@ public struct CustomAction: ConfigurableAction, Codable, Sendable, Equatable {
     public let id: String
     public let title: String
     public let iconName: String
+    /// The icon parsed from a manifest, when it is not an SF Symbol. `iconName` can only carry a
+    /// symbol name, so a packaged file icon (`icon.svg`, `icon.png`) would otherwise be flattened
+    /// to its filename and rendered as a missing symbol. Not persisted: actions created in the UI
+    /// only ever carry symbols, and manifest-backed actions are rebuilt from the manifest on load.
+    public var resolvedIcon: ActionIcon?
     public let type: CustomActionType
     public let chrome: ActionChrome
     public let rules: ExtensionActionRules?
-    
+
+    private enum CodingKeys: String, CodingKey {
+        case id, title, iconName, type, chrome, rules
+    }
+
     public init(
         id: String,
         title: String,
         iconName: String,
         type: CustomActionType,
         chrome: ActionChrome = ActionChrome(badge: .custom, rowStyle: .standard, popupBehavior: .perform, source: .custom),
-        rules: ExtensionActionRules? = nil
+        rules: ExtensionActionRules? = nil,
+        resolvedIcon: ActionIcon? = nil
     ) {
         self.id = id
         self.title = title
@@ -38,10 +48,11 @@ public struct CustomAction: ConfigurableAction, Codable, Sendable, Equatable {
         self.type = type
         self.chrome = chrome
         self.rules = rules
+        self.resolvedIcon = resolvedIcon
     }
     
     public var icon: ActionIcon {
-        return .symbol(iconName)
+        return resolvedIcon ?? .symbol(iconName)
     }
 
     public var preferenceIconName: String {

--- a/Sources/OpenClip/Platform/Extensions/DefaultActionFactory.swift
+++ b/Sources/OpenClip/Platform/Extensions/DefaultActionFactory.swift
@@ -326,7 +326,8 @@ public final class DefaultActionFactory: ActionFactory, Sendable {
                 iconName: iconSymbolName(icon),
                 type: .textSnippet(template: scriptCode),
                 chrome: extensionChrome,
-                rules: rules
+                rules: rules,
+                resolvedIcon: icon
             )
         }
         
@@ -362,7 +363,8 @@ public final class DefaultActionFactory: ActionFactory, Sendable {
                     iconName: iconSymbolName(icon),
                     type: .shellScript(script: scriptCode, replaceSelection: true),
                     chrome: extensionChrome,
-                    rules: rules
+                    rules: rules,
+                    resolvedIcon: icon
                 )
             default:
                 break

--- a/Tests/OpenClipTests/DefaultActionFactoryTests.swift
+++ b/Tests/OpenClipTests/DefaultActionFactoryTests.swift
@@ -491,4 +491,68 @@ final class DefaultActionFactoryTests: XCTestCase {
 
         try? FileManager.default.removeItem(at: tempDir)
     }
+    /// An inline `shell` action becomes a `CustomAction`, which carries only an SF Symbol name.
+    /// A packaged file icon must survive that trip: flattening `.local` to its filename produced
+    /// `.symbol("icon.svg")`, a symbol that does not exist, so the action rendered with no icon.
+    func testInlineShellActionKeepsPackagedFileIcon() async {
+        let tempDir = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        try? FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: tempDir) }
+        let iconURL = tempDir.appendingPathComponent("icon.svg")
+        try? "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 24 24\"><path d=\"M2 2h20v20H2z\"/></svg>"
+            .write(to: iconURL, atomically: true, encoding: .utf8)
+
+        let factory = DefaultActionFactory()
+        let actionMeta = ExtensionActionMetadata(
+            title: "Shell With File Icon",
+            icon: "icon.svg",
+            type: "shell",
+            scriptCode: "echo $OPENCLIP_TEXT"
+        )
+        let manifest = ExtensionMetadata(identifier: "com.test.shellicon", name: "Shell Icon Test", actions: [actionMeta], options: nil)
+
+        let action = await factory.createAction(metadata: actionMeta, manifest: manifest, directoryURL: tempDir, index: 0)
+        XCTAssertTrue(action is CustomAction)
+        XCTAssertEqual(action?.icon, .local(tempDir.appendingPathComponent("icon.svg")))
+    }
+
+    /// The same path must still resolve SF Symbol icons as symbols.
+    func testInlineShellActionKeepsSymbolIcon() async {
+        let tempDir = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        try? FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: tempDir) }
+
+        let factory = DefaultActionFactory()
+        let actionMeta = ExtensionActionMetadata(
+            title: "Shell With Symbol Icon",
+            icon: "leaf.fill",
+            type: "shell",
+            scriptCode: "echo $OPENCLIP_TEXT"
+        )
+        let manifest = ExtensionMetadata(identifier: "com.test.shellsymbol", name: "Shell Symbol Test", actions: [actionMeta], options: nil)
+
+        let action = await factory.createAction(metadata: actionMeta, manifest: manifest, directoryURL: tempDir, index: 0)
+        XCTAssertEqual(action?.icon, .symbol("leaf.fill"))
+    }
+
+    /// Text snippets take the same `CustomAction` path and lost file icons the same way.
+    func testTextSnippetActionKeepsPackagedFileIcon() async {
+        let tempDir = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        try? FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: tempDir) }
+        try? "png".write(to: tempDir.appendingPathComponent("icon.png"), atomically: true, encoding: .utf8)
+
+        let factory = DefaultActionFactory()
+        let actionMeta = ExtensionActionMetadata(
+            title: "Snippet With File Icon",
+            icon: "icon.png",
+            type: "textsnippet",
+            scriptCode: "> {text}"
+        )
+        let manifest = ExtensionMetadata(identifier: "com.test.snippeticon", name: "Snippet Icon Test", actions: [actionMeta], options: nil)
+
+        let action = await factory.createAction(metadata: actionMeta, manifest: manifest, directoryURL: tempDir, index: 0)
+        XCTAssertEqual(action?.icon, .local(tempDir.appendingPathComponent("icon.png")))
+    }
+
 }


### PR DESCRIPTION
### The bug

A manifest that declares a packaged icon file renders with **no icon at all** when the action is an inline `shell` (or `textsnippet`) action:

```jsonc
{
  "title": "Look up",
  "icon": "icon.svg",          // or icon.png
  "type": "shell",
  "scriptCode": "open -g \"myapp://...\""
}
```

The action works, it just has no icon in the popup bar, the ⌥⌘C action search palette, and the preferences list.

Every other kind is fine. `url`, `javascript`, `applescript` and script-file actions all take the parsed `ActionIcon` straight through, so only these two kinds are affected.

### Why

`DefaultActionFactory` builds inline `shell` and `textsnippet` actions as `CustomAction`, which stores its icon as a bare SF Symbol name:

```swift
public let iconName: String
public var icon: ActionIcon { .symbol(iconName) }
```

so the factory has to flatten the parsed icon with `iconSymbolName(icon)`, which turns `.local(<dir>/icon.svg)` into the string `"icon.svg"`. That comes back out as `.symbol("icon.svg")`, an SF Symbol name that does not exist, and `Image(systemName:)` renders nothing.

Verified against `main` (b30ba30) with a temporary diagnostic before writing the fix:

```
icon=leaf.fill inline=true  type=CustomAction icon=symbol(leaf.fill)  popup=symbol(leaf.fill)
icon=icon.svg  inline=true  type=CustomAction icon=symbol(icon.svg)   popup=symbol(icon.svg)     <- broken
icon=icon.svg  inline=false type=ScriptAction icon=local(icon.svg)    popup=local(icon.svg)      <- fine
```

### The fix

`CustomAction` now carries the parsed icon alongside `iconName` and prefers it, and the factory passes it at both call sites. The new property is left out of `CodingKeys`: actions created in the preferences UI only ever carry symbols, and manifest-backed actions are rebuilt from the manifest on load, so nothing persisted changes shape.

Symbol icons keep resolving exactly as before.

### Tests

Three cases added to `DefaultActionFactoryTests`: an inline shell action with a packaged `icon.svg`, the same path with an SF Symbol, and a text snippet with a packaged `icon.png`. All three fail on `main` and pass with the fix.

Full suite: 1065 passing. `PopupPanelTests.testEnterSearchWithButtonAnchorCentersSearchOnButton` fails, but it fails the same way on a clean checkout of `main` here, so it is not from this change.

### How I hit it

I am writing a Leafy extension (openclip-extensions#1). It needs `shell` rather than `url` because it opens a `leafy://` URL with `open -g`, and going through `NSWorkspace.open` would activate the target app and break the context read the extension depends on. Packaging an icon with it was how I found this.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Preserved custom icons for inline shell and text-snippet actions.
  - Improved icon handling so packaged file icons continue displaying correctly.
  - Ensured inline shell actions still resolve and display SF Symbol icons as expected.

- **Tests**
  - Added coverage for custom file icons and SF Symbol icon resolution across supported inline actions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->