### PR TITLE
fix(popup): trigger, placement and palette fixes + palette row shortcuts

### DIFF
--- a/OpenClip.xcodeproj/project.pbxproj
+++ b/OpenClip.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		00F0A9839339C1E8829D2A6D /* ExtensionTrustStateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7065CFC746479DF29BD1525F /* ExtensionTrustStateTests.swift */; };
+		00F99CE9A59716DFB7EF8A58 /* PaletteRowShortcuts.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4953987A3DEEA1E3E220311D /* PaletteRowShortcuts.swift */; };
 		016ACDECE2BC05DB5A380F65 /* CustomAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = A8DAACCC7C82CE7BB96D5F0D /* CustomAction.swift */; };
 		01A2A263D4D44A93E3409667 /* PopupGesturePolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 842374852607342FFC468020 /* PopupGesturePolicy.swift */; };
 		02AF81963047538ADE0363F5 /* RuleEngine.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57E8EC4414979D75CE50BA12 /* RuleEngine.swift */; };
@@ -481,6 +482,7 @@
 		46F35FE3A8EA5549603E53B4 /* PermissionRecoveryView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PermissionRecoveryView.swift; sourceTree = "<group>"; };
 		47E51843D196C894F4B98910 /* SettingsStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsStoreTests.swift; sourceTree = "<group>"; };
 		493FF0699565029ED4F5E07A /* ActionSearchKeywords.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActionSearchKeywords.swift; sourceTree = "<group>"; };
+		4953987A3DEEA1E3E220311D /* PaletteRowShortcuts.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaletteRowShortcuts.swift; sourceTree = "<group>"; };
 		49648502F040834635BBD8ED /* TextRetrieverTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextRetrieverTests.swift; sourceTree = "<group>"; };
 		4A4F5CBA9485E0EFFF56190C /* ActionIdentity.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActionIdentity.swift; sourceTree = "<group>"; };
 		4AB2405B7995F2DC5F45C474 /* AIToolsActionSubActionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AIToolsActionSubActionTests.swift; sourceTree = "<group>"; };
@@ -860,6 +862,7 @@
 				6129D3E6F351430FA57265B6 /* MacSelectionMonitor.swift */,
 				1B1ED5E66BD010DECBA31B69 /* MacTextRetriever.swift */,
 				755F137CBA2F4725D29AFEE9 /* OnceResume.swift */,
+				4953987A3DEEA1E3E220311D /* PaletteRowShortcuts.swift */,
 				07948B26DD33C5F462D65FAE /* PasteAvailabilityProbe.swift */,
 				E05FFC96E0F041907FD0B7E2 /* PasteboardCopyEngine.swift */,
 				0484D51261909B820AB7747B /* PasteboardSnapshot.swift */,
@@ -1779,6 +1782,7 @@
 				EE047575D4BBDD2F0D88A15C /* OpenClipModuleLoader.swift in Sources */,
 				6B6EB24072E6FDB50051E1F5 /* OpenClipSnippetParser+DefaultFactory.swift in Sources */,
 				E349DDD966C6A17A8B49DAAA /* OpenURLAction.swift in Sources */,
+				00F99CE9A59716DFB7EF8A58 /* PaletteRowShortcuts.swift in Sources */,
 				D3C8C3EA66019AC8C95C551C /* PasteAvailabilityProbe.swift in Sources */,
 				974C03DE6A31270A924FBC49 /* PasteboardCopyEngine.swift in Sources */,
 				A95E0584A13E2D121061BE66 /* PasteboardSnapshot.swift in Sources */,

--- a/OpenClip.xcodeproj/project.pbxproj
+++ b/OpenClip.xcodeproj/project.pbxproj
@@ -340,6 +340,7 @@
 		FAE8B480FE55D8C3ACC20A29 /* PreferencesView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F660BE562891C148ECA1E083 /* PreferencesView.swift */; };
 		FD4AAED6B52C78979F10227E /* LocalIconCacheTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E64E77AACA56DB3C341E5044 /* LocalIconCacheTests.swift */; };
 		FD6DE7EA993732CE74D6331B /* CustomActionDraftTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 29B9F196EE9D3082CCEA29E2 /* CustomActionDraftTests.swift */; };
+		FF37203790338215C05FC616 /* PaletteAIRunTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F70CEEE45FFA6B08C6C286E3 /* PaletteAIRunTests.swift */; };
 		FF465DCBAE09757549C4A37B /* OnboardingWindowController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8980C8AD7397B5E27CC86D63 /* OnboardingWindowController.swift */; };
 /* End PBXBuildFile section */
 
@@ -702,6 +703,7 @@
 		F4AD51BBA1C1F3ABEF4061B8 /* SelectionGatePolicyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SelectionGatePolicyTests.swift; sourceTree = "<group>"; };
 		F660BE562891C148ECA1E083 /* PreferencesView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PreferencesView.swift; sourceTree = "<group>"; };
 		F6D2EFD3816A5D71776023F4 /* SubBarStateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SubBarStateTests.swift; sourceTree = "<group>"; };
+		F70CEEE45FFA6B08C6C286E3 /* PaletteAIRunTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaletteAIRunTests.swift; sourceTree = "<group>"; };
 		F83E744E54478C7A60BEE112 /* AppRulesTab.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppRulesTab.swift; sourceTree = "<group>"; };
 		FADAC40972B146605441712F /* ExtensionUpdatePlannerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExtensionUpdatePlannerTests.swift; sourceTree = "<group>"; };
 		FB8E693598E421C204E409DD /* WordCompletionProviding.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WordCompletionProviding.swift; sourceTree = "<group>"; };
@@ -1296,6 +1298,7 @@
 				8CB9BA0577EDDA7E174755C2 /* OpenClipJSHostTests.swift */,
 				1E5F5E01EF86BB0AFEFEE150 /* OpenClipModuleLoaderTests.swift */,
 				3359F30EB7FC15DFC02A4D9B /* OpenClipSnippetParserTests.swift */,
+				F70CEEE45FFA6B08C6C286E3 /* PaletteAIRunTests.swift */,
 				D1FD683F171A6F049676827E /* PaletteShortcutTests.swift */,
 				201CA35D10C8474B786349EE /* PasteAvailabilityProbeTests.swift */,
 				3F2731480550C2912B357B1C /* PasteAvailabilityTests.swift */,
@@ -1553,6 +1556,7 @@
 				ED408F095ADAD70E95B15D39 /* OpenClipJSHostTests.swift in Sources */,
 				72D406208C35164983A1EC13 /* OpenClipModuleLoaderTests.swift in Sources */,
 				CB0F2118E3D0E7195D500A5D /* OpenClipSnippetParserTests.swift in Sources */,
+				FF37203790338215C05FC616 /* PaletteAIRunTests.swift in Sources */,
 				4F586CC0ED7A445DBA7C8C7D /* PaletteShortcutTests.swift in Sources */,
 				7A6B2CBBA01D8F8A4E89D8DC /* PasteAvailabilityProbeTests.swift in Sources */,
 				184207DF1E09CEFFCC848F2B /* PasteAvailabilityTests.swift in Sources */,

--- a/OpenClip.xcodeproj/project.pbxproj
+++ b/OpenClip.xcodeproj/project.pbxproj
@@ -102,6 +102,7 @@
 		4E94CAC5D8C6131D7ABEC9FC /* MemorySettingsStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = DDF25B7CA70822AE323518F8 /* MemorySettingsStore.swift */; };
 		4ED90C4E3724281438D25FEF /* ConfigurationRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = C29A7771E75FA4091D2066E2 /* ConfigurationRequest.swift */; };
 		4F04EDDEE2B8E5135E1E9B5B /* ExtensionOption.swift in Sources */ = {isa = PBXBuildFile; fileRef = B7534A2D6FD5368B237CB5C5 /* ExtensionOption.swift */; };
+		4F586CC0ED7A445DBA7C8C7D /* PaletteShortcutTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1FD683F171A6F049676827E /* PaletteShortcutTests.swift */; };
 		501DCB56294AC12CBF0A1672 /* ActionRegistryGroupTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A84739BEC83F5FF50303C867 /* ActionRegistryGroupTests.swift */; };
 		502E0EAB60D92A89C1F8957F /* ResultCardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C14D435609D5583A39FA164 /* ResultCardView.swift */; };
 		505BCF709F1851C81A35DD64 /* ActionCoordinatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7BBCBD7E4F5F0D1015061E8D /* ActionCoordinatorTests.swift */; };
@@ -652,6 +653,7 @@
 		CEE41531ACE74639DE1C5CB4 /* RemoteExtensionInstaller.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteExtensionInstaller.swift; sourceTree = "<group>"; };
 		D0F292704F06603C30BB2C77 /* DebugLogCommandTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DebugLogCommandTests.swift; sourceTree = "<group>"; };
 		D17261567A410E583636E381 /* PreferenceTabTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PreferenceTabTests.swift; sourceTree = "<group>"; };
+		D1FD683F171A6F049676827E /* PaletteShortcutTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaletteShortcutTests.swift; sourceTree = "<group>"; };
 		D30E9B1A09FFEE44BC1A5793 /* AppPickerSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppPickerSheet.swift; sourceTree = "<group>"; };
 		D33B3004A90DD3BE1E64DD30 /* ExtensionManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExtensionManagerTests.swift; sourceTree = "<group>"; };
 		D472E48BB7CBCC599EE48E92 /* TopLevelActionResolverTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TopLevelActionResolverTests.swift; sourceTree = "<group>"; };
@@ -1294,6 +1296,7 @@
 				8CB9BA0577EDDA7E174755C2 /* OpenClipJSHostTests.swift */,
 				1E5F5E01EF86BB0AFEFEE150 /* OpenClipModuleLoaderTests.swift */,
 				3359F30EB7FC15DFC02A4D9B /* OpenClipSnippetParserTests.swift */,
+				D1FD683F171A6F049676827E /* PaletteShortcutTests.swift */,
 				201CA35D10C8474B786349EE /* PasteAvailabilityProbeTests.swift */,
 				3F2731480550C2912B357B1C /* PasteAvailabilityTests.swift */,
 				40068DD0346E93060C2DE55A /* PasteboardCopyEngineTests.swift */,
@@ -1550,6 +1553,7 @@
 				ED408F095ADAD70E95B15D39 /* OpenClipJSHostTests.swift in Sources */,
 				72D406208C35164983A1EC13 /* OpenClipModuleLoaderTests.swift in Sources */,
 				CB0F2118E3D0E7195D500A5D /* OpenClipSnippetParserTests.swift in Sources */,
+				4F586CC0ED7A445DBA7C8C7D /* PaletteShortcutTests.swift in Sources */,
 				7A6B2CBBA01D8F8A4E89D8DC /* PasteAvailabilityProbeTests.swift in Sources */,
 				184207DF1E09CEFFCC848F2B /* PasteAvailabilityTests.swift in Sources */,
 				8CABBF132C8D96FB5362D7E1 /* PasteboardCopyEngineTests.swift in Sources */,

--- a/Sources/Core/Actions/ActionRegistry.swift
+++ b/Sources/Core/Actions/ActionRegistry.swift
@@ -230,23 +230,62 @@ public final class ActionRegistry: ObservableObject, Sendable {
     }
     
     /// Context gating shared by the bar and the search palette: can this action actually perform
-    /// against the current selection/app? Settings-disable state is deliberately out of scope here
-    /// (the bar applies it separately; the palette ignores it). Clipboard-fallback actions that
-    /// require a live selection and formatting actions under a deny-formatting app policy drop.
-    /// AI presets are treated as performable (a palette selection routes to the AI card regardless
-    /// of the enable toggle; the bar excludes presets by policy, not by ability).
+    /// against the current selection/app? Settings-disable state is applied separately (see
+    /// `settingsHiddenIDs`). Clipboard-fallback actions that require a live selection and
+    /// formatting actions under a deny-formatting app policy drop. An AI preset answers through
+    /// its own `isEnabled`, which reads the preset's toggle in AI settings, so a preset switched
+    /// off there is not offered anywhere.
     private func canPerform(_ action: any Action, in context: ActionContext) -> Bool {
-        // AI presets are always performable from the palette: a selection routes to the AI
-        // card regardless of the preset's enable toggle, so they stay visible.
-        if ActionIdentity.isAIPreset(action) {
-            return true
-        }
         // Clipboard fallback is not a live selection: Copy/Cut (and any future action that
         // reads or mutates the real selection) must not act on text that was never selected.
         if context.selection.isClipboardFallback && action.chrome.requiresLiveSelection {
             return false
         }
         return action.isEnabled(for: context)
+    }
+
+    /// Whether the user has switched this action off in settings — per action, or through its
+    /// whole extension package. Shared by the bar and the palette so "disabled" means the same
+    /// thing on both surfaces.
+    private func isDisabledInSettings(_ action: any Action, disabledIDs: Set<String>, disabledPackages: Set<String>) -> Bool {
+        if disabledIDs.contains(action.id) { return true }
+        if let packageID = ActionIdentity.extensionPackageID(of: action), disabledPackages.contains(packageID) {
+            return true
+        }
+        return false
+    }
+
+    /// Group rows whose members must be hidden with them: a disabled group never leaks its
+    /// sub-actions, on either surface. `isRowVisible` decides whether a group row itself survives
+    /// (the bar also requires it to be performable in context).
+    private func hiddenGroupIDs(isRowVisible: (any Action) -> Bool) -> Set<String> {
+        Set(
+            actions
+                .filter { $0.chrome.popupBehavior == .showSubActions }
+                .filter { !isRowVisible($0) }
+                .map(\.id)
+        )
+    }
+
+    /// True when the action belongs to a group in `hiddenGroupIDs` — either by id prefix (built-in
+    /// and extension groups) or by explicit membership (custom groups keep canonical ids).
+    private func belongsToHiddenGroup(_ action: any Action, hiddenGroupIDs: Set<String>, customGroupMemberToGroupID: [String: String]) -> Bool {
+        if hiddenGroupIDs.contains(where: { action.id.hasPrefix($0 + ".") }) { return true }
+        if let owningGroupID = customGroupMemberToGroupID[action.id], hiddenGroupIDs.contains(owningGroupID) {
+            return true
+        }
+        return false
+    }
+
+    /// Custom-group membership map (member id → group id).
+    private func customGroupMembership() -> [String: String] {
+        var map: [String: String] = [:]
+        for def in groupDefs {
+            for memberID in def.memberActionIDs {
+                map[memberID] = def.id
+            }
+        }
+        return map
     }
 
     public func availableActions(for context: ActionContext) -> [any Action] {
@@ -264,69 +303,50 @@ public final class ActionRegistry: ObservableObject, Sendable {
                 return false
             }
             guard canPerform(action, in: context) else { return false }
-            if disabledIDs.contains(action.id) {
-                return false
-            }
-            // Whole-package disable: an action whose chrome source names a disabled package
-            // is hidden before per-action visibility runs.
-            if let packageID = ActionIdentity.extensionPackageID(of: action), disabledPackages.contains(packageID) {
-                return false
-            }
-            return true
+            // Per-action and whole-package disable, before per-action visibility runs.
+            return !isDisabledInSettings(action, disabledIDs: disabledIDs, disabledPackages: disabledPackages)
         }
 
         // Group sub-actions are only reachable through their group's sub-menu. A group whose
         // row is disabled (or otherwise not visible) hides its sub-actions entirely, so a
         // disabled group never leaks its sub-actions into the bar.
-        let groupRowIDs = actions
-            .filter { $0.chrome.popupBehavior == .showSubActions }
-            .map { $0.id }
-        let enabledGroupIDs = Set(
-            actions
-                .filter { $0.chrome.popupBehavior == .showSubActions }
-                .filter { passes($0) }
-                .map { $0.id }
-        )
-
-        // Custom groups: hide members of a disabled custom group.
-        // This parallels the prefix-based hiding above but uses the explicit
-        // memberActionIDs list since custom group members keep canonical IDs.
-        let customGroupMemberToGroupID: [String: String] = {
-            var map: [String: String] = [:]
-            for def in groupDefs {
-                for memberID in def.memberActionIDs {
-                    map[memberID] = def.id
-                }
-            }
-            return map
-        }()
+        let hiddenGroups = hiddenGroupIDs(isRowVisible: passes)
+        let customGroupMemberToGroupID = customGroupMembership()
 
         return actions.filter { action in
             guard passes(action) else { return false }
-            if let groupID = groupRowIDs.first(where: { action.id.hasPrefix($0 + ".") }),
-               !enabledGroupIDs.contains(groupID) {
-                return false
-            }
-            if let owningGroupID = customGroupMemberToGroupID[action.id],
-               !enabledGroupIDs.contains(owningGroupID) {
-                return false
-            }
-            return true
+            return !belongsToHiddenGroup(action, hiddenGroupIDs: hiddenGroups, customGroupMemberToGroupID: customGroupMemberToGroupID)
         }
     }
 
-    /// The registered catalog for the action-search palette, filtered to actions that can
-    /// actually perform given the current context. Settings-disabled actions (`.disabledActionIDs`,
-    /// `.disabledPackages`) stay visible — the palette is a full-catalog surface and a disabled row
-    /// can be re-enabled — but actions that cannot run against this context are dropped:
+    /// The registered catalog for the action-search palette: what the user can actually run right
+    /// now. An action switched off in settings never appears — per action, through its whole
+    /// extension package, through a disabled group (whose members go with it), or, for an AI
+    /// preset, through its toggle in AI settings — so the palette offers the same set the bar
+    /// does, just flat and unpaginated. Actions that cannot run against this context drop too:
     /// `isEnabled(for:)` failures (no selection, regex/app/expression gates), clipboard-fallback
     /// actions that require a live selection, and formatting actions under a deny-formatting app
     /// policy. Sub-actions appear individually, flat; group rows remain (their sub-actions are
     /// reachable directly from the palette). `chrome.launchesAI` launchers and the inline
     /// completion pseudo-action are always excluded.
     public func searchCatalog(for context: ActionContext) -> [any Action] {
-        actions.filter { action in
+        let disabledIDs = settingsStore.get(.disabledActionIDs)
+        let disabledPackages = settingsStore.get(.disabledPackages)
+        // A group row hides its members here on settings state alone: the palette lists the
+        // members, not the row, so "the group is off" has to reach them.
+        let hiddenGroups = hiddenGroupIDs { row in
+            !isDisabledInSettings(row, disabledIDs: disabledIDs, disabledPackages: disabledPackages)
+        }
+        let customGroupMemberToGroupID = customGroupMembership()
+
+        return actions.filter { action in
             if action.chrome.launchesAI || ActionIdentity.isCompletionPseudoAction(action) || action is GatedExtensionAction {
+                return false
+            }
+            if isDisabledInSettings(action, disabledIDs: disabledIDs, disabledPackages: disabledPackages) {
+                return false
+            }
+            if belongsToHiddenGroup(action, hiddenGroupIDs: hiddenGroups, customGroupMemberToGroupID: customGroupMemberToGroupID) {
                 return false
             }
             return canPerform(action, in: context)

--- a/Sources/Core/Actions/ActionRegistry.swift
+++ b/Sources/Core/Actions/ActionRegistry.swift
@@ -182,12 +182,18 @@ public final class ActionRegistry: ObservableObject, Sendable {
         }
         
         newActions.insert(contentsOf: movingActions, at: dest)
-        actions = newActions
-        
-        let newOrder = actions
+
+        let newOrder = newActions
             .filter { !ActionIdentity.isAIPreset($0) && !($0 is CustomGroupAction) }
             .map { $0.id }
         settingsStore.set(.actionOrder, value: newOrder)
+
+        // Re-derive rather than publishing the hand-moved array: a drag moves only the rows the
+        // user grabbed, so anything whose placement is *derived* — a sub-action following its
+        // parent row (AI presets under AI Tools), a group's members trailing its header — would
+        // keep the position it had before the drag until the next registration re-sorted the
+        // catalog. That is why reordering AI Tools appeared to need a restart to take effect.
+        sortActions()
     }
     
     public func unregister(actionID: String) {

--- a/Sources/Core/Actions/ActionRegistry.swift
+++ b/Sources/Core/Actions/ActionRegistry.swift
@@ -41,6 +41,25 @@ public final class ActionRegistry: ObservableObject, Sendable {
         sortActions()
     }
     
+    /// Maps each sub-action to the row that provides it (`SubActionProviding`: the AI Tools
+    /// launcher, group rows), so `sortActions` can place children with their parent. A child the
+    /// user has ordered explicitly is left alone — an `action.order` entry always outranks
+    /// inheritance — and the first provider claiming a child wins, so membership stays
+    /// single-valued. One level only: a child never re-parents through another child.
+    private func subActionParents(explicitlyOrderedIDs: [String: Int]) -> [String: String] {
+        let resolver = SubActionResolver()
+        var parents: [String: String] = [:]
+        for parent in registeredActions where parent is any SubActionProviding {
+            for child in resolver.subActions(of: parent, in: registeredActions) {
+                guard child.id != parent.id,
+                      explicitlyOrderedIDs[child.id] == nil,
+                      parents[child.id] == nil else { continue }
+                parents[child.id] = parent.id
+            }
+        }
+        return parents
+    }
+
     private func sortActions() {
         let order = settingsStore.get(.actionOrder)
         let orderIndexMap: [String: Int] = Dictionary(
@@ -48,24 +67,45 @@ public final class ActionRegistry: ObservableObject, Sendable {
             uniquingKeysWith: { first, _ in first }
         )
 
+        // A row that opens into sub-actions (the AI Tools launcher, group rows) owns where its
+        // children sit: flat surfaces — the search palette above all — list the children instead
+        // of the parent row, so a child that inherits nothing lands at the very end of the
+        // catalog no matter where the user dragged the parent. AI presets are the visible case:
+        // they carry chrome source `.ai`, which is neither user-ordered nor builtin, so "AI Tools
+        // first" in Preferences still left every AI command last in the palette.
+        let parentIDByChildID = subActionParents(explicitlyOrderedIDs: orderIndexMap)
+        let actionsByID = Dictionary(registeredActions.map { ($0.id, $0) }, uniquingKeysWith: { first, _ in first })
+
         // Tier classification:
         // Tier 0: Explicitly ordered by user in `action.order` (sorted by rank in orderIndexMap)
         // Tier 1: Un-ordered built-in actions (sorted stably by insertion order)
         // Tier 2: Un-ordered extensions/other actions (sorted stably by insertion order)
-        let ranked: [(action: any Action, tier: Int, rank: Int, stableOffset: Int)] = registeredActions.enumerated().map { offset, action in
+        // A child adopts its parent's whole classification and sorts immediately after it
+        // (`subRank` 1), so it follows the parent wherever the parent lands.
+        func placement(of action: any Action) -> (tier: Int, rank: Int) {
             if let index = orderIndexMap[action.id] {
-                return (action, 0, index, offset)
+                return (0, index)
             } else if ActionIdentity.isBuiltin(action) {
-                return (action, 1, 0, offset)
+                return (1, 0)
             } else {
-                return (action, 2, 0, offset)
+                return (2, 0)
             }
+        }
+
+        let ranked: [(action: any Action, tier: Int, rank: Int, subRank: Int, stableOffset: Int)] = registeredActions.enumerated().map { offset, action in
+            if let parentID = parentIDByChildID[action.id], let parent = actionsByID[parentID] {
+                let inherited = placement(of: parent)
+                return (action, inherited.tier, inherited.rank, 1, offset)
+            }
+            let own = placement(of: action)
+            return (action, own.tier, own.rank, 0, offset)
         }
 
         let sortedBase = ranked
             .sorted { lhs, rhs in
                 if lhs.tier != rhs.tier { return lhs.tier < rhs.tier }
                 if lhs.rank != rhs.rank { return lhs.rank < rhs.rank }
+                if lhs.subRank != rhs.subRank { return lhs.subRank < rhs.subRank }
                 return lhs.stableOffset < rhs.stableOffset
             }
             .map(\.action)

--- a/Sources/OpenClip/AI/AIAction.swift
+++ b/Sources/OpenClip/AI/AIAction.swift
@@ -47,9 +47,13 @@ public struct AIAction: Action {
         self.title = title
     }
 
+    /// Off when AI is switched off wholesale, or when this preset's own toggle in AI settings is
+    /// off — the palette and every other surface gate on this, so a disabled preset is offered
+    /// nowhere.
     @MainActor
     public func isEnabled(for context: ActionContext) -> Bool {
-        preset()?.isEnabled ?? false
+        guard AIServiceManager.shared.isAIEnabled else { return false }
+        return preset()?.isEnabled ?? false
     }
 
     /// Defensive fallback for any non-palette caller (the palette routes `.ai` through the AI

--- a/Sources/OpenClip/AI/AIActionSync.swift
+++ b/Sources/OpenClip/AI/AIActionSync.swift
@@ -5,8 +5,9 @@
 // `AIAction`s, so every preset shows up as a searchable entry in the action-search palette and
 // as its own row in Preferences → Actions (while staying out of the popup bar — the reorderable
 // `builtin.aiTools` action is the bar's AI entry point). Also registers that AI Tools launcher.
-// Reconciles the registered set whenever the preset list
-// changes; the title snapshot on `AIAction` is refreshed by re-registering on any content change.
+// Reconciles the registered set whenever the preset list changes; the title snapshot on
+// `AIAction` is refreshed by re-registering on any content change, and a changed *order* is
+// re-registered from scratch so the catalog (palette, AI sub-bar) follows the user's ordering.
 import Foundation
 import Core
 
@@ -15,7 +16,9 @@ public final class AIActionSync {
     public static let shared = AIActionSync()
 
     private let coordinator = ActionCoordinator.shared
-    private var registeredIDs: Set<String> = []
+    /// The preset ids currently registered, in the order they were registered. Order matters:
+    /// the catalog position of the AI actions (and so the palette / AI sub-bar order) follows it.
+    private var registeredOrder: [String] = []
     private var lastFingerprint: [String] = []
     private var observer: NSObjectProtocol?
 
@@ -40,15 +43,28 @@ public final class AIActionSync {
         let fingerprint = presets.map { "\($0.id)|\($0.title)|\($0.prompt)|\($0.isEnabled)" }
         guard fingerprint != lastFingerprint else { return }
 
-        let currentIDs = Set(presets.map { AIAction(presetID: $0.id, title: $0.title).id })
-        for id in registeredIDs.subtracting(currentIDs) {
-            coordinator.unregister(actionID: id)
-        }
-        for preset in presets {
-            coordinator.register(action: AIAction(presetID: preset.id, title: preset.title))
+        let currentOrder = presets.map { AIAction(presetID: $0.id, title: $0.title).id }
+
+        if currentOrder != registeredOrder {
+            // The user reordered (or added/removed) presets. `register(action:)` replaces an
+            // existing id *where it already sits*, so updating in place would keep the old catalog
+            // positions and a reorder in Preferences would never reach the palette or the AI
+            // sub-bar. Drop the whole set and re-register in list order instead.
+            for id in registeredOrder {
+                coordinator.unregister(actionID: id)
+            }
+            for preset in presets {
+                coordinator.register(action: AIAction(presetID: preset.id, title: preset.title))
+            }
+        } else {
+            // Same presets in the same order — only titles/prompts/enabled state changed, so an
+            // in-place refresh is enough (and leaves the catalog undisturbed).
+            for preset in presets {
+                coordinator.register(action: AIAction(presetID: preset.id, title: preset.title))
+            }
         }
 
-        registeredIDs = currentIDs
+        registeredOrder = currentOrder
         lastFingerprint = fingerprint
     }
 }

--- a/Sources/OpenClip/AI/AIServiceManager.swift
+++ b/Sources/OpenClip/AI/AIServiceManager.swift
@@ -113,25 +113,26 @@ public final class AIServiceManager: ObservableObject {
         return list.isEmpty ? [Self.defaultPresets[0]] : list
     }
 
-    /// Reorders the preset list, moving `id` into the slot `destinationIndex` currently holds
-    /// (drop-on-row semantics: the dragged row takes the target's place and the rest shift).
-    /// The list order *is* the order everywhere — the AI sub-bar, the search palette, and the
-    /// Preferences list all read it — so persisting the new array is the whole feature.
-    public func movePreset(id: String, to destinationIndex: Int) {
-        let reordered = Self.reordering(presets, moving: id, to: destinationIndex)
+    /// Reorders the preset list, moving `id` into `gapIndex` — the gap the insertion bar was
+    /// drawn in, counted between rows (0 = above the first, `count` = below the last), matching
+    /// the drop semantics of the Actions outline. The list order *is* the order everywhere — the
+    /// AI sub-bar, the search palette, and the Preferences list all read it — so persisting the
+    /// new array is the whole feature.
+    public func movePreset(id: String, toGap gapIndex: Int) {
+        let reordered = Self.reordering(presets, moving: id, toGap: gapIndex)
         guard reordered.map(\.id) != presets.map(\.id) else { return }
         presets = reordered
     }
 
     /// Pure reorder used by `movePreset`, split out so the ordering rules are testable without the
-    /// `@AppStorage`-backed singleton. An unknown id or an out-of-range destination leaves the
-    /// list untouched (the destination is clamped, never trapped).
-    public static func reordering(_ presets: [AIActionPreset], moving id: String, to destinationIndex: Int) -> [AIActionPreset] {
+    /// `@AppStorage`-backed singleton. Gap indices are pre-removal (SwiftUI's `move(fromOffsets:
+    /// toOffset:)` convention), so dropping into the gap directly below a row is a no-op rather
+    /// than an off-by-one. An unknown id or an out-of-range gap leaves the list intact — the gap
+    /// is clamped, never trapped on.
+    public static func reordering(_ presets: [AIActionPreset], moving id: String, toGap gapIndex: Int) -> [AIActionPreset] {
         guard let sourceIndex = presets.firstIndex(where: { $0.id == id }) else { return presets }
         var list = presets
-        let moved = list.remove(at: sourceIndex)
-        let clamped = max(0, min(destinationIndex, list.count))
-        list.insert(moved, at: clamped)
+        list.move(fromOffsets: IndexSet(integer: sourceIndex), toOffset: max(0, min(gapIndex, presets.count)))
         return list
     }
 

--- a/Sources/OpenClip/AI/AIServiceManager.swift
+++ b/Sources/OpenClip/AI/AIServiceManager.swift
@@ -113,6 +113,28 @@ public final class AIServiceManager: ObservableObject {
         return list.isEmpty ? [Self.defaultPresets[0]] : list
     }
 
+    /// Reorders the preset list, moving `id` into the slot `destinationIndex` currently holds
+    /// (drop-on-row semantics: the dragged row takes the target's place and the rest shift).
+    /// The list order *is* the order everywhere — the AI sub-bar, the search palette, and the
+    /// Preferences list all read it — so persisting the new array is the whole feature.
+    public func movePreset(id: String, to destinationIndex: Int) {
+        let reordered = Self.reordering(presets, moving: id, to: destinationIndex)
+        guard reordered.map(\.id) != presets.map(\.id) else { return }
+        presets = reordered
+    }
+
+    /// Pure reorder used by `movePreset`, split out so the ordering rules are testable without the
+    /// `@AppStorage`-backed singleton. An unknown id or an out-of-range destination leaves the
+    /// list untouched (the destination is clamped, never trapped).
+    public static func reordering(_ presets: [AIActionPreset], moving id: String, to destinationIndex: Int) -> [AIActionPreset] {
+        guard let sourceIndex = presets.firstIndex(where: { $0.id == id }) else { return presets }
+        var list = presets
+        let moved = list.remove(at: sourceIndex)
+        let clamped = max(0, min(destinationIndex, list.count))
+        list.insert(moved, at: clamped)
+        return list
+    }
+
     public func updatePreset(_ updated: AIActionPreset) {
         var current = presets
         if let idx = current.firstIndex(where: { $0.id == updated.id }) {

--- a/Sources/OpenClip/Platform/HotkeyManager.swift
+++ b/Sources/OpenClip/Platform/HotkeyManager.swift
@@ -16,12 +16,16 @@ public final class HotkeyManager {
     public static let shared = HotkeyManager()
     private var lastFallbackClipboard: (changeCount: Int, text: String)?
     
+    /// Gating for the ⌥⌘C trigger. Deliberately does **not** consult `SettingKey.isAppEnabled`:
+    /// that setting is "Appear Automatically" (both in Preferences and the menu bar), so it owns
+    /// the selection monitor's automatic popup, not the explicit shortcut — turning automatic
+    /// appearance off is the global form of the per-app `hotkeyOnly` rule, which has always kept
+    /// the hotkey alive. The real kill switches still apply here: Pause OpenClip
+    /// (`pauseUntilTimestamp`), the app-exclusion list, and a per-app `disabled` rule.
     internal static func triggerAllowed(
-        isAppEnabled: Bool,
         frontmost: NSRunningApplication?,
         settingsStore: SettingsStore = DefaultSettingsStore.shared
     ) -> Bool {
-        guard isAppEnabled else { return false }
         if settingsStore.get(.pauseUntilTimestamp) > Date().timeIntervalSince1970 {
             return false
         }
@@ -51,10 +55,8 @@ public final class HotkeyManager {
                 // No `.current` fallback: with no identifiable target app there is nothing to
                 // retrieve from, and targeting OpenClip itself is explicitly forbidden.
                 let frontmostApp = NSWorkspace.shared.frontmostApplication
-                guard Self.triggerAllowed(
-                    isAppEnabled: DefaultSettingsStore.shared.get(.isAppEnabled),
-                    frontmost: frontmostApp
-                ), let frontApp = frontmostApp else { return }
+                guard Self.triggerAllowed(frontmost: frontmostApp),
+                      let frontApp = frontmostApp else { return }
                 let policy = RuleEngine.shared.resolvePolicies(for: frontApp.bundleIdentifier ?? "")
                 let appIdentity = AppIdentity(frontApp)
 

--- a/Sources/OpenClip/Platform/HotkeyManager.swift
+++ b/Sources/OpenClip/Platform/HotkeyManager.swift
@@ -39,6 +39,12 @@ public final class HotkeyManager {
     }
 
     public func setup(popupController: PopupWindowController) {
+        // ⌘1…⌘9 pick a palette row. Parked until a palette opens — see PaletteRowShortcuts for why
+        // they must be global hot keys rather than key equivalents on the panel.
+        PaletteRowShortcuts.install { [weak popupController] row in
+            popupController?.runPaletteRow(row) ?? false
+        }
+
         KeyboardShortcuts.onKeyUp(for: .togglePopup) { [weak popupController] in
             Task { @MainActor in
                 // Popup already visible: if in search mode, the hotkey dismisses the popup (toggle off);

--- a/Sources/OpenClip/Platform/MacSelectionMonitor.swift
+++ b/Sources/OpenClip/Platform/MacSelectionMonitor.swift
@@ -48,7 +48,16 @@ internal final class MacSelectionMonitor: SelectionMonitoring {
     
     /// Key codes (ANSI/QWERTY) that signal a selection gesture worth retrieving.
     private static let selectAllKeyCode: UInt16 = 0x00      // kVK_ANSI_A
-    private static let arrowKeyCodes: Set<UInt16> = [0x7B, 0x7C, 0x7D, 0x7E]  // left/right/down/up
+    /// ⌘L: "select the location" — the address bar in browsers, the current line in editors.
+    /// Like ⌘A it selects a whole container, so it is gated the same way downstream.
+    private static let selectLocationKeyCode: UInt16 = 0x25 // kVK_ANSI_L
+    /// Keys that extend a selection when Shift is held: the four arrows plus the page/line jumps,
+    /// which are the same gesture over a bigger stride (⇧⌥→ and ⇧End both extend a selection).
+    private static let extendKeyCodes: Set<UInt16> = [
+        0x7B, 0x7C, 0x7D, 0x7E,   // left / right / down / up
+        0x73, 0x77,               // home / end
+        0x74, 0x79                // page up / page down
+    ]
 
     /// Squared drift limits for the hold trigger (points²). A drag beyond `holdDragDisarmSquared`
     /// (5 px) disarms the pending timer outright; the timer fires only while the press is parked
@@ -139,33 +148,41 @@ internal final class MacSelectionMonitor: SelectionMonitoring {
     
     // MARK: - Trigger detection
     
-    /// True when a key event is a selection gesture OpenClip should retrieve: ⌘A (select all) or an
-    /// arrow key with Shift held (⇧/⌥⇧/⌘⇧+arrow extend/collapse selection). Only the select-all
-    /// gesture requires the exact `.command` set; arrow gestures fire whenever `.shift` is held with
-    /// optional `.option`/`.command`, so plain typing and unrelated shortcuts still don't match.
+    /// True when a key event is a selection gesture OpenClip should retrieve: ⌘A (select all),
+    /// ⌘L (select the address bar / current line), or an extend key with Shift held (⇧/⌥⇧/⌘⇧ +
+    /// arrow, Home, End, Page Up, Page Down). The whole-container gestures require the exact
+    /// `.command` set; extend gestures fire whenever `.shift` is held with optional
+    /// `.option`/`.command`, so plain typing and unrelated shortcuts still don't match.
     /// Persistent/non-gesture flags (`.capsLock`
     /// is held in every keyDown's modifierFlags while caps lock is engaged; `.function`, `.numericPad`,
-    /// `.help` are device/hardware bits) are stripped before comparing.
+    /// `.help` are device/hardware bits) are stripped before comparing — Home/End/Page keys carry
+    /// `.function`, so that stripping is what lets them match at all.
     internal static func isSelectionTrigger(keyCode: UInt16, flags: NSEvent.ModifierFlags) -> Bool {
-        let gestureFlags = flags
-            .intersection(.deviceIndependentFlagsMask)
-            .subtracting([.capsLock, .function, .numericPad, .help])
+        let gestureFlags = normalizedGestureFlags(flags)
         if gestureFlags == .command {
-            return keyCode == selectAllKeyCode
+            return keyCode == selectAllKeyCode || keyCode == selectLocationKeyCode
         }
         if gestureFlags.contains(.shift) && gestureFlags.isSubset(of: [.shift, .option, .command]) {
-            return arrowKeyCodes.contains(keyCode)
+            return extendKeyCodes.contains(keyCode)
         }
         return false
     }
 
-    /// True only for the exact ⌘A (select-all) gesture, using the same flag normalization as
-    /// `isSelectionTrigger`.
-    private static func isSelectAllKey(keyCode: UInt16, flags: NSEvent.ModifierFlags) -> Bool {
-        let gestureFlags = flags
+    /// True for the whole-container select gestures — the exact ⌘A (select all) and ⌘L (select the
+    /// location / line). Both hand the retrieval gate the same "this selects everything in the
+    /// focused container" signal, so a row selection in Finder/Mail is refused while text is not.
+    internal static func isSelectAllKey(keyCode: UInt16, flags: NSEvent.ModifierFlags) -> Bool {
+        let gestureFlags = normalizedGestureFlags(flags)
+        guard gestureFlags == .command else { return false }
+        return keyCode == selectAllKeyCode || keyCode == selectLocationKeyCode
+    }
+
+    /// Strips the flags that are never part of a gesture: `.capsLock` rides along in every keyDown
+    /// while caps lock is engaged, and `.function`/`.numericPad`/`.help` are device bits.
+    private static func normalizedGestureFlags(_ flags: NSEvent.ModifierFlags) -> NSEvent.ModifierFlags {
+        flags
             .intersection(.deviceIndependentFlagsMask)
             .subtracting([.capsLock, .function, .numericPad, .help])
-        return gestureFlags == .command && keyCode == selectAllKeyCode
     }
     
     // MARK: - Event handling
@@ -355,8 +372,8 @@ internal final class MacSelectionMonitor: SelectionMonitoring {
     
     /// Keyboard selection gesture: retrieve under the frontmost app resolved *after* the debounce
     /// (a ⌘A/⇧+arrow in one app followed by a switch during the debounce window must target the
-    /// now-frontmost app). `isSelectAll` marks a ⌘A select-all, which copy-based retrieval modes
-    /// reject unless the focused element is text-bearing (row selection in Finder/Mail/table views).
+    /// now-frontmost app). `isSelectAll` marks a whole-container gesture (⌘A / ⌘L), which retrieval
+    /// refuses on a row/list container (row selection in Finder/Mail/table views).
     internal func handleSelectionTrigger(isSelectAll: Bool) {
         debounceTask?.cancel()
         guard settingsStore.get(.pauseUntilTimestamp) <= Date().timeIntervalSince1970 else { return }

--- a/Sources/OpenClip/Platform/PaletteRowShortcuts.swift
+++ b/Sources/OpenClip/Platform/PaletteRowShortcuts.swift
@@ -1,0 +1,77 @@
+// PaletteRowShortcuts.swift
+// OpenClip
+//
+// ⌘1…⌘9 for the search palette's first nine rows, registered as *global* hot keys for exactly as
+// long as the palette is on screen.
+//
+// They have to be global. macOS routes a command-modified key to the **active application**, and
+// the popup is a non-activating panel of an app that is deliberately never active: plain keys
+// reach the key panel (typing in the palette works), but a ⌘-digit is delivered to whatever app
+// the user is working in — it never enters OpenClip's event stream at all, so neither an event
+// monitor nor `performKeyEquivalent` on the panel can see it, and the source app rings the bell
+// for a shortcut it does not recognize. Raycast and Chrome get these keys because they *are* the
+// active app; OpenClip's whole point is not to steal that.
+//
+// So the same Carbon hot-key mechanism the ⌥⌘C trigger already uses (via KeyboardShortcuts) takes
+// ⌘1…⌘9 system-wide while the palette is open, and hands them back the moment it closes. That
+// also consumes them, so the source app never sees the keystroke.
+import AppKit
+import Core
+import KeyboardShortcuts
+
+extension KeyboardShortcuts.Name {
+    static let paletteRow1 = Self("paletteRow1", default: .init(.one, modifiers: [.command]))
+    static let paletteRow2 = Self("paletteRow2", default: .init(.two, modifiers: [.command]))
+    static let paletteRow3 = Self("paletteRow3", default: .init(.three, modifiers: [.command]))
+    static let paletteRow4 = Self("paletteRow4", default: .init(.four, modifiers: [.command]))
+    static let paletteRow5 = Self("paletteRow5", default: .init(.five, modifiers: [.command]))
+    static let paletteRow6 = Self("paletteRow6", default: .init(.six, modifiers: [.command]))
+    static let paletteRow7 = Self("paletteRow7", default: .init(.seven, modifiers: [.command]))
+    static let paletteRow8 = Self("paletteRow8", default: .init(.eight, modifiers: [.command]))
+    static let paletteRow9 = Self("paletteRow9", default: .init(.nine, modifiers: [.command]))
+}
+
+@MainActor
+enum PaletteRowShortcuts {
+    /// Row number (1-based) → its shortcut name, in row order.
+    static let names: [KeyboardShortcuts.Name] = [
+        .paletteRow1, .paletteRow2, .paletteRow3, .paletteRow4, .paletteRow5,
+        .paletteRow6, .paletteRow7, .paletteRow8, .paletteRow9
+    ]
+
+    /// Runs the 1-based row, returning false when there is no such row. Set by the composition
+    /// root; nil until then.
+    private static var runRow: ((Int) -> Bool)?
+    private static var isInstalled = false
+    private(set) static var isActive = false
+
+    /// Registers the handlers once and immediately parks the keys: ⌘1…⌘9 belong to the rest of
+    /// the system until a palette actually opens.
+    static func install(runRow: @escaping (Int) -> Bool) {
+        self.runRow = runRow
+        guard !isInstalled else { return }
+        isInstalled = true
+        for (index, name) in names.enumerated() {
+            let row = index + 1
+            KeyboardShortcuts.onKeyDown(for: name) {
+                MainActor.assumeIsolated {
+                    let handled = Self.runRow?(row) ?? false
+                    Log.presentation.debug("palette shortcut ⌘\(row, privacy: .public) handled=\(handled, privacy: .public)")
+                }
+            }
+        }
+        setActive(false)
+    }
+
+    /// Takes the keys while the palette is up, hands them back when it goes away. Idempotent, so
+    /// every popup transition can simply state what it wants.
+    static func setActive(_ active: Bool) {
+        guard active != isActive || !active else { return }
+        isActive = active
+        if active {
+            KeyboardShortcuts.enable(names)
+        } else {
+            KeyboardShortcuts.disable(names)
+        }
+    }
+}

--- a/Sources/OpenClip/Platform/Selection/SelectionRetrievalCoordinator.swift
+++ b/Sources/OpenClip/Platform/Selection/SelectionRetrievalCoordinator.swift
@@ -71,8 +71,9 @@ public struct SelectionRetrievalCoordinator: Sendable {
     /// Reads the current selection for `app` under `policy`, or `nil` when the gate rejects the
     /// context or no strategy produced text. `cursor` is the system cursor class (`CursorClassifier.current`,
     /// which is `@MainActor`) captured by the caller; `.unknown` (unrecognized cursor) never blocks.
-    /// `isSelectAll` marks a ⌘A gesture: a copy-based read is then skipped unless the focused element
-    /// is text-bearing, so row selections in Finder/Mail/table views never fire a real copy.
+    /// `isSelectAll` marks a whole-container select gesture (⌘A, and ⌘L for the address bar / line):
+    /// retrieval is then skipped when the focus is a row/list container, so row selections in
+    /// Finder/Mail/table views never fire a real copy.
     public func retrieve(
         for app: AppIdentity,
         policy: AppPolicyContext,
@@ -103,12 +104,17 @@ public struct SelectionRetrievalCoordinator: Sendable {
             return nil
         }
 
-        // ⌘A select-all on a non-text element (row selection in Finder/Mail/table views) must never
-        // produce text: AX reads would surface the row labels, and a copy trigger would fire a real
-        // copy on rows, not text. Guard before the cascade so every strategy, not just copy modes,
-        // honors it.
-        if isSelectAll, !Self.isTextBearing(target) {
-            Log.selection.debug("coordinator: select-all on non-text element; skipping retrieval")
+        // A whole-container select gesture (⌘A, ⌘L) landing on a *row* selection — Finder, Mail,
+        // table views — must never produce text: AX reads would surface the row labels, and a copy
+        // trigger would fire a real copy on rows, not text. The guard names those containers
+        // explicitly rather than demanding a known text role: apps that expose no usable AX text
+        // element at all (editors and terminals drawing their own text — Zed, Ghostty, Electron
+        // hosts) are precisely the ones that depend on the copy strategies, and a whitelist made
+        // ⌘A the one gesture that never worked there while a drag or ⇧+arrow in the same element
+        // succeeded. Unknown is allowed; only a recognized row container is refused. Guarded
+        // before the cascade so every strategy, not just copy modes, honors it.
+        if isSelectAll, Self.isRowSelectionContext(target) {
+            Log.selection.debug("coordinator: select-all on a row-selection element; skipping retrieval")
             return nil
         }
 
@@ -354,6 +360,21 @@ public struct SelectionRetrievalCoordinator: Sendable {
     /// Whether the focused element can hold a *text* selection (as opposed to a row/table selection
     /// that ⌘A would expand). True for editable text roles, anything inside a web area, and any
     /// element that already exposes a text selection range.
+    /// AX roles whose "select all" selects rows/items rather than text.
+    private static let rowSelectionRoles: Set<String> = [
+        "AXTable", "AXOutline", "AXBrowser", "AXList", "AXRow", "AXCell", "AXColumn", "AXGrid"
+    ]
+
+    /// True when a select-all gesture would be selecting rows rather than text. A text element
+    /// wins even inside a table (a cell being edited is still text), so `isTextBearing` is checked
+    /// first; otherwise the focused element — or a container it sits in — has to be a recognized
+    /// row/list role. Anything else, including an app that exposes no roles at all, is allowed.
+    private static func isRowSelectionContext(_ target: AXElementInspector.Target) -> Bool {
+        if isTextBearing(target) { return false }
+        if let role = target.role, rowSelectionRoles.contains(role) { return true }
+        return !target.containedInRoles.isDisjoint(with: rowSelectionRoles)
+    }
+
     private static func isTextBearing(_ target: AXElementInspector.Target) -> Bool {
         if target.selectedTextRange != nil { return true }
         let textRoles: Set<String> = ["AXTextField", "AXTextArea", "AXSearchField", "AXComboBox", "AXWebArea"]

--- a/Sources/OpenClip/UI/Popup/PopupPositioner.swift
+++ b/Sources/OpenClip/UI/Popup/PopupPositioner.swift
@@ -79,12 +79,6 @@ public struct PopupPositioner: Sendable {
         alignedX(releaseX: releaseX, width: width, screenBounds: screenBounds, alignment: .center)
     }
 
-    /// Returns a frame of `popupSize` centered horizontally and vertically within `screenBounds`.
-    public static func centerInScreen(popupSize: CGSize, screenBounds: CGRect) -> CGRect {
-        let x = screenBounds.midX - popupSize.width / 2
-        let y = screenBounds.midY - popupSize.height / 2
-        return CGRect(x: x, y: y, width: popupSize.width, height: popupSize.height)
-    }
 
     /// Horizontal midX for a search palette of `searchWidth` initiated from a button click at `buttonScreenMidX`
     /// within a bar whose right edge is `barMaxX`. The palette aligns with the button's center point

--- a/Sources/OpenClip/UI/Popup/PopupSearchView.swift
+++ b/Sources/OpenClip/UI/Popup/PopupSearchView.swift
@@ -4,6 +4,9 @@
 // The action-search palette: a focused text field filtering the full action catalog (enabled and
 // disabled) as you type, rendered as one surface with the popup bar. Results appear above or
 // below the field depending on popup position; up to 3 rows visible, scrollable beyond that.
+// Rows are chosen with the arrows + Return, the mouse, or ⌘1…⌘9 — the first nine rows carry a
+// shortcut (shown on the row) that runs them outright. The keys live on the focused field, so
+// they exist only while the palette is open.
 import SwiftUI
 import AppKit
 import Core
@@ -174,7 +177,12 @@ public struct PopupSearchView: View {
                 .onSubmit { runSelected() }
                 .onKeyPress { press in
                     // Attached to the focused field: Escape drops the scope (or exits search),
-                    // up/down move the result selection.
+                    // up/down move the result selection, ⌘1…⌘9 run a row outright.
+                    if press.modifiers.contains(.command),
+                       let position = press.characters.first?.wholeNumberValue,
+                       (1...Self.maxShortcutRows).contains(position) {
+                        return runRow(at: position - 1) ? .handled : .ignored
+                    }
                     if press.key == .escape {
                         exitSearch()
                         return .handled
@@ -306,6 +314,13 @@ public struct PopupSearchView: View {
                         .font(.caption2)
                         .foregroundColor(PopupThemeModel.restSecondary(for: effectiveTheme))
                 }
+                if let shortcut = Self.shortcutHint(forRow: index) {
+                    Text(shortcut)
+                        .font(.caption2)
+                        .monospacedDigit()
+                        .foregroundColor(isSelected ? .white.opacity(0.85) : PopupThemeModel.restSecondary(for: effectiveTheme))
+                        .accessibilityLabel("Command \(index + 1)")
+                }
             }
             .padding(.horizontal, 12)
             .frame(height: PopupMetrics.searchResultRowHeight)
@@ -325,6 +340,26 @@ public struct PopupSearchView: View {
         guard newIndex != selectedIndex else { return }
         scrollSelectionOnKeyboard = true
         selectedIndex = newIndex
+    }
+
+    /// How many rows carry a ⌘-digit shortcut: ⌘1…⌘9. Rows past the ninth have none — ⌘0 is not
+    /// a tenth row, it is simply unhandled.
+    static let maxShortcutRows = 9
+
+    /// The shortcut label for a row, or nil past the ninth.
+    static func shortcutHint(forRow index: Int) -> String? {
+        guard index >= 0, index < maxShortcutRows else { return nil }
+        return "⌘\(index + 1)"
+    }
+
+    /// Runs the row a ⌘-digit points at. Returns false when there is no such row, so the keystroke
+    /// falls through to the field (⌘5 in a three-result list types nothing and does nothing)
+    /// instead of being silently swallowed.
+    private func runRow(at index: Int) -> Bool {
+        guard index >= 0, index < Self.maxShortcutRows, results.indices.contains(index) else { return false }
+        selectedIndex = index
+        runSelected()
+        return true
     }
 
     private func runSelected() {

--- a/Sources/OpenClip/UI/Popup/PopupSearchView.swift
+++ b/Sources/OpenClip/UI/Popup/PopupSearchView.swift
@@ -139,6 +139,7 @@ public struct PopupSearchView: View {
             }
         }
         .frame(width: PopupMetrics.searchPanelContentWidth)
+        .background(CommandDigitCatcher { row in runRow(at: row - 1) })
         .clipShape(RoundedRectangle(cornerRadius: PopupMetrics.searchCornerRadius, style: .continuous))
         .onPreferenceChange(SearchHoverFramePreferenceKey.self) { frames in
             MainActor.assumeIsolated {
@@ -177,12 +178,9 @@ public struct PopupSearchView: View {
                 .onSubmit { runSelected() }
                 .onKeyPress { press in
                     // Attached to the focused field: Escape drops the scope (or exits search),
-                    // up/down move the result selection, ⌘1…⌘9 run a row outright.
-                    if press.modifiers.contains(.command),
-                       let position = press.characters.first?.wholeNumberValue,
-                       (1...Self.maxShortcutRows).contains(position) {
-                        return runRow(at: position - 1) ? .handled : .ignored
-                    }
+                    // up/down move the result selection. ⌘-digits never arrive here — a
+                    // command-modified key is dispatched through `performKeyEquivalent` and never
+                    // reaches `keyDown:` — so those live in `CommandDigitCatcher` below.
                     if press.key == .escape {
                         exitSearch()
                         return .handled
@@ -345,6 +343,20 @@ public struct PopupSearchView: View {
     /// How many rows carry a ⌘-digit shortcut: ⌘1…⌘9. Rows past the ninth have none — ⌘0 is not
     /// a tenth row, it is simply unhandled.
     static let maxShortcutRows = 9
+
+    /// The 1-based row a ⌘-digit event points at, or nil when the event is not one. Pure, so the
+    /// modifier rules are testable without a window: exactly Command (⌥/⇧/⌃ combinations are
+    /// somebody else's shortcut), and a single digit 1...9.
+    static func commandDigitRow(for event: NSEvent) -> Int? {
+        let modifiers = event.modifierFlags
+            .intersection(.deviceIndependentFlagsMask)
+            .subtracting([.capsLock, .function, .numericPad, .help])
+        guard modifiers == .command else { return nil }
+        guard let characters = event.charactersIgnoringModifiers, characters.count == 1,
+              let digit = characters.first?.wholeNumberValue,
+              (1...maxShortcutRows).contains(digit) else { return nil }
+        return digit
+    }
 
     /// The shortcut label for a row, or nil past the ninth.
     static func shortcutHint(forRow index: Int) -> String? {
@@ -531,6 +543,43 @@ public struct PopupSearchView: View {
             }
         } else if hoveredTarget == target {
             hoveredTarget = nil
+        }
+    }
+}
+
+
+// MARK: - ⌘-digit Key Equivalents
+
+/// Catches ⌘1…⌘9 for the palette. It has to be an AppKit view: a command-modified key is
+/// dispatched by `NSApplication` through `performKeyEquivalent` down the view tree and is
+/// consumed there — it never becomes a `keyDown:`, so SwiftUI's `onKeyPress` (and the focused
+/// text field) never see it, and an unhandled one ends in the system beep. `performKeyEquivalent`
+/// walks *every* view in the tree regardless of hit-testing, so a zero-size background view is
+/// enough. The handler is refreshed on each SwiftUI update so it always runs against the current
+/// result list.
+private struct CommandDigitCatcher: NSViewRepresentable {
+    /// Runs the 1-based row, returning false when there is none (the event then falls through).
+    let onRow: @MainActor (Int) -> Bool
+
+    func makeNSView(context: Context) -> CatcherView {
+        let view = CatcherView()
+        view.onRow = onRow
+        return view
+    }
+
+    func updateNSView(_ nsView: CatcherView, context: Context) {
+        nsView.onRow = onRow
+    }
+
+    final class CatcherView: NSView {
+        var onRow: (@MainActor (Int) -> Bool)?
+
+        override func performKeyEquivalent(with event: NSEvent) -> Bool {
+            if let row = PopupSearchView.commandDigitRow(for: event),
+               MainActor.assumeIsolated({ onRow?(row) ?? false }) {
+                return true
+            }
+            return super.performKeyEquivalent(with: event)
         }
     }
 }

--- a/Sources/OpenClip/UI/Popup/PopupSearchView.swift
+++ b/Sources/OpenClip/UI/Popup/PopupSearchView.swift
@@ -575,11 +575,14 @@ private struct CommandDigitCatcher: NSViewRepresentable {
         var onRow: (@MainActor (Int) -> Bool)?
 
         override func performKeyEquivalent(with event: NSEvent) -> Bool {
-            if let row = PopupSearchView.commandDigitRow(for: event),
-               MainActor.assumeIsolated({ onRow?(row) ?? false }) {
-                return true
+            guard let row = PopupSearchView.commandDigitRow(for: event) else {
+                return super.performKeyEquivalent(with: event)
             }
-            return super.performKeyEquivalent(with: event)
+            // Claimed whether or not a row exists: while the palette is on screen ⌘1…⌘9 are its
+            // own, so ⌘5 in a three-row list quietly does nothing instead of beeping or reaching
+            // the app underneath.
+            MainActor.assumeIsolated { _ = onRow?(row) }
+            return true
         }
     }
 }

--- a/Sources/OpenClip/UI/Popup/PopupSearchView.swift
+++ b/Sources/OpenClip/UI/Popup/PopupSearchView.swift
@@ -550,14 +550,16 @@ public struct PopupSearchView: View {
 
 // MARK: - ⌘-digit Key Equivalents
 
-/// Catches ⌘1…⌘9 for the palette. It has to be an AppKit view: a command-modified key is
-/// dispatched by `NSApplication` through `performKeyEquivalent` down the view tree and is
-/// consumed there — it never becomes a `keyDown:`, so SwiftUI's `onKeyPress` (and the focused
-/// text field) never see it, and an unhandled one ends in the system beep. `performKeyEquivalent`
-/// walks *every* view in the tree regardless of hit-testing, so a zero-size background view is
-/// enough. The handler is refreshed on each SwiftUI update so it always runs against the current
-/// result list.
-private struct CommandDigitCatcher: NSViewRepresentable {
+/// Holds the palette's ⌘1…⌘9 row runner. The handler is refreshed on every SwiftUI update, so it
+/// always runs against the current result list — which is why the runner lives in an AppKit view
+/// the controller can find (`PopupWindowController.runPaletteRow`) rather than in a closure
+/// captured out of a SwiftUI `View` struct, where the `@State` results would go stale.
+///
+/// It also answers `performKeyEquivalent`, which covers the case where OpenClip *is* the active
+/// app and AppKit runs its key-equivalent phase normally. That phase never runs for the popup's
+/// non-activating panel, which is why `PaletteRowShortcuts` exists — see that file for the
+/// routing story.
+struct CommandDigitCatcher: NSViewRepresentable {
     /// Runs the 1-based row, returning false when there is none (the event then falls through).
     let onRow: @MainActor (Int) -> Bool
 
@@ -573,6 +575,13 @@ private struct CommandDigitCatcher: NSViewRepresentable {
 
     final class CatcherView: NSView {
         var onRow: (@MainActor (Int) -> Bool)?
+
+        /// Runs a 1-based row directly, for the global ⌘-digit hot keys — those never arrive as
+        /// events in this process, so there is no key equivalent to walk.
+        @MainActor
+        func run(row: Int) -> Bool {
+            onRow?(row) ?? false
+        }
 
         override func performKeyEquivalent(with event: NSEvent) -> Bool {
             guard let row = PopupSearchView.commandDigitRow(for: event) else {

--- a/Sources/OpenClip/UI/Popup/PopupView.swift
+++ b/Sources/OpenClip/UI/Popup/PopupView.swift
@@ -470,10 +470,18 @@ public struct PopupView: View {
             },
             onRunAI: { actionID in
                 onActionPerformed?(actionID)
-                onExitSearch()
                 if let onRunAI {
+                    // Run first: the controller's AI flow snapshots the selection and dismisses
+                    // the popup itself. Exiting search beforehand dismissed it *for* a palette
+                    // opened straight from the hotkey (`openedDirectlyInSearch` → `hide()`),
+                    // which cleared `currentActionContext` — so the preset never ran and only
+                    // logged "Cannot run AI preset". From the bar the same exit merely returned
+                    // to the bar, which is why AI worked there and nowhere else.
                     onRunAI(actionID)
                 } else {
+                    // Preview/static fallback: no controller flow to dismiss anything, so the
+                    // palette closes itself before streaming into the card.
+                    onExitSearch()
                     guard let preset = aiManager.preset(forActionID: actionID) else { return }
                     runAIPreset(prompt: aiManager.promptForPreset(preset), title: preset.title)
                 }

--- a/Sources/OpenClip/UI/Popup/PopupWindowController.swift
+++ b/Sources/OpenClip/UI/Popup/PopupWindowController.swift
@@ -212,21 +212,20 @@ public class PopupWindowController {
         let rawVertical = settingsStore.get(SettingKey.popupVerticalPosition)
         let verticalPosition = PopupVerticalPosition(rawValue: rawVertical) ?? .auto
 
-        // Pre-compute card direction from real screen position
-        let screen: NSScreen? = {
-            if initialMode == .search {
-                return NSScreen.main ?? PopupPositioner.screen(containing: context.cursorPosition)
-            }
-            return PopupPositioner.screen(containing: context.cursorPosition) ?? NSScreen.main
-        }()
+        // Pre-compute card direction from real screen position. Placement is the same for both
+        // entry points: a palette opened by the shortcut is anchored on the selection and honors
+        // the alignment / vertical-position preferences exactly like the bar the mouse opens —
+        // it used to land in the middle of the main screen, ignoring both.
+        let screen = PopupPositioner.screen(containing: context.cursorPosition) ?? NSScreen.main
         let screenBounds = screen?.visibleFrame ?? NSRect(x: 0, y: 0, width: 800, height: 600)
-        let tempFrame: CGRect
-        if initialMode == .search {
-            tempFrame = PopupPositioner.centerInScreen(popupSize: CGSize(width: PopupMetrics.searchPanelWidth, height: 50), screenBounds: screenBounds)
-        } else {
-            tempFrame = PopupPositioner.calculateFrame(
-                for: context, popupSize: CGSize(width: 320, height: 50), in: screenBounds, alignment: alignment, verticalPosition: verticalPosition)
-        }
+        let probeWidth = initialMode == .search ? PopupMetrics.searchPanelWidth : 320
+        let tempFrame = PopupPositioner.calculateFrame(
+            for: context,
+            popupSize: CGSize(width: probeWidth, height: 50),
+            in: screenBounds,
+            alignment: alignment,
+            verticalPosition: verticalPosition
+        )
         cardAbove = tempFrame.minY < screenBounds.minY + PopupMetrics.cardAboveThreshold
 
         modeStore.mode = initialMode
@@ -313,15 +312,9 @@ public class PopupWindowController {
         let size = sanitizedPopupSize(panel.contentView?.fittingSize)
 
         // Compute card direction from real screen position using the actual rendered panel size.
-        let calculatedFrame: CGRect
-        if initialMode == .search {
-            calculatedFrame = PopupPositioner.centerInScreen(popupSize: size, screenBounds: screenBounds)
-            panel.setFrame(calculatedFrame, display: true)
-        } else {
-            calculatedFrame = PopupPositioner.calculateFrame(
-                for: context, popupSize: size, in: screenBounds, alignment: alignment, verticalPosition: verticalPosition)
-            positionPanel(panel, size: size, for: context, alignment: alignment, verticalPosition: verticalPosition)
-        }
+        let calculatedFrame = PopupPositioner.calculateFrame(
+            for: context, popupSize: size, in: screenBounds, alignment: alignment, verticalPosition: verticalPosition)
+        positionPanel(panel, size: size, for: context, alignment: alignment, verticalPosition: verticalPosition)
         cardAbove = calculatedFrame.minY < screenBounds.minY + PopupMetrics.cardAboveThreshold
         modeStore.searchResultsAbove = cardAbove
         modeStore.subBarAbove = PopupPositioner.isPlacedAbove(frame: calculatedFrame, releasePoint: context.cursorPosition)

--- a/Sources/OpenClip/UI/Popup/PopupWindowController.swift
+++ b/Sources/OpenClip/UI/Popup/PopupWindowController.swift
@@ -229,6 +229,7 @@ public class PopupWindowController {
         cardAbove = tempFrame.minY < screenBounds.minY + PopupMetrics.cardAboveThreshold
 
         modeStore.mode = initialMode
+        PaletteRowShortcuts.setActive(initialMode == .search)
         modeStore.searchResultsAbove = cardAbove
         modeStore.subBarAbove = PopupPositioner.isPlacedAbove(frame: tempFrame, releasePoint: context.cursorPosition)
         // Probed before selection retrieval by the trigger sites and resolved before this frame,
@@ -407,6 +408,7 @@ public class PopupWindowController {
             modeStore.scope = scope
         }
         modeStore.mode = .search
+        PaletteRowShortcuts.setActive(true)
         // Content-driven growth keeps the panel's bottom edge fixed (results render above the field,
         // so growth must extend upward); see PopupPanel.setFrame.
         panel.pinBottomEdgeOnResize = modeStore.searchResultsAbove
@@ -479,6 +481,7 @@ public class PopupWindowController {
         }
         modeStore.scope = nil
         modeStore.mode = .actions
+        PaletteRowShortcuts.setActive(false)
         // Return to the bar keeps the field-anchoring rule active for hover-preview/banner growth
         // (strip renders above the bar when the popup sits low), so set it explicitly rather than
         // leaving the search-mode value behind. Cleared by show()/hide() before placement.
@@ -517,6 +520,7 @@ public class PopupWindowController {
         modeStore.isProcessingAI = isStreaming
         modeStore.resultCard = ResultCardPayload(text: text, isError: isError, title: title, icon: icon, isStreaming: isStreaming)
         if modeStore.mode != .content {
+            PaletteRowShortcuts.setActive(false)
             panel?.pinBottomEdgeOnResize = modeStore.searchResultsAbove
             panel?.horizontalAnchor = .center
             modeStore.mode = .content
@@ -660,6 +664,7 @@ public class PopupWindowController {
         isRightClickInProgress = false
         modeStore.isProcessingAI = false
         modeStore.mode = .actions
+        PaletteRowShortcuts.setActive(false)
         modeStore.isSubBarActive = false
         modeStore.activeSubGroupID = nil
         modeStore.scope = nil
@@ -711,15 +716,7 @@ public class PopupWindowController {
         }
         
         localEventMonitor = NSEvent.addLocalMonitorForEvents(matching: [.leftMouseDown, .rightMouseDown, .leftMouseUp, .rightMouseUp, .mouseMoved, .scrollWheel, .keyDown]) { [weak self] event in
-            guard let self else { return event }
-            // The palette's ⌘1…⌘9 have to be claimed here. AppKit runs its key-equivalent phase
-            // for the *active* application, and the popup panel is a non-activating panel of an
-            // inactive app: keystrokes reach the panel (typing works), but nothing ever asks the
-            // view tree to handle a command-modified key, so it falls off the responder chain and
-            // rings the system bell. Running that phase by hand — and swallowing the event —
-            // gives the palette its shortcut and keeps the ⌘-digit out of the source app.
-            if self.consumesPaletteShortcut(event) { return nil }
-            self.handleEvent(event)
+            self?.handleEvent(event)
             return event
         }
         
@@ -751,16 +748,23 @@ public class PopupWindowController {
         NSWorkspace.shared.notificationCenter.removeObserver(self)
     }
 
-    /// True when the event is a ⌘-digit the popup's own view tree claims (the search palette's row
-    /// shortcuts). Runs AppKit's key-equivalent phase against the panel explicitly — see the local
-    /// monitor for why it never runs on its own here. Internal for tests.
-    func consumesPaletteShortcut(_ event: NSEvent) -> Bool {
-        guard event.type == .keyDown,
-              let row = PopupSearchView.commandDigitRow(for: event),
-              let panel, panel.isVisible else { return false }
-        let consumed = panel.performKeyEquivalent(with: event)
-        Log.presentation.debug("palette shortcut: ⌘\(row, privacy: .public) consumed=\(consumed, privacy: .public)")
-        return consumed
+    /// Runs the palette row a global ⌘-digit hot key points at (1-based), returning false when
+    /// there is no palette or no such row. The row list lives in the SwiftUI palette, so this
+    /// reaches it through the catcher view mounted in the panel — the same walk `focusSearchField`
+    /// uses to find the text field. Internal for tests.
+    func runPaletteRow(_ row: Int) -> Bool {
+        guard modeStore.mode == .search, let panel, panel.isVisible,
+              let catcher = Self.findCommandDigitCatcher(in: panel.contentView) else { return false }
+        return catcher.run(row: row)
+    }
+
+    private static func findCommandDigitCatcher(in view: NSView?) -> CommandDigitCatcher.CatcherView? {
+        guard let view else { return nil }
+        if let catcher = view as? CommandDigitCatcher.CatcherView { return catcher }
+        for subview in view.subviews {
+            if let found = findCommandDigitCatcher(in: subview) { return found }
+        }
+        return nil
     }
 
     func handleEvent(_ event: NSEvent) {

--- a/Sources/OpenClip/UI/Popup/PopupWindowController.swift
+++ b/Sources/OpenClip/UI/Popup/PopupWindowController.swift
@@ -711,7 +711,15 @@ public class PopupWindowController {
         }
         
         localEventMonitor = NSEvent.addLocalMonitorForEvents(matching: [.leftMouseDown, .rightMouseDown, .leftMouseUp, .rightMouseUp, .mouseMoved, .scrollWheel, .keyDown]) { [weak self] event in
-            self?.handleEvent(event)
+            guard let self else { return event }
+            // The palette's ⌘1…⌘9 have to be claimed here. AppKit runs its key-equivalent phase
+            // for the *active* application, and the popup panel is a non-activating panel of an
+            // inactive app: keystrokes reach the panel (typing works), but nothing ever asks the
+            // view tree to handle a command-modified key, so it falls off the responder chain and
+            // rings the system bell. Running that phase by hand — and swallowing the event —
+            // gives the palette its shortcut and keeps the ⌘-digit out of the source app.
+            if self.consumesPaletteShortcut(event) { return nil }
+            self.handleEvent(event)
             return event
         }
         
@@ -741,6 +749,18 @@ public class PopupWindowController {
         }
         NotificationCenter.default.removeObserver(self)
         NSWorkspace.shared.notificationCenter.removeObserver(self)
+    }
+
+    /// True when the event is a ⌘-digit the popup's own view tree claims (the search palette's row
+    /// shortcuts). Runs AppKit's key-equivalent phase against the panel explicitly — see the local
+    /// monitor for why it never runs on its own here. Internal for tests.
+    func consumesPaletteShortcut(_ event: NSEvent) -> Bool {
+        guard event.type == .keyDown,
+              let row = PopupSearchView.commandDigitRow(for: event),
+              let panel, panel.isVisible else { return false }
+        let consumed = panel.performKeyEquivalent(with: event)
+        Log.presentation.debug("palette shortcut: ⌘\(row, privacy: .public) consumed=\(consumed, privacy: .public)")
+        return consumed
     }
 
     func handleEvent(_ event: NSEvent) {

--- a/Sources/OpenClip/UI/Preferences/AITab.swift
+++ b/Sources/OpenClip/UI/Preferences/AITab.swift
@@ -17,6 +17,8 @@ public struct AITab: View {
 
     @State private var editingPreset: AIActionPreset? = nil
     @State private var showingAddPresetSheet = false
+    /// The row a dragged preset is currently hovering, so it can show where the drop will land.
+    @State private var dropTargetPresetID: String? = nil
     @State private var newTitle: String = ""
     @State private var newPrompt: String = ""
     
@@ -50,8 +52,14 @@ public struct AITab: View {
                     .foregroundColor(.accentColor)
                 }) {
                     VStack(alignment: .leading, spacing: 6) {
-                        ForEach(aiManager.presets) { preset in
+                        ForEach(Array(aiManager.presets.enumerated()), id: \.element.id) { index, preset in
                             HStack(alignment: .center, spacing: 12) {
+                                Image(systemName: "line.3.horizontal")
+                                    .font(.system(size: 11, weight: .medium))
+                                    .foregroundColor(.secondary.opacity(0.7))
+                                    .help("Drag to reorder")
+                                    .accessibilityLabel("Drag to reorder")
+
                                 Toggle("", isOn: Binding(
                                     get: { preset.isEnabled },
                                     set: { newValue in
@@ -93,6 +101,28 @@ public struct AITab: View {
                                 }
                             }
                             .padding(.vertical, 4)
+                            .padding(.horizontal, 6)
+                            .contentShape(Rectangle())
+                            // The list order is the order everywhere (palette, AI sub-bar), so the
+                            // drag writes straight through to the preset list. Dropping onto a row
+                            // takes that row's slot; the rest shift down.
+                            .background(
+                                RoundedRectangle(cornerRadius: 6, style: .continuous)
+                                    .fill(dropTargetPresetID == preset.id ? Color.accentColor.opacity(0.15) : Color.clear)
+                            )
+                            .draggable(preset.id) {
+                                Text(preset.title)
+                                    .font(.system(size: 12, weight: .medium))
+                                    .padding(6)
+                            }
+                            .dropDestination(for: String.self) { items, _ in
+                                dropTargetPresetID = nil
+                                guard let draggedID = items.first, draggedID != preset.id else { return false }
+                                aiManager.movePreset(id: draggedID, to: index)
+                                return true
+                            } isTargeted: { targeted in
+                                dropTargetPresetID = targeted ? preset.id : (dropTargetPresetID == preset.id ? nil : dropTargetPresetID)
+                            }
 
                             if preset.id != aiManager.presets.last?.id {
                                 Divider()

--- a/Sources/OpenClip/UI/Preferences/AITab.swift
+++ b/Sources/OpenClip/UI/Preferences/AITab.swift
@@ -4,6 +4,40 @@
 // Renders the AI preferences view with top-bar sub-tab switching between AI Engine Configuration and AI Actions Management.
 import SwiftUI
 
+/// Row frames of the AI preset list, keyed by preset id, in the list's coordinate space.
+private struct PresetRowFramePreferenceKey: PreferenceKey {
+    static let defaultValue: [String: CGRect] = [:]
+    static func reduce(value: inout [String: CGRect], nextValue: () -> [String: CGRect]) {
+        value.merge(nextValue()) { _, new in new }
+    }
+}
+
+/// Drop handling for the AI preset list. A `DropDelegate` (rather than `dropDestination`) because
+/// only this API reports the drag position *continuously*, which is what the insertion bar needs
+/// to follow the cursor between rows.
+private struct PresetListDropDelegate: DropDelegate {
+    let gapForLocation: (CGPoint) -> Int
+    let onGapChanged: (Int?) -> Void
+    let onDrop: (Int) -> Bool
+
+    func dropEntered(info: DropInfo) {
+        onGapChanged(gapForLocation(info.location))
+    }
+
+    func dropUpdated(info: DropInfo) -> DropProposal? {
+        onGapChanged(gapForLocation(info.location))
+        return DropProposal(operation: .move)
+    }
+
+    func dropExited(info: DropInfo) {
+        onGapChanged(nil)
+    }
+
+    func performDrop(info: DropInfo) -> Bool {
+        onDrop(gapForLocation(info.location))
+    }
+}
+
 public enum AISubTab: String, CaseIterable, Identifiable, Sendable {
     case configure = "Configure"
     case actions = "Actions"
@@ -17,8 +51,13 @@ public struct AITab: View {
 
     @State private var editingPreset: AIActionPreset? = nil
     @State private var showingAddPresetSheet = false
-    /// The row a dragged preset is currently hovering, so it can show where the drop will land.
-    @State private var dropTargetPresetID: String? = nil
+    /// Frames of the preset rows in the list's own coordinate space, used to turn a drag position
+    /// into the gap it would drop into (same rule AppKit's insertion bar follows).
+    @State private var presetRowFrames: [String: CGRect] = [:]
+    /// The gap a drag is currently over: 0 = above the first row, `count` = below the last.
+    @State private var insertionGap: Int? = nil
+    /// The preset being dragged, captured at drag start so the drop is resolved synchronously.
+    @State private var draggingPresetID: String? = nil
     @State private var newTitle: String = ""
     @State private var newPrompt: String = ""
     
@@ -35,6 +74,60 @@ public struct AITab: View {
                 actionsView
             }
         }
+    }
+
+    // MARK: - Preset Reordering
+
+    private static let presetListSpace = "aiPresetList"
+
+    /// Reports a row's frame in the list's coordinate space (drawn as a clear background, so it
+    /// never affects layout).
+    private func rowFrameReader(for id: String) -> some View {
+        GeometryReader { geo in
+            Color.clear.preference(
+                key: PresetRowFramePreferenceKey.self,
+                value: [id: geo.frame(in: .named(Self.presetListSpace))]
+            )
+        }
+    }
+
+    /// The gap a drag at `location` would drop into, resolved against the current row frames.
+    private func gap(at location: CGPoint) -> Int {
+        Self.insertionGap(atY: location.y, rowFrames: orderedRowFrames)
+    }
+
+    /// Row frames in list order (a row that has not reported its frame yet is skipped).
+    private var orderedRowFrames: [CGRect] {
+        aiManager.presets.compactMap { presetRowFrames[$0.id] }
+    }
+
+    /// Pure gap rule (unit-tested): every row whose midpoint the drag has passed counts, so 0 is
+    /// above the first row and `rowFrames.count` is below the last — the same rule AppKit's
+    /// insertion bar follows in the Actions outline.
+    static func insertionGap(atY y: CGFloat, rowFrames: [CGRect]) -> Int {
+        rowFrames.filter { y > $0.midY }.count
+    }
+
+    /// The blue insertion bar, drawn in the gap rather than on a row.
+    @ViewBuilder
+    private var insertionBar: some View {
+        if let insertionGap, let y = Self.insertionY(forGap: insertionGap, rowFrames: orderedRowFrames) {
+            Rectangle()
+                .fill(Color.accentColor)
+                .frame(height: 2)
+                .frame(maxWidth: .infinity)
+                .offset(y: y - 1)
+                .allowsHitTesting(false)
+        }
+    }
+
+    /// Y position of a gap (unit-tested): the top edge of the row it precedes, or the bottom edge
+    /// of the last row for the trailing gap. Nil when there are no rows to sit between.
+    static func insertionY(forGap gap: Int, rowFrames: [CGRect]) -> CGFloat? {
+        guard let first = rowFrames.first, let last = rowFrames.last else { return nil }
+        if gap <= 0 { return first.minY }
+        if gap >= rowFrames.count { return last.maxY }
+        return rowFrames[gap].minY
     }
 
     // MARK: - Actions View
@@ -54,12 +147,6 @@ public struct AITab: View {
                     VStack(alignment: .leading, spacing: 6) {
                         ForEach(Array(aiManager.presets.enumerated()), id: \.element.id) { index, preset in
                             HStack(alignment: .center, spacing: 12) {
-                                Image(systemName: "line.3.horizontal")
-                                    .font(.system(size: 11, weight: .medium))
-                                    .foregroundColor(.secondary.opacity(0.7))
-                                    .help("Drag to reorder")
-                                    .accessibilityLabel("Drag to reorder")
-
                                 Toggle("", isOn: Binding(
                                     get: { preset.isEnabled },
                                     set: { newValue in
@@ -101,27 +188,18 @@ public struct AITab: View {
                                 }
                             }
                             .padding(.vertical, 4)
-                            .padding(.horizontal, 6)
                             .contentShape(Rectangle())
-                            // The list order is the order everywhere (palette, AI sub-bar), so the
-                            // drag writes straight through to the preset list. Dropping onto a row
-                            // takes that row's slot; the rest shift down.
-                            .background(
-                                RoundedRectangle(cornerRadius: 6, style: .continuous)
-                                    .fill(dropTargetPresetID == preset.id ? Color.accentColor.opacity(0.15) : Color.clear)
-                            )
-                            .draggable(preset.id) {
+                            // The row itself is the drag handle — no grip glyph, matching the
+                            // Actions outline. The drop is resolved by the whole list below, which
+                            // draws the insertion bar in the gap the drag is over.
+                            .background(rowFrameReader(for: preset.id))
+                            .onDrag {
+                                draggingPresetID = preset.id
+                                return NSItemProvider(object: preset.id as NSString)
+                            } preview: {
                                 Text(preset.title)
                                     .font(.system(size: 12, weight: .medium))
                                     .padding(6)
-                            }
-                            .dropDestination(for: String.self) { items, _ in
-                                dropTargetPresetID = nil
-                                guard let draggedID = items.first, draggedID != preset.id else { return false }
-                                aiManager.movePreset(id: draggedID, to: index)
-                                return true
-                            } isTargeted: { targeted in
-                                dropTargetPresetID = targeted ? preset.id : (dropTargetPresetID == preset.id ? nil : dropTargetPresetID)
                             }
 
                             if preset.id != aiManager.presets.last?.id {
@@ -130,6 +208,24 @@ public struct AITab: View {
                         }
                     }
                     .padding(.vertical, 4)
+                    .coordinateSpace(name: Self.presetListSpace)
+                    .onPreferenceChange(PresetRowFramePreferenceKey.self) { frames in
+                        MainActor.assumeIsolated { presetRowFrames = frames }
+                    }
+                    .overlay(alignment: .topLeading) { insertionBar }
+                    .onDrop(of: [.text], delegate: PresetListDropDelegate(
+                        gapForLocation: { location in gap(at: location) },
+                        onGapChanged: { gap in insertionGap = gap },
+                        onDrop: { gap in
+                            defer {
+                                insertionGap = nil
+                                draggingPresetID = nil
+                            }
+                            guard let draggedID = draggingPresetID else { return false }
+                            aiManager.movePreset(id: draggedID, toGap: gap)
+                            return true
+                        }
+                    ))
                 }
             }
             .formStyle(.grouped)

--- a/Tests/OpenClipTests/AIActionTests.swift
+++ b/Tests/OpenClipTests/AIActionTests.swift
@@ -42,31 +42,39 @@ final class AIActionTests: XCTestCase {
         }
     }
 
-    /// Dropping a row onto an earlier one takes that slot; everything below shifts down.
-    func testMovingAPresetUpTakesTheTargetSlot() {
-        let reordered = AIServiceManager.reordering(sample, moving: "explain", to: 0)
+    /// Dropping into the topmost gap (the insertion bar above the first row) puts the preset first.
+    func testDroppingIntoTheTopGapMovesToFirst() {
+        let reordered = AIServiceManager.reordering(sample, moving: "explain", toGap: 0)
         XCTAssertEqual(reordered.map(\.id), ["explain", "proofread", "rewrite", "summarize"])
     }
 
-    /// Moving down lands in the target's slot too (the rows above close the gap first).
-    func testMovingAPresetDownTakesTheTargetSlot() {
-        let reordered = AIServiceManager.reordering(sample, moving: "proofread", to: 2)
+    /// Gap indices are pre-removal, so dropping into the gap *above* "explain" (index 3) leaves
+    /// the moved row directly before it.
+    func testDroppingIntoAMiddleGapLandsInThatGap() {
+        let reordered = AIServiceManager.reordering(sample, moving: "proofread", toGap: 3)
         XCTAssertEqual(reordered.map(\.id), ["rewrite", "summarize", "proofread", "explain"])
     }
 
-    func testMovingToItsOwnIndexIsANoOp() {
-        XCTAssertEqual(AIServiceManager.reordering(sample, moving: "rewrite", to: 1).map(\.id),
-                       sample.map(\.id))
+    /// The gap below the last row appends.
+    func testDroppingIntoTheBottomGapMovesToLast() {
+        let reordered = AIServiceManager.reordering(sample, moving: "proofread", toGap: 4)
+        XCTAssertEqual(reordered.map(\.id), ["rewrite", "summarize", "explain", "proofread"])
     }
 
-    /// Nothing traps: an unknown id or an out-of-range destination is handled, not crashed on.
-    func testUnknownIDAndOutOfRangeDestinationAreSafe() {
-        XCTAssertEqual(AIServiceManager.reordering(sample, moving: "nope", to: 0).map(\.id), sample.map(\.id))
-        XCTAssertEqual(AIServiceManager.reordering(sample, moving: "proofread", to: 99).map(\.id),
+    /// Both gaps touching a row are no-ops for that row — a drag that goes nowhere changes nothing.
+    func testDroppingIntoAnAdjacentGapIsANoOp() {
+        XCTAssertEqual(AIServiceManager.reordering(sample, moving: "rewrite", toGap: 1).map(\.id), sample.map(\.id))
+        XCTAssertEqual(AIServiceManager.reordering(sample, moving: "rewrite", toGap: 2).map(\.id), sample.map(\.id))
+    }
+
+    /// Nothing traps: an unknown id or an out-of-range gap is handled, not crashed on.
+    func testUnknownIDAndOutOfRangeGapAreSafe() {
+        XCTAssertEqual(AIServiceManager.reordering(sample, moving: "nope", toGap: 0).map(\.id), sample.map(\.id))
+        XCTAssertEqual(AIServiceManager.reordering(sample, moving: "proofread", toGap: 99).map(\.id),
                        ["rewrite", "summarize", "explain", "proofread"])
-        XCTAssertEqual(AIServiceManager.reordering(sample, moving: "explain", to: -3).map(\.id),
+        XCTAssertEqual(AIServiceManager.reordering(sample, moving: "explain", toGap: -3).map(\.id),
                        ["explain", "proofread", "rewrite", "summarize"])
-        XCTAssertEqual(AIServiceManager.reordering([], moving: "proofread", to: 0).count, 0)
+        XCTAssertEqual(AIServiceManager.reordering([], moving: "proofread", toGap: 0).count, 0)
     }
 
     /// A preset keeps its content across a move — reordering must not rewrite prompts or state.
@@ -74,9 +82,34 @@ final class AIActionTests: XCTestCase {
         var presets = sample
         presets[3].prompt = "explain it simply"
         presets[3].isEnabled = false
-        let moved = AIServiceManager.reordering(presets, moving: "explain", to: 0)
+        let moved = AIServiceManager.reordering(presets, moving: "explain", toGap: 0)
         XCTAssertEqual(moved.first?.prompt, "explain it simply")
         XCTAssertEqual(moved.first?.isEnabled, false)
+    }
+
+    // MARK: - Insertion bar geometry (Preferences → AI → Actions)
+
+    /// Eight 30pt rows stacked from y=0, as the preset list lays them out.
+    private var rowFrames: [CGRect] {
+        (0..<4).map { CGRect(x: 0, y: CGFloat($0) * 30, width: 400, height: 30) }
+    }
+
+    /// The gap follows the cursor by row midpoints — the rule AppKit's insertion bar uses.
+    func testInsertionGapFollowsRowMidpoints() {
+        XCTAssertEqual(AITab.insertionGap(atY: 0, rowFrames: rowFrames), 0, "above the first row")
+        XCTAssertEqual(AITab.insertionGap(atY: 14, rowFrames: rowFrames), 0, "top half of row 0")
+        XCTAssertEqual(AITab.insertionGap(atY: 16, rowFrames: rowFrames), 1, "bottom half of row 0")
+        XCTAssertEqual(AITab.insertionGap(atY: 46, rowFrames: rowFrames), 2, "bottom half of row 1")
+        XCTAssertEqual(AITab.insertionGap(atY: 400, rowFrames: rowFrames), 4, "below the last row")
+        XCTAssertEqual(AITab.insertionGap(atY: 10, rowFrames: []), 0, "empty list has one gap")
+    }
+
+    /// The bar is drawn in the gap — on a row edge, never across a row.
+    func testInsertionBarSitsOnTheRowEdges() {
+        XCTAssertEqual(AITab.insertionY(forGap: 0, rowFrames: rowFrames), 0)
+        XCTAssertEqual(AITab.insertionY(forGap: 2, rowFrames: rowFrames), 60)
+        XCTAssertEqual(AITab.insertionY(forGap: 4, rowFrames: rowFrames), 120, "trailing gap sits on the last row's bottom edge")
+        XCTAssertNil(AITab.insertionY(forGap: 0, rowFrames: []))
     }
 
     func testAIActionIconForPreset() {

--- a/Tests/OpenClipTests/AIActionTests.swift
+++ b/Tests/OpenClipTests/AIActionTests.swift
@@ -34,6 +34,51 @@ final class AIActionTests: XCTestCase {
         XCTAssertEqual(action.icon, .text("Proofread"))
     }
 
+    // MARK: - Preset ordering (drag to reorder in Preferences → AI → Actions)
+
+    private var sample: [AIActionPreset] {
+        ["proofread", "rewrite", "summarize", "explain"].map {
+            AIActionPreset(id: $0, title: $0, prompt: "p", isEnabled: true)
+        }
+    }
+
+    /// Dropping a row onto an earlier one takes that slot; everything below shifts down.
+    func testMovingAPresetUpTakesTheTargetSlot() {
+        let reordered = AIServiceManager.reordering(sample, moving: "explain", to: 0)
+        XCTAssertEqual(reordered.map(\.id), ["explain", "proofread", "rewrite", "summarize"])
+    }
+
+    /// Moving down lands in the target's slot too (the rows above close the gap first).
+    func testMovingAPresetDownTakesTheTargetSlot() {
+        let reordered = AIServiceManager.reordering(sample, moving: "proofread", to: 2)
+        XCTAssertEqual(reordered.map(\.id), ["rewrite", "summarize", "proofread", "explain"])
+    }
+
+    func testMovingToItsOwnIndexIsANoOp() {
+        XCTAssertEqual(AIServiceManager.reordering(sample, moving: "rewrite", to: 1).map(\.id),
+                       sample.map(\.id))
+    }
+
+    /// Nothing traps: an unknown id or an out-of-range destination is handled, not crashed on.
+    func testUnknownIDAndOutOfRangeDestinationAreSafe() {
+        XCTAssertEqual(AIServiceManager.reordering(sample, moving: "nope", to: 0).map(\.id), sample.map(\.id))
+        XCTAssertEqual(AIServiceManager.reordering(sample, moving: "proofread", to: 99).map(\.id),
+                       ["rewrite", "summarize", "explain", "proofread"])
+        XCTAssertEqual(AIServiceManager.reordering(sample, moving: "explain", to: -3).map(\.id),
+                       ["explain", "proofread", "rewrite", "summarize"])
+        XCTAssertEqual(AIServiceManager.reordering([], moving: "proofread", to: 0).count, 0)
+    }
+
+    /// A preset keeps its content across a move — reordering must not rewrite prompts or state.
+    func testReorderPreservesPresetContent() {
+        var presets = sample
+        presets[3].prompt = "explain it simply"
+        presets[3].isEnabled = false
+        let moved = AIServiceManager.reordering(presets, moving: "explain", to: 0)
+        XCTAssertEqual(moved.first?.prompt, "explain it simply")
+        XCTAssertEqual(moved.first?.isEnabled, false)
+    }
+
     func testAIActionIconForPreset() {
         XCTAssertEqual(AIAction.iconForPreset(presetID: "proofread"), .text("Proofread"))
         XCTAssertEqual(AIAction.iconForPreset(presetID: "rewrite"), .text("Rewrite"))

--- a/Tests/OpenClipTests/ActionCoordinatorStartupTests.swift
+++ b/Tests/OpenClipTests/ActionCoordinatorStartupTests.swift
@@ -5,12 +5,20 @@ import XCTest
 final class ActionCoordinatorStartupTests: XCTestCase {
     let packageID = "com.custom.startup.test"
     var tempDir: URL!
+    /// `ActionRegistry.shared` is built on `DefaultSettingsStore.shared`, i.e. the *real* app
+    /// preferences domain — the test host shares its bundle id with OpenClip. `unregister` prunes
+    /// `action.order` against whatever the registry currently holds, so unregistering here used to
+    /// rewrite (and with a near-empty test registry, wipe) the developer's own action order.
+    /// Snapshot the key and put it back.
+    private var savedActionOrder: [String] = []
     
     override func setUp() async throws {
         try await super.setUp()
-        await MainActor.run {
+        savedActionOrder = await MainActor.run { () -> [String] in
+            let saved = DefaultSettingsStore.shared.get(.actionOrder)
             TestIsolation.reset()
             ExtensionManager.shared.actionFactory = DefaultActionFactory()
+            return saved
         }
         tempDir = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
         try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
@@ -18,9 +26,11 @@ final class ActionCoordinatorStartupTests: XCTestCase {
     
     override func tearDown() async throws {
         let pid = packageID
+        let restoredOrder = savedActionOrder
         await MainActor.run {
             ActionRegistry.shared.unregister(actionID: pid)
             ExtensionManager.shared.actionFactory = nil
+            DefaultSettingsStore.shared.set(.actionOrder, value: restoredOrder)
         }
         if let tempDir = tempDir {
             try? FileManager.default.removeItem(at: tempDir)

--- a/Tests/OpenClipTests/ActionRegistryTests.swift
+++ b/Tests/OpenClipTests/ActionRegistryTests.swift
@@ -175,7 +175,7 @@ final class ActionRegistryTests: XCTestCase {
     }
 
     @MainActor
-    func testSearchCatalogDropsContextuallyDisabledButKeepsSettingsDisabled() {
+    func testSearchCatalogDropsContextuallyUnableAndSettingsDisabled() {
         let store = MemorySettingsStore()
         let registry = ActionRegistry(settingsStore: store)
         let groupChrome = ActionChrome(
@@ -189,8 +189,8 @@ final class ActionRegistryTests: XCTestCase {
         let completion = MockAction(id: "builtin.completion", shouldBeEnabled: true, chrome: ActionChrome(popupBehavior: .provideCompletions))
         // Contextually unable: `isEnabled(for:)` is false, so the palette must not offer it.
         let contextuallyUnable = MockAction(id: "mock.searchdisabled", shouldBeEnabled: false)
-        // Settings-disabled (`.disabledActionIDs`): the palette is a full-catalog surface, so a
-        // row toggled off in Preferences still appears.
+        // Settings-disabled (`.disabledActionIDs`): a row toggled off in Preferences is not
+        // offered anywhere, the palette included.
         let settingsDisabled = MockAction(id: "mock.settingsdisabled", shouldBeEnabled: true)
         let normal = MockAction(id: "mock.searchnormal", shouldBeEnabled: true)
         registry.register(builtIns: [group, sub, completion, contextuallyUnable, settingsDisabled, normal])
@@ -202,14 +202,17 @@ final class ActionRegistryTests: XCTestCase {
         XCTAssertTrue(catalog.contains { $0.id == "mock.searchgroup" })
         XCTAssertTrue(catalog.contains { $0.id == "mock.searchgroup.a" })
         XCTAssertFalse(catalog.contains { $0.id == "mock.searchdisabled" })
-        XCTAssertTrue(catalog.contains { $0.id == "mock.settingsdisabled" })
+        XCTAssertFalse(catalog.contains { $0.id == "mock.settingsdisabled" },
+                       "an action switched off in Preferences must not be offered in the palette")
         XCTAssertTrue(catalog.contains { $0.id == "mock.searchnormal" })
         XCTAssertFalse(catalog.contains { $0.id == "builtin.completion" })
     }
 
     @MainActor
     func testAIChromeActionsExcludedFromBarButIncludedInSearchCatalog() {
-        let registry = ActionRegistry()
+        // Own store: `ActionRegistry()` reads the real preferences domain (the test host shares
+        // OpenClip's bundle id), so a developer disabling Copy in the app would fail this test.
+        let registry = ActionRegistry(settingsStore: MemorySettingsStore())
         let aiChrome = ActionChrome(badge: .none, rowStyle: .standard, popupBehavior: .perform, source: .ai)
         let aiAction = MockAction(id: "ai.preset.proofread", shouldBeEnabled: true, chrome: aiChrome)
         let normal = MockAction(id: "mock.normal", shouldBeEnabled: true)
@@ -228,7 +231,7 @@ final class ActionRegistryTests: XCTestCase {
 
     @MainActor
     func testAIToolsLauncherInBarExcludedFromPalette() {
-        let registry = ActionRegistry()
+        let registry = ActionRegistry(settingsStore: MemorySettingsStore())
         let launcher = MockAction(id: "builtin.aiTools", shouldBeEnabled: true, chrome: ActionChrome(launchesAI: true))
         let completion = MockAction(id: "builtin.completion", shouldBeEnabled: true, chrome: ActionChrome(popupBehavior: .provideCompletions))
         let normal = MockAction(id: "mock.normal", shouldBeEnabled: true)
@@ -448,6 +451,57 @@ final class ActionRegistryTests: XCTestCase {
         XCTAssertEqual(Self.palette(registry), ["ai.preset.rewrite", "ai.preset.proofread", "builtin.cut"])
     }
 
+    /// A disabled AI preset is gone from the palette too — the toggle in AI → Actions is the same
+    /// promise as the one in Preferences → Actions.
+    @MainActor
+    func testDisabledAIPresetIsNotOfferedInThePalette() {
+        let store = MemorySettingsStore()
+        let registry = ActionRegistry(settingsStore: store)
+        let enabled = MockAction(id: "ai.preset.proofread", shouldBeEnabled: true,
+                                 chrome: ActionChrome(badge: .none, rowStyle: .standard, popupBehavior: .perform, source: .ai))
+        // `shouldBeEnabled: false` stands in for the preset's toggle being off: the real AIAction
+        // answers `isEnabled` from AIServiceManager's preset list.
+        let disabled = MockAction(id: "ai.preset.rewrite", shouldBeEnabled: false,
+                                  chrome: ActionChrome(badge: .none, rowStyle: .standard, popupBehavior: .perform, source: .ai))
+        registry.register(builtIns: [enabled, disabled])
+
+        XCTAssertEqual(Self.palette(registry), ["ai.preset.proofread"])
+    }
+
+    /// A disabled group takes its sub-actions with it: the palette lists the members rather than
+    /// the group row, so the row's toggle has to reach them.
+    @MainActor
+    func testDisabledGroupHidesItsSubActionsFromThePalette() {
+        let store = MemorySettingsStore()
+        let registry = ActionRegistry(settingsStore: store)
+        let groupChrome = ActionChrome(badge: .none, rowStyle: .actionGroup, popupBehavior: .showSubActions, source: .builtin)
+        let group = MockAction(id: "mock.group", shouldBeEnabled: true, chrome: groupChrome)
+        let member = MockAction(id: "mock.group.member", shouldBeEnabled: true)
+        let other = MockAction(id: "mock.other", shouldBeEnabled: true)
+        registry.register(builtIns: [group, member, other])
+        XCTAssertEqual(Self.palette(registry), ["mock.group", "mock.group.member", "mock.other"])
+
+        store.set(.disabledActionIDs, value: Set(["mock.group"]))
+        XCTAssertEqual(Self.palette(registry), ["mock.other"])
+    }
+
+    /// A disabled extension package hides its actions from the palette as well as the bar.
+    @MainActor
+    func testDisabledPackageIsNotOfferedInThePalette() {
+        let store = MemorySettingsStore()
+        let registry = ActionRegistry(settingsStore: store)
+        let extChrome = ActionChrome(source: .extensionPkg(packageID: "com.ext.pkg"))
+        registry.register(builtIns: [
+            MockAction(id: "com.ext.pkg.action", shouldBeEnabled: true, chrome: extChrome),
+            MockAction(id: "mock.other", shouldBeEnabled: true)
+        ])
+        // The builtin leads: an un-ordered extension sorts behind it.
+        XCTAssertEqual(Self.palette(registry), ["mock.other", "com.ext.pkg.action"])
+
+        store.set(.disabledPackages, value: Set(["com.ext.pkg"]))
+        XCTAssertEqual(Self.palette(registry), ["mock.other"])
+    }
+
     @MainActor
     func testUnorderedBuiltinActionsPreserveStableInsertionOrder() {
         let store = MemorySettingsStore()
@@ -483,7 +537,7 @@ final class ActionRegistryTests: XCTestCase {
 
     @MainActor
     func testClipboardFallbackExcludesRequiresLiveSelectionActions() {
-        let registry = ActionRegistry()
+        let registry = ActionRegistry(settingsStore: MemorySettingsStore())
         let copy = MockAction(id: "builtin.copy", shouldBeEnabled: true, chrome: ActionChrome(requiresLiveSelection: true))
         let cut = MockAction(id: "builtin.cut", shouldBeEnabled: true, chrome: ActionChrome(requiresLiveSelection: true))
         let paste = MockAction(id: "builtin.paste", shouldBeEnabled: true)

--- a/Tests/OpenClipTests/ActionRegistryTests.swift
+++ b/Tests/OpenClipTests/ActionRegistryTests.swift
@@ -25,6 +25,26 @@ struct MockAction: Action {
     }
 }
 
+/// Stands in for the AI Tools launcher: a row that resolves its children out of the catalog
+/// (`chrome.source == .ai`), exactly as `AIToolsAction` does.
+struct MockLauncherAction: Action, SubActionProviding {
+    let id: String
+    let title = "Launcher"
+    let icon = ActionIcon.symbol("sparkles")
+    var chrome: ActionChrome { ActionChrome(source: .builtin, launchesAI: true) }
+
+    @MainActor
+    func isEnabled(for context: ActionContext) -> Bool { true }
+
+    @MainActor
+    func perform(_ context: ActionContext) async throws -> ActionResult { .success }
+
+    @MainActor
+    func subActions(in catalog: [any Action]) -> [any Action] {
+        catalog.filter { ActionIdentity.isAIPreset($0) }
+    }
+}
+
 final class ActionRegistryTests: XCTestCase {
     override func setUp() async throws {
         try await super.setUp()
@@ -258,6 +278,95 @@ final class ActionRegistryTests: XCTestCase {
 
         XCTAssertGreaterThan(ai, lastBuiltin, "AI Tools sits after the last ordered builtin")
         XCTAssertLessThan(ai, firstExt, "AI Tools precedes extensions by default")
+    }
+
+    // MARK: - Sub-actions follow their parent row
+
+    private static func aiPreset(_ id: String) -> MockAction {
+        MockAction(id: id, shouldBeEnabled: true,
+                   chrome: ActionChrome(badge: .none, rowStyle: .standard, popupBehavior: .perform, source: .ai))
+    }
+
+    @MainActor
+    private static func palette(_ registry: ActionRegistry) -> [String] {
+        let selection = SelectionContext(text: "test", sourceApp: AppIdentity(bundleIdentifier: "com.test", localizedName: "Test"), cursorPosition: .zero, timestamp: Date(), appPolicy: .default)
+        return registry.searchCatalog(for: ActionContext(selection: selection, modifiers: [])).map(\.id)
+    }
+
+    /// Regression: AI presets carry chrome source `.ai` — neither user-ordered nor builtin — so
+    /// they sank to the very end of the catalog however the user had dragged "AI Tools". The
+    /// palette lists the presets in place of the launcher row, so dragging AI Tools to the top
+    /// must put the AI commands at the top of the palette.
+    @MainActor
+    func testAIPresetsFollowTheLauncherOrderedFirst() {
+        let store = MemorySettingsStore()
+        store.set(.actionOrder, value: ["builtin.aiTools", "builtin.copy", "builtin.search"])
+        let registry = ActionRegistry(settingsStore: store)
+
+        registry.register(builtIns: [
+            MockAction(id: "builtin.copy", shouldBeEnabled: true),
+            MockAction(id: "builtin.search", shouldBeEnabled: true)
+        ])
+        registry.register(action: MockLauncherAction(id: "builtin.aiTools"))
+        registry.register(action: Self.aiPreset("ai.preset.proofread"))
+        registry.register(action: Self.aiPreset("ai.preset.rewrite"))
+
+        XCTAssertEqual(registry.actions.map(\.id),
+                       ["builtin.aiTools", "ai.preset.proofread", "ai.preset.rewrite", "builtin.copy", "builtin.search"])
+        // What the user actually sees: the palette drops the launcher, so the presets lead.
+        XCTAssertEqual(Self.palette(registry),
+                       ["ai.preset.proofread", "ai.preset.rewrite", "builtin.copy", "builtin.search"])
+    }
+
+    /// The same inheritance in the other direction — AI Tools dragged last keeps its presets last.
+    @MainActor
+    func testAIPresetsFollowTheLauncherOrderedLast() {
+        let store = MemorySettingsStore()
+        store.set(.actionOrder, value: ["builtin.copy", "builtin.search", "builtin.aiTools"])
+        let registry = ActionRegistry(settingsStore: store)
+
+        registry.register(action: MockLauncherAction(id: "builtin.aiTools"))
+        registry.register(action: Self.aiPreset("ai.preset.proofread"))
+        registry.register(builtIns: [
+            MockAction(id: "builtin.copy", shouldBeEnabled: true),
+            MockAction(id: "builtin.search", shouldBeEnabled: true)
+        ])
+
+        XCTAssertEqual(registry.actions.map(\.id),
+                       ["builtin.copy", "builtin.search", "builtin.aiTools", "ai.preset.proofread"])
+    }
+
+    /// With no user order at all, presets still sit with their launcher among the builtins rather
+    /// than behind every installed extension.
+    @MainActor
+    func testAIPresetsFollowTheLauncherWithNoUserOrder() {
+        let registry = ActionRegistry(settingsStore: MemorySettingsStore())
+        let extChrome = ActionChrome(source: .extensionPkg(packageID: "com.ext.pkg"))
+
+        registry.register(action: MockLauncherAction(id: "builtin.aiTools"))
+        registry.register(action: MockAction(id: "com.ext.pkg.1", shouldBeEnabled: true, chrome: extChrome))
+        registry.register(action: Self.aiPreset("ai.preset.proofread"))
+
+        let ids = registry.actions.map(\.id)
+        XCTAssertEqual(ids.firstIndex(of: "ai.preset.proofread"), ids.firstIndex(of: "builtin.aiTools").map { $0 + 1 })
+        XCTAssertLessThan(ids.firstIndex(of: "ai.preset.proofread")!, ids.firstIndex(of: "com.ext.pkg.1")!)
+    }
+
+    /// Inheritance is a fallback, never an override: a child the user ordered explicitly keeps the
+    /// rank they gave it.
+    @MainActor
+    func testExplicitlyOrderedChildKeepsItsOwnRank() {
+        let store = MemorySettingsStore()
+        store.set(.actionOrder, value: ["ai.preset.rewrite", "builtin.copy", "builtin.aiTools"])
+        let registry = ActionRegistry(settingsStore: store)
+
+        registry.register(action: MockLauncherAction(id: "builtin.aiTools"))
+        registry.register(action: Self.aiPreset("ai.preset.rewrite"))
+        registry.register(action: Self.aiPreset("ai.preset.proofread"))
+        registry.register(action: MockAction(id: "builtin.copy", shouldBeEnabled: true))
+
+        XCTAssertEqual(registry.actions.map(\.id),
+                       ["ai.preset.rewrite", "builtin.copy", "builtin.aiTools", "ai.preset.proofread"])
     }
 
     @MainActor

--- a/Tests/OpenClipTests/ActionRegistryTests.swift
+++ b/Tests/OpenClipTests/ActionRegistryTests.swift
@@ -421,6 +421,33 @@ final class ActionRegistryTests: XCTestCase {
         XCTAssertEqual(store.get(.actionOrder), ["builtin.search", "builtin.cut", "builtin.copy"])
     }
 
+    /// The contract `AIActionSync` leans on when the user reorders presets: `register(action:)`
+    /// replaces an id *in place*, so a reorder has to unregister and re-register to move the
+    /// entries — and when it does, the catalog follows the new order immediately.
+    @MainActor
+    func testReRegisteringPresetsInANewOrderReordersTheCatalog() {
+        let store = MemorySettingsStore()
+        store.set(.actionOrder, value: ["builtin.aiTools", "builtin.cut"])
+        let registry = ActionRegistry(settingsStore: store)
+
+        registry.register(action: MockLauncherAction(id: "builtin.aiTools"))
+        registry.register(action: MockAction(id: "builtin.cut", shouldBeEnabled: true))
+        registry.register(action: Self.aiPreset("ai.preset.proofread"))
+        registry.register(action: Self.aiPreset("ai.preset.rewrite"))
+        XCTAssertEqual(Self.palette(registry), ["ai.preset.proofread", "ai.preset.rewrite", "builtin.cut"])
+
+        // Re-registering in place must NOT move anything (titles/prompts changing is not a move).
+        registry.register(action: Self.aiPreset("ai.preset.rewrite"))
+        XCTAssertEqual(Self.palette(registry), ["ai.preset.proofread", "ai.preset.rewrite", "builtin.cut"])
+
+        // A real reorder: drop both, re-register in the new order.
+        registry.unregister(actionID: "ai.preset.proofread")
+        registry.unregister(actionID: "ai.preset.rewrite")
+        registry.register(action: Self.aiPreset("ai.preset.rewrite"))
+        registry.register(action: Self.aiPreset("ai.preset.proofread"))
+        XCTAssertEqual(Self.palette(registry), ["ai.preset.rewrite", "ai.preset.proofread", "builtin.cut"])
+    }
+
     @MainActor
     func testUnorderedBuiltinActionsPreserveStableInsertionOrder() {
         let store = MemorySettingsStore()

--- a/Tests/OpenClipTests/ActionRegistryTests.swift
+++ b/Tests/OpenClipTests/ActionRegistryTests.swift
@@ -369,6 +369,58 @@ final class ActionRegistryTests: XCTestCase {
                        ["ai.preset.rewrite", "builtin.copy", "builtin.aiTools", "ai.preset.proofread"])
     }
 
+    /// Regression (user-reported): dragging AI Tools to the top in Preferences changed nothing in
+    /// the palette until OpenClip was restarted. `moveActions` published the hand-moved array
+    /// directly, and a drag moves only the grabbed row — the presets kept their pre-drag position
+    /// until some later registration re-sorted the catalog. The move must re-derive the order.
+    @MainActor
+    func testMovingTheLauncherImmediatelyMovesItsPresets() {
+        let store = MemorySettingsStore()
+        store.set(.actionOrder, value: ["builtin.cut", "builtin.copy", "builtin.aiTools"])
+        let registry = ActionRegistry(settingsStore: store)
+
+        registry.register(builtIns: [
+            MockAction(id: "builtin.cut", shouldBeEnabled: true),
+            MockAction(id: "builtin.copy", shouldBeEnabled: true)
+        ])
+        registry.register(action: MockLauncherAction(id: "builtin.aiTools"))
+        registry.register(action: Self.aiPreset("ai.preset.proofread"))
+        registry.register(action: Self.aiPreset("ai.preset.rewrite"))
+
+        XCTAssertEqual(registry.actions.map(\.id),
+                       ["builtin.cut", "builtin.copy", "builtin.aiTools", "ai.preset.proofread", "ai.preset.rewrite"])
+
+        // Drag AI Tools to the top, exactly as the Preferences outline does (indices into `actions`).
+        let launcherIndex = registry.actions.firstIndex { $0.id == "builtin.aiTools" }!
+        registry.moveActions(from: IndexSet(integer: launcherIndex), to: 0)
+
+        // No re-registration, no restart: the presets follow immediately.
+        XCTAssertEqual(registry.actions.map(\.id),
+                       ["builtin.aiTools", "ai.preset.proofread", "ai.preset.rewrite", "builtin.cut", "builtin.copy"])
+        XCTAssertEqual(Self.palette(registry),
+                       ["ai.preset.proofread", "ai.preset.rewrite", "builtin.cut", "builtin.copy"])
+        // The persisted order stays free of derived rows.
+        XCTAssertEqual(store.get(.actionOrder), ["builtin.aiTools", "builtin.cut", "builtin.copy"])
+    }
+
+    /// Moving an ordinary row still lands exactly where it was dropped.
+    @MainActor
+    func testMovingAnOrdinaryActionIsAppliedImmediately() {
+        let store = MemorySettingsStore()
+        store.set(.actionOrder, value: ["builtin.cut", "builtin.copy", "builtin.search"])
+        let registry = ActionRegistry(settingsStore: store)
+        registry.register(builtIns: [
+            MockAction(id: "builtin.cut", shouldBeEnabled: true),
+            MockAction(id: "builtin.copy", shouldBeEnabled: true),
+            MockAction(id: "builtin.search", shouldBeEnabled: true)
+        ])
+
+        registry.moveActions(from: IndexSet(integer: 2), to: 0)
+
+        XCTAssertEqual(registry.actions.map(\.id), ["builtin.search", "builtin.cut", "builtin.copy"])
+        XCTAssertEqual(store.get(.actionOrder), ["builtin.search", "builtin.cut", "builtin.copy"])
+    }
+
     @MainActor
     func testUnorderedBuiltinActionsPreserveStableInsertionOrder() {
         let store = MemorySettingsStore()

--- a/Tests/OpenClipTests/HotkeyManagerTests.swift
+++ b/Tests/OpenClipTests/HotkeyManagerTests.swift
@@ -3,10 +3,11 @@ import AppKit
 @testable import OpenClip
 @testable import Core
 
-/// Regression coverage for the hotkey trigger path: ⌥⌘C must obey the same gating every mouse/
-/// keyboard monitor site applies — the master switch, app exclusion (including OpenClip itself),
-/// and the text substantiality/length contract — instead of retrieving and injecting a synthetic
-/// ⌘C into any frontmost app unconditionally.
+/// Regression coverage for the hotkey trigger path: ⌥⌘C must obey the gating that actually
+/// applies to an explicit request — Pause, app exclusion (including OpenClip itself), per-app
+/// `disabled` rules, and the text substantiality/length contract — instead of retrieving and
+/// injecting a synthetic ⌘C into any frontmost app unconditionally. "Appear Automatically" is
+/// **not** one of those gates: it owns the automatic popup only.
 @MainActor
 final class HotkeyManagerTests: XCTestCase {
     override func setUp() async throws {
@@ -14,44 +15,44 @@ final class HotkeyManagerTests: XCTestCase {
         await MainActor.run { TestIsolation.reset() }
     }
 
-    func testDisabledAppNeverTriggers() {
-        XCTAssertFalse(HotkeyManager.triggerAllowed(
-            isAppEnabled: false,
-            frontmost: NSRunningApplication()
-        ))
+    /// "Appear Automatically" off means the popup stops following selections — the shortcut is an
+    /// explicit request and must still work. It used to be gated on the same setting, so the
+    /// hotkey silently did nothing whenever the toggle was off.
+    func testAutomaticAppearanceOffStillAllowsTheHotkey() {
+        let store = MemorySettingsStore()
+        store.set(.isAppEnabled, value: false)
+        let app = MockFrontmostApp(bundleID: "com.apple.TextEdit")
+        XCTAssertTrue(HotkeyManager.triggerAllowed(frontmost: app, settingsStore: store))
     }
 
     func testNoIdentifiableTargetNeverTriggers() {
         // Covers both a nil frontmost app and one without a bundle ID: previously this fell back
         // to OpenClip itself.
-        XCTAssertFalse(HotkeyManager.triggerAllowed(isAppEnabled: true, frontmost: nil))
-        XCTAssertFalse(HotkeyManager.triggerAllowed(
-            isAppEnabled: true,
-            frontmost: MockFrontmostApp(bundleID: nil)
-        ))
+        XCTAssertFalse(HotkeyManager.triggerAllowed(frontmost: nil))
+        XCTAssertFalse(HotkeyManager.triggerAllowed(frontmost: MockFrontmostApp(bundleID: nil)))
     }
 
     func testExcludedAppsNeverTrigger() {
         // A bundle from AppFilter's exclusion list must be rejected even when enabled.
         let excluded = MockFrontmostApp(bundleID: "com.adobe.photoshop")
-        XCTAssertFalse(HotkeyManager.triggerAllowed(isAppEnabled: true, frontmost: excluded))
+        XCTAssertFalse(HotkeyManager.triggerAllowed(frontmost: excluded))
     }
 
     func testAppWithDisabledRuleNeverTriggers() {
         RuleEngine.shared.addOrUpdateRule(AppRule(bundleIdentifiers: ["com.test.disabled"], disabled: true))
         let app = MockFrontmostApp(bundleID: "com.test.disabled")
-        XCTAssertFalse(HotkeyManager.triggerAllowed(isAppEnabled: true, frontmost: app))
+        XCTAssertFalse(HotkeyManager.triggerAllowed(frontmost: app))
     }
 
     func testAppWithHotkeyOnlyRuleTriggers() {
         RuleEngine.shared.addOrUpdateRule(AppRule(bundleIdentifiers: ["com.test.hotkeyonly"], hotkeyOnly: true))
         let app = MockFrontmostApp(bundleID: "com.test.hotkeyonly")
-        XCTAssertTrue(HotkeyManager.triggerAllowed(isAppEnabled: true, frontmost: app))
+        XCTAssertTrue(HotkeyManager.triggerAllowed(frontmost: app))
     }
 
     func testOrdinaryForegroundAppTriggers() {
         let ordinary = MockFrontmostApp(bundleID: "com.apple.TextEdit")
-        XCTAssertTrue(HotkeyManager.triggerAllowed(isAppEnabled: true, frontmost: ordinary))
+        XCTAssertTrue(HotkeyManager.triggerAllowed(frontmost: ordinary))
     }
 
     func testPauseUntilTimestampBlocksTrigger() {
@@ -60,15 +61,15 @@ final class HotkeyManagerTests: XCTestCase {
 
         // Unpaused: allowed
         store.set(.pauseUntilTimestamp, value: 0.0)
-        XCTAssertTrue(HotkeyManager.triggerAllowed(isAppEnabled: true, frontmost: app, settingsStore: store))
+        XCTAssertTrue(HotkeyManager.triggerAllowed(frontmost: app, settingsStore: store))
 
         // Paused in future: blocked
         store.set(.pauseUntilTimestamp, value: Date().timeIntervalSince1970 + 1800)
-        XCTAssertFalse(HotkeyManager.triggerAllowed(isAppEnabled: true, frontmost: app, settingsStore: store))
+        XCTAssertFalse(HotkeyManager.triggerAllowed(frontmost: app, settingsStore: store))
 
         // Expired pause in past: allowed
         store.set(.pauseUntilTimestamp, value: Date().timeIntervalSince1970 - 10)
-        XCTAssertTrue(HotkeyManager.triggerAllowed(isAppEnabled: true, frontmost: app, settingsStore: store))
+        XCTAssertTrue(HotkeyManager.triggerAllowed(frontmost: app, settingsStore: store))
     }
 }
 

--- a/Tests/OpenClipTests/MacSelectionMonitorTests.swift
+++ b/Tests/OpenClipTests/MacSelectionMonitorTests.swift
@@ -12,6 +12,35 @@ final class MacSelectionMonitorTests: XCTestCase {
         XCTAssertFalse(MacSelectionMonitor.isSelectionTrigger(keyCode: 0x00, flags: []))
     }
 
+    /// ⌘L selects the address bar in a browser and the current line in editors — a selection
+    /// gesture like any other, and one that produced no popup at all before.
+    func testCommandLTriggersSelectionRetrieval() {
+        XCTAssertTrue(MacSelectionMonitor.isSelectionTrigger(keyCode: 0x25, flags: [.command]))
+        XCTAssertTrue(MacSelectionMonitor.isSelectAllKey(keyCode: 0x25, flags: [.command]),
+                      "⌘L selects a whole container, so it must be gated like ⌘A")
+        XCTAssertFalse(MacSelectionMonitor.isSelectionTrigger(keyCode: 0x25, flags: []))
+        XCTAssertFalse(MacSelectionMonitor.isSelectionTrigger(keyCode: 0x25, flags: [.command, .shift]))
+    }
+
+    /// ⇧+Home/End/Page Up/Page Down extend a selection exactly like ⇧+arrow, just by a bigger
+    /// stride. They carry `.function` in their modifier flags, which the normalization strips.
+    func testShiftJumpKeysExtendSelection() {
+        for keyCode: UInt16 in [0x73, 0x77, 0x74, 0x79] {   // home / end / page up / page down
+            XCTAssertTrue(MacSelectionMonitor.isSelectionTrigger(keyCode: keyCode, flags: [.shift, .function]),
+                          "⇧ + keyCode \(keyCode) must count as extending the selection")
+            XCTAssertTrue(MacSelectionMonitor.isSelectionTrigger(keyCode: keyCode, flags: [.shift, .command, .function]))
+            XCTAssertFalse(MacSelectionMonitor.isSelectionTrigger(keyCode: keyCode, flags: [.function]),
+                           "without Shift these only move the caret")
+        }
+    }
+
+    /// ⌘A is a whole-container gesture; a plain ⌘-something else is not a selection gesture at all.
+    func testOnlySelectAllAndLocationAreWholeContainerGestures() {
+        XCTAssertTrue(MacSelectionMonitor.isSelectAllKey(keyCode: 0x00, flags: [.command]))
+        XCTAssertFalse(MacSelectionMonitor.isSelectAllKey(keyCode: 0x08, flags: [.command]))   // ⌘C
+        XCTAssertFalse(MacSelectionMonitor.isSelectAllKey(keyCode: 0x00, flags: [.command, .option]))
+    }
+
     // MARK: - Keyboard anchor selection (⌘A popup placement)
 
     /// Regression: a ⌘A select-all spans the whole document, so anchoring at its top-left corner

--- a/Tests/OpenClipTests/PaletteAIRunTests.swift
+++ b/Tests/OpenClipTests/PaletteAIRunTests.swift
@@ -1,0 +1,92 @@
+import XCTest
+import AppKit
+import SwiftUI
+import Core
+@testable import OpenClip
+
+/// Running an AI preset from the search palette. The popup's AI flow snapshots the selection and
+/// dismisses the popup itself, so the palette must not dismiss first: a palette opened straight
+/// from the hotkey is *hidden* by exiting search, which clears the action context, and the preset
+/// then never ran ("Cannot run AI preset: currentActionContext is nil"). From the bar the same
+/// exit only returned to the bar, which is why AI appeared to work there.
+@MainActor
+final class PaletteAIRunTests: XCTestCase {
+    private final class Recorder {
+        var events: [String] = []
+    }
+
+    private func aiPreset(_ id: String) -> MockAction {
+        MockAction(id: id, shouldBeEnabled: true,
+                   chrome: ActionChrome(badge: .none, rowStyle: .standard, popupBehavior: .perform, source: .ai))
+    }
+
+    private func context() -> ActionContext {
+        let selection = SelectionContext(
+            text: "hello world",
+            sourceApp: AppIdentity(bundleIdentifier: "com.test", localizedName: "Test"),
+            cursorPosition: .zero,
+            timestamp: Date(),
+            appPolicy: .default
+        )
+        return ActionContext(selection: selection, modifiers: [])
+    }
+
+    /// Drives the production view stack: PopupView in search mode, the row picked with ⌘1.
+    private func runFirstPaletteRow(recorder: Recorder) throws {
+        let store = PopupModeStore()
+        store.mode = .search
+        let view = PopupView(
+            actions: [],
+            allActions: [],
+            context: context(),
+            modeStore: store,
+            onExitSearch: { recorder.events.append("exit-search") },
+            onResult: { _ in recorder.events.append("result") },
+            onRunAI: { _ in recorder.events.append("run-ai") }
+        )
+        .environment(\.colorScheme, .dark)
+
+        let host = NSHostingView(rootView: AnyView(view))
+        host.layoutSubtreeIfNeeded()
+        let panel = PopupPanel()
+        panel.allowsKey = true
+        panel.contentView = host
+        panel.setFrame(NSRect(x: 300, y: 300, width: 360, height: 320), display: true)
+        panel.makeKeyAndOrderFront(nil)
+        defer { panel.orderOut(nil) }
+        RunLoop.current.run(until: Date().addingTimeInterval(0.6))
+
+        let event = try XCTUnwrap(NSEvent.keyEvent(
+            with: .keyDown, location: .zero, modifierFlags: [.command],
+            timestamp: ProcessInfo.processInfo.systemUptime, windowNumber: panel.windowNumber,
+            context: nil, characters: "1", charactersIgnoringModifiers: "1", isARepeat: false, keyCode: 18
+        ))
+        XCTAssertTrue(panel.performKeyEquivalent(with: event), "⌘1 must reach the palette")
+        RunLoop.current.run(until: Date().addingTimeInterval(0.3))
+    }
+
+    func testAIPresetRunsAndIsNotPrecededByASearchExit() throws {
+        TestIsolation.reset()
+        defer { TestIsolation.reset() }
+        ActionRegistry.shared.register(action: aiPreset("ai.preset.proofread"))
+
+        let recorder = Recorder()
+        try runFirstPaletteRow(recorder: recorder)
+
+        XCTAssertEqual(recorder.events, ["run-ai"],
+                       "the AI flow must run, and nothing may dismiss the popup before it snapshots the selection")
+    }
+
+    /// The ordinary path is unchanged: a non-AI action still performs and reports its result.
+    func testOrdinaryActionStillPerformsFromThePalette() throws {
+        TestIsolation.reset()
+        defer { TestIsolation.reset() }
+        ActionRegistry.shared.register(action: MockAction(id: "mock.plain", shouldBeEnabled: true))
+
+        let recorder = Recorder()
+        try runFirstPaletteRow(recorder: recorder)
+
+        XCTAssertEqual(recorder.events, ["result"])
+        XCTAssertFalse(recorder.events.contains("run-ai"))
+    }
+}

--- a/Tests/OpenClipTests/PaletteShortcutTests.swift
+++ b/Tests/OpenClipTests/PaletteShortcutTests.swift
@@ -146,6 +146,55 @@ final class PaletteShortcutTests: XCTestCase {
                       "⌘1 must be consumed inside the real palette panel — an unhandled key equivalent beeps")
     }
 
+    /// The monitor hook is what actually delivers the shortcut in the running app: AppKit never
+    /// runs its key-equivalent phase for a non-activating panel of an inactive app, so the
+    /// controller runs it by hand and swallows the event.
+    func testControllerConsumesCommandDigitsOnlyWhileThePaletteIsOpen() throws {
+        TestIsolation.reset()
+        defer { TestIsolation.reset() }
+        ActionRegistry.shared.register(action: makeAction("mock.palette.row"))
+
+        let store = MemorySettingsStore()
+        let isolatedPasteboard = NSPasteboard(name: NSPasteboard.Name("OpenClipTest-\(UUID().uuidString)"))
+        let controller = PopupWindowController(
+            resultHandler: DefaultActionResultHandler(pasteboard: isolatedPasteboard),
+            settingsStore: store
+        )
+        let screenBounds = (NSScreen.main ?? NSScreen.screens.first)?.visibleFrame
+            ?? NSRect(x: 0, y: 0, width: 800, height: 600)
+        let selection = SelectionContext(
+            text: "hello world",
+            sourceApp: AppIdentity(bundleIdentifier: "com.test", localizedName: "Test"),
+            cursorPosition: CGPoint(x: screenBounds.midX, y: screenBounds.midY),
+            timestamp: Date(),
+            appPolicy: .default
+        )
+
+        func commandDigit(_ characters: String) throws -> NSEvent {
+            try XCTUnwrap(NSEvent.keyEvent(
+                with: .keyDown, location: .zero, modifierFlags: [.command],
+                timestamp: ProcessInfo.processInfo.systemUptime, windowNumber: 0,
+                context: nil, characters: characters, charactersIgnoringModifiers: characters,
+                isARepeat: false, keyCode: 18
+            ))
+        }
+
+        // Nothing on screen: the key belongs to whatever the user is working in.
+        XCTAssertFalse(controller.consumesPaletteShortcut(try commandDigit("1")))
+
+        controller.show(for: selection, pasteAvailable: true, initialMode: .search)
+        defer { controller.hide() }
+        RunLoop.current.run(until: Date().addingTimeInterval(0.6))
+        XCTAssertTrue(controller.consumesPaletteShortcut(try commandDigit("1")),
+                      "the palette must claim ⌘1 so it never reaches the source app or beeps")
+        XCTAssertFalse(controller.consumesPaletteShortcut(try commandDigit("a")),
+                       "only digits — ⌘A stays the source app's")
+
+        controller.hide()
+        XCTAssertFalse(controller.consumesPaletteShortcut(try commandDigit("1")),
+                       "a dismissed palette claims nothing")
+    }
+
     /// A digit past the end of the list does nothing at all — no run, no crash.
     func testCommandDigitBeyondTheResultsDoesNothing() throws {
         let recorder = Recorder()
@@ -174,10 +223,10 @@ final class PaletteShortcutTests: XCTestCase {
             timestamp: ProcessInfo.processInfo.systemUptime, windowNumber: panel.windowNumber,
             context: nil, characters: "5", charactersIgnoringModifiers: "5", isARepeat: false, keyCode: 23
         ))
-        XCTAssertFalse(panel.performKeyEquivalent(with: event),
-                       "a digit past the results must fall through, not be swallowed")
+        XCTAssertTrue(panel.performKeyEquivalent(with: event),
+                      "while the palette is open ⌘-digits are its own — claimed even with no such row, so the key never beeps or leaks to the app underneath")
         RunLoop.current.run(until: Date().addingTimeInterval(0.3))
 
-        XCTAssertTrue(recorder.performed.isEmpty)
+        XCTAssertTrue(recorder.performed.isEmpty, "but nothing runs")
     }
 }

--- a/Tests/OpenClipTests/PaletteShortcutTests.swift
+++ b/Tests/OpenClipTests/PaletteShortcutTests.swift
@@ -6,10 +6,14 @@ import Core
 
 /// ⌘1…⌘9 select a palette row outright.
 ///
-/// These tests drive `performKeyEquivalent` — the path `NSApplication` actually uses for a
-/// command-modified key. An earlier version of this suite called `panel.sendEvent`, which skips
-/// the key-equivalent dispatch and delivers straight to `keyDown:`; it passed while the shipped
-/// app only beeped, because SwiftUI's `onKeyPress` never sees a ⌘-digit.
+/// Delivery is by *global* hot key (`PaletteRowShortcuts`): a ⌘-digit is routed by macOS to the
+/// active application, and the popup is a non-activating panel of an app that is never active, so
+/// the keystroke never enters this process — no event monitor and no `performKeyEquivalent` on
+/// the panel can see it. Two earlier attempts failed exactly there, each with a test that passed:
+/// the first drove `panel.sendEvent` (which skips key-equivalent dispatch entirely), the second
+/// drove `performKeyEquivalent` by hand (which nothing calls in the real app). The tests below
+/// cover what is testable in-process — the row lookup and the parsing — and the routing itself is
+/// carried by the same Carbon mechanism as the ⌥⌘C trigger.
 @MainActor
 final class PaletteShortcutTests: XCTestCase {
     private final class Recorder {
@@ -146,10 +150,9 @@ final class PaletteShortcutTests: XCTestCase {
                       "⌘1 must be consumed inside the real palette panel — an unhandled key equivalent beeps")
     }
 
-    /// The monitor hook is what actually delivers the shortcut in the running app: AppKit never
-    /// runs its key-equivalent phase for a non-activating panel of an inactive app, so the
-    /// controller runs it by hand and swallows the event.
-    func testControllerConsumesCommandDigitsOnlyWhileThePaletteIsOpen() throws {
+    /// The global hot keys deliver a row number, not an event, so the controller has to find the
+    /// live palette and run that row — and must claim nothing when no palette is open.
+    func testControllerRunsPaletteRowsOnlyWhileThePaletteIsOpen() throws {
         TestIsolation.reset()
         defer { TestIsolation.reset() }
         ActionRegistry.shared.register(action: makeAction("mock.palette.row"))
@@ -170,29 +173,55 @@ final class PaletteShortcutTests: XCTestCase {
             appPolicy: .default
         )
 
-        func commandDigit(_ characters: String) throws -> NSEvent {
-            try XCTUnwrap(NSEvent.keyEvent(
-                with: .keyDown, location: .zero, modifierFlags: [.command],
-                timestamp: ProcessInfo.processInfo.systemUptime, windowNumber: 0,
-                context: nil, characters: characters, charactersIgnoringModifiers: characters,
-                isARepeat: false, keyCode: 18
-            ))
-        }
-
-        // Nothing on screen: the key belongs to whatever the user is working in.
-        XCTAssertFalse(controller.consumesPaletteShortcut(try commandDigit("1")))
+        // Nothing on screen: the keys belong to whatever the user is working in.
+        XCTAssertFalse(controller.runPaletteRow(1))
 
         controller.show(for: selection, pasteAvailable: true, initialMode: .search)
         defer { controller.hide() }
         RunLoop.current.run(until: Date().addingTimeInterval(0.6))
-        XCTAssertTrue(controller.consumesPaletteShortcut(try commandDigit("1")),
-                      "the palette must claim ⌘1 so it never reaches the source app or beeps")
-        XCTAssertFalse(controller.consumesPaletteShortcut(try commandDigit("a")),
-                       "only digits — ⌘A stays the source app's")
+
+        XCTAssertTrue(controller.runPaletteRow(1), "⌘1 must reach the live palette's first row")
+        XCTAssertFalse(controller.runPaletteRow(9), "a row that is not there runs nothing")
 
         controller.hide()
-        XCTAssertFalse(controller.consumesPaletteShortcut(try commandDigit("1")),
-                       "a dismissed palette claims nothing")
+        XCTAssertFalse(controller.runPaletteRow(1), "a dismissed palette runs nothing")
+    }
+
+    /// The keys are held only while a palette is up, so ⌘1…⌘9 belong to every other app the rest
+    /// of the time.
+    func testShortcutsAreHeldOnlyWhileThePaletteIsOpen() throws {
+        TestIsolation.reset()
+        defer { TestIsolation.reset() }
+        PaletteRowShortcuts.setActive(false)
+
+        let store = MemorySettingsStore()
+        let isolatedPasteboard = NSPasteboard(name: NSPasteboard.Name("OpenClipTest-\(UUID().uuidString)"))
+        let controller = PopupWindowController(
+            resultHandler: DefaultActionResultHandler(pasteboard: isolatedPasteboard),
+            settingsStore: store
+        )
+        let selection = SelectionContext(
+            text: "hello world",
+            sourceApp: AppIdentity(bundleIdentifier: "com.test", localizedName: "Test"),
+            cursorPosition: CGPoint(x: 400, y: 400),
+            timestamp: Date(),
+            appPolicy: .default
+        )
+
+        controller.show(for: selection, pasteAvailable: true, initialMode: .actions)
+        defer { controller.hide() }
+        XCTAssertFalse(PaletteRowShortcuts.isActive, "the bar does not use row shortcuts")
+
+        controller.enterSearch()
+        XCTAssertTrue(PaletteRowShortcuts.isActive, "the palette takes ⌘1…⌘9 while it is open")
+
+        controller.exitSearch()
+        XCTAssertFalse(PaletteRowShortcuts.isActive, "leaving search hands them back")
+
+        controller.enterSearch()
+        XCTAssertTrue(PaletteRowShortcuts.isActive)
+        controller.hide()
+        XCTAssertFalse(PaletteRowShortcuts.isActive, "and so does dismissing the popup")
     }
 
     /// A digit past the end of the list does nothing at all — no run, no crash.

--- a/Tests/OpenClipTests/PaletteShortcutTests.swift
+++ b/Tests/OpenClipTests/PaletteShortcutTests.swift
@@ -1,0 +1,119 @@
+import XCTest
+import AppKit
+import SwiftUI
+import Core
+@testable import OpenClip
+
+/// ⌘1…⌘9 select a palette row outright. The keys are attached to the palette's focused field, so
+/// they exist only while the palette is open — pressing ⌘2 anywhere else is none of OpenClip's
+/// business.
+@MainActor
+final class PaletteShortcutTests: XCTestCase {
+    private final class Recorder {
+        var performed: [String] = []
+    }
+
+    private func makeAction(_ id: String) -> MockAction {
+        MockAction(id: id, shouldBeEnabled: true)
+    }
+
+    private func context() -> ActionContext {
+        let selection = SelectionContext(
+            text: "hello world",
+            sourceApp: AppIdentity(bundleIdentifier: "com.test", localizedName: "Test"),
+            cursorPosition: .zero,
+            timestamp: Date(),
+            appPolicy: .default
+        )
+        return ActionContext(selection: selection, modifiers: [])
+    }
+
+    func testShortcutHintsCoverTheFirstNineRowsOnly() {
+        XCTAssertEqual(PopupSearchView.shortcutHint(forRow: 0), "⌘1")
+        XCTAssertEqual(PopupSearchView.shortcutHint(forRow: 8), "⌘9")
+        XCTAssertNil(PopupSearchView.shortcutHint(forRow: 9), "the tenth row has no shortcut")
+        XCTAssertNil(PopupSearchView.shortcutHint(forRow: 40))
+        XCTAssertNil(PopupSearchView.shortcutHint(forRow: -1))
+        XCTAssertEqual(PopupSearchView.maxShortcutRows, 9)
+    }
+
+    /// End-to-end: a real key window hosting the palette, a synthetic ⌘2, and the *second* row's
+    /// action runs. This is the part that a pure test cannot cover — whether the keystroke ever
+    /// reaches the field's key handler.
+    func testCommandDigitRunsThatRow() throws {
+        let recorder = Recorder()
+        let catalog: [any Action] = ["mock.first", "mock.second", "mock.third"].map { makeAction($0) }
+        let palette = PopupSearchView(
+            catalog: catalog,
+            context: context(),
+            resultsAbove: false,
+            onResult: { _ in },
+            onExit: {},
+            onActionPerformed: { recorder.performed.append($0) }
+        )
+        .environment(\.colorScheme, .dark)
+
+        let host = NSHostingView(rootView: AnyView(palette))
+        host.layoutSubtreeIfNeeded()
+        let size = host.fittingSize
+        let panel = PopupPanel()
+        panel.allowsKey = true
+        panel.contentView = host
+        panel.setFrame(NSRect(x: 300, y: 300, width: max(size.width, 320), height: max(size.height, 200)), display: true)
+        panel.makeKeyAndOrderFront(nil)
+        defer { panel.orderOut(nil) }
+        RunLoop.current.run(until: Date().addingTimeInterval(0.5))
+
+        let event = try XCTUnwrap(NSEvent.keyEvent(
+            with: .keyDown,
+            location: .zero,
+            modifierFlags: [.command],
+            timestamp: ProcessInfo.processInfo.systemUptime,
+            windowNumber: panel.windowNumber,
+            context: nil,
+            characters: "2",
+            charactersIgnoringModifiers: "2",
+            isARepeat: false,
+            keyCode: 19   // kVK_ANSI_2
+        ))
+        panel.sendEvent(event)
+        RunLoop.current.run(until: Date().addingTimeInterval(0.3))
+
+        XCTAssertEqual(recorder.performed, ["mock.second"],
+                       "⌘2 must run the second row, not the selected one")
+    }
+
+    /// A digit past the end of the list does nothing at all — no run, no crash.
+    func testCommandDigitBeyondTheResultsDoesNothing() throws {
+        let recorder = Recorder()
+        let palette = PopupSearchView(
+            catalog: [makeAction("mock.only")],
+            context: context(),
+            resultsAbove: false,
+            onResult: { _ in },
+            onExit: {},
+            onActionPerformed: { recorder.performed.append($0) }
+        )
+        .environment(\.colorScheme, .dark)
+
+        let host = NSHostingView(rootView: AnyView(palette))
+        host.layoutSubtreeIfNeeded()
+        let panel = PopupPanel()
+        panel.allowsKey = true
+        panel.contentView = host
+        panel.setFrame(NSRect(x: 300, y: 300, width: 320, height: 200), display: true)
+        panel.makeKeyAndOrderFront(nil)
+        defer { panel.orderOut(nil) }
+        RunLoop.current.run(until: Date().addingTimeInterval(0.5))
+
+        let event = try XCTUnwrap(NSEvent.keyEvent(
+            with: .keyDown, location: .zero, modifierFlags: [.command],
+            timestamp: ProcessInfo.processInfo.systemUptime, windowNumber: panel.windowNumber,
+            context: nil, characters: "5", charactersIgnoringModifiers: "5", isARepeat: false, keyCode: 23
+        ))
+        panel.sendEvent(event)
+        RunLoop.current.run(until: Date().addingTimeInterval(0.3))
+
+        XCTAssertTrue(recorder.performed.isEmpty)
+    }
+}

--- a/Tests/OpenClipTests/PaletteShortcutTests.swift
+++ b/Tests/OpenClipTests/PaletteShortcutTests.swift
@@ -4,9 +4,12 @@ import SwiftUI
 import Core
 @testable import OpenClip
 
-/// ⌘1…⌘9 select a palette row outright. The keys are attached to the palette's focused field, so
-/// they exist only while the palette is open — pressing ⌘2 anywhere else is none of OpenClip's
-/// business.
+/// ⌘1…⌘9 select a palette row outright.
+///
+/// These tests drive `performKeyEquivalent` — the path `NSApplication` actually uses for a
+/// command-modified key. An earlier version of this suite called `panel.sendEvent`, which skips
+/// the key-equivalent dispatch and delivers straight to `keyDown:`; it passed while the shipped
+/// app only beeped, because SwiftUI's `onKeyPress` never sees a ⌘-digit.
 @MainActor
 final class PaletteShortcutTests: XCTestCase {
     private final class Recorder {
@@ -26,6 +29,27 @@ final class PaletteShortcutTests: XCTestCase {
             appPolicy: .default
         )
         return ActionContext(selection: selection, modifiers: [])
+    }
+
+    /// Only plain ⌘ + 1...9 counts: a bare digit types into the field, and ⌘⌥/⌘⇧/⌃ combinations
+    /// belong to somebody else.
+    func testCommandDigitParsing() throws {
+        func event(_ characters: String, _ flags: NSEvent.ModifierFlags) throws -> NSEvent {
+            try XCTUnwrap(NSEvent.keyEvent(
+                with: .keyDown, location: .zero, modifierFlags: flags, timestamp: 0, windowNumber: 0,
+                context: nil, characters: characters, charactersIgnoringModifiers: characters,
+                isARepeat: false, keyCode: 0
+            ))
+        }
+        XCTAssertEqual(PopupSearchView.commandDigitRow(for: try event("1", [.command])), 1)
+        XCTAssertEqual(PopupSearchView.commandDigitRow(for: try event("9", [.command])), 9)
+        XCTAssertEqual(PopupSearchView.commandDigitRow(for: try event("3", [.command, .capsLock])), 3,
+                       "caps lock rides along in every event and must not disarm the shortcut")
+        XCTAssertNil(PopupSearchView.commandDigitRow(for: try event("0", [.command])), "⌘0 is not a row")
+        XCTAssertNil(PopupSearchView.commandDigitRow(for: try event("2", [])), "a bare digit types")
+        XCTAssertNil(PopupSearchView.commandDigitRow(for: try event("2", [.command, .option])))
+        XCTAssertNil(PopupSearchView.commandDigitRow(for: try event("2", [.command, .shift])))
+        XCTAssertNil(PopupSearchView.commandDigitRow(for: try event("a", [.command])))
     }
 
     func testShortcutHintsCoverTheFirstNineRowsOnly() {
@@ -76,11 +100,50 @@ final class PaletteShortcutTests: XCTestCase {
             isARepeat: false,
             keyCode: 19   // kVK_ANSI_2
         ))
-        panel.sendEvent(event)
+        XCTAssertTrue(panel.performKeyEquivalent(with: event),
+                      "the palette must consume ⌘2 — an unhandled key equivalent is what beeps")
         RunLoop.current.run(until: Date().addingTimeInterval(0.3))
 
         XCTAssertEqual(recorder.performed, ["mock.second"],
                        "⌘2 must run the second row, not the selected one")
+    }
+
+    /// The production stack, not a hand-built palette: the controller's real panel, PopupView and
+    /// palette, asked through the same `performKeyEquivalent` entry point `NSApplication` uses.
+    /// This is what proves the catcher is reachable inside the app's actual view tree.
+    func testCommandDigitIsConsumedByTheRealPalettePanel() throws {
+        TestIsolation.reset()
+        defer { TestIsolation.reset() }
+        ActionRegistry.shared.register(action: makeAction("mock.palette.row"))
+
+        let store = MemorySettingsStore()
+        let isolatedPasteboard = NSPasteboard(name: NSPasteboard.Name("OpenClipTest-\(UUID().uuidString)"))
+        let controller = PopupWindowController(
+            resultHandler: DefaultActionResultHandler(pasteboard: isolatedPasteboard),
+            settingsStore: store
+        )
+        let screenBounds = (NSScreen.main ?? NSScreen.screens.first)?.visibleFrame
+            ?? NSRect(x: 0, y: 0, width: 800, height: 600)
+        let selection = SelectionContext(
+            text: "hello world",
+            sourceApp: AppIdentity(bundleIdentifier: "com.test", localizedName: "Test"),
+            cursorPosition: CGPoint(x: screenBounds.midX, y: screenBounds.midY),
+            timestamp: Date(),
+            appPolicy: .default
+        )
+        controller.show(for: selection, pasteAvailable: true, initialMode: .search)
+        defer { controller.hide() }
+        let panel = try XCTUnwrap(controller.panel)
+        RunLoop.current.run(until: Date().addingTimeInterval(0.6))
+
+        let event = try XCTUnwrap(NSEvent.keyEvent(
+            with: .keyDown, location: .zero, modifierFlags: [.command],
+            timestamp: ProcessInfo.processInfo.systemUptime, windowNumber: panel.windowNumber,
+            context: nil, characters: "1", charactersIgnoringModifiers: "1", isARepeat: false, keyCode: 18
+        ))
+
+        XCTAssertTrue(panel.performKeyEquivalent(with: event),
+                      "⌘1 must be consumed inside the real palette panel — an unhandled key equivalent beeps")
     }
 
     /// A digit past the end of the list does nothing at all — no run, no crash.
@@ -111,7 +174,8 @@ final class PaletteShortcutTests: XCTestCase {
             timestamp: ProcessInfo.processInfo.systemUptime, windowNumber: panel.windowNumber,
             context: nil, characters: "5", charactersIgnoringModifiers: "5", isARepeat: false, keyCode: 23
         ))
-        panel.sendEvent(event)
+        XCTAssertFalse(panel.performKeyEquivalent(with: event),
+                       "a digit past the results must fall through, not be swallowed")
         RunLoop.current.run(until: Date().addingTimeInterval(0.3))
 
         XCTAssertTrue(recorder.performed.isEmpty)

--- a/Tests/OpenClipTests/PopupKeyModeTests.swift
+++ b/Tests/OpenClipTests/PopupKeyModeTests.swift
@@ -166,15 +166,28 @@ final class PopupKeyModeTests: XCTestCase {
         XCTAssertTrue(controller.isVisible, "exitSearch on a bar session must keep the popup visible")
     }
 
-    func testDirectSearchSessionCentersOnScreen() {
+    /// A palette opened straight from the hotkey is placed like the bar the mouse opens: anchored
+    /// on the selection, honoring the placement preferences. (It used to be centred on the main
+    /// screen — this test asserted that, and the centring is what the user saw as the palette
+    /// appearing nowhere near their text.)
+    func testDirectSearchSessionIsAnchoredOnTheSelection() {
+        let store = MemorySettingsStore()
+        store.set(.popupAlignment, value: PopupBarAlignment.left.rawValue)
+        store.set(.popupVerticalPosition, value: PopupVerticalPosition.below.rawValue)
         let isolatedPasteboard = NSPasteboard(name: NSPasteboard.Name("OpenClipTest-\(UUID().uuidString)"))
-        let controller = PopupWindowController(resultHandler: DefaultActionResultHandler(pasteboard: isolatedPasteboard))
+        let controller = PopupWindowController(
+            resultHandler: DefaultActionResultHandler(pasteboard: isolatedPasteboard),
+            settingsStore: store
+        )
         defer { controller.hide() }
 
+        let screenBounds = (NSScreen.main ?? NSScreen.screens.first)?.visibleFrame
+            ?? NSRect(x: 0, y: 0, width: 800, height: 600)
+        let cursor = CGPoint(x: screenBounds.minX + 240, y: screenBounds.maxY - 200)
         let context = SelectionContext(
             text: "test selection",
             sourceApp: AppIdentity(bundleIdentifier: "com.test", localizedName: "Test"),
-            cursorPosition: CGPoint(x: 50, y: 50),
+            cursorPosition: cursor,
             timestamp: Date(),
             appPolicy: .default
         )
@@ -186,13 +199,10 @@ final class PopupKeyModeTests: XCTestCase {
             return
         }
 
-        let screen = NSScreen.main ?? PopupPositioner.screen(containing: context.cursorPosition)
-        let screenBounds = screen?.visibleFrame ?? NSRect(x: 0, y: 0, width: 800, height: 600)
-        let expectedX = screenBounds.midX - panel.frame.width / 2
-        let expectedY = screenBounds.midY - panel.frame.height / 2
-
-        XCTAssertEqual(panel.frame.origin.x, expectedX, accuracy: 1.0, "Direct search must be horizontally centered on screen")
-        XCTAssertEqual(panel.frame.origin.y, expectedY, accuracy: 1.0, "Direct search must be vertically centered on screen")
+        XCTAssertEqual(panel.frame.origin.x, cursor.x - PopupPositioner.firstActionCenterOffset, accuracy: 1.0,
+                       "left alignment must anchor the palette on the selection")
+        XCTAssertLessThanOrEqual(panel.frame.maxY, cursor.y,
+                                 "the .below vertical preference must be honored")
     }
 
     func testEnterSearchWithButtonLocalFrameDoesNotExceedBarMaxX() {

--- a/Tests/OpenClipTests/PopupPanelTests.swift
+++ b/Tests/OpenClipTests/PopupPanelTests.swift
@@ -416,6 +416,42 @@ final class PopupPanelTests: XCTestCase {
     }
 
     /// Returns the popup panel after show(for:) has mounted it.
+    /// The shortcut-opened palette must land where the mouse-opened bar would: anchored on the
+    /// selection, honoring the alignment and vertical-position preferences. It used to be centered
+    /// on the main screen, ignoring both.
+    @MainActor
+    func testShortcutPaletteIsAnchoredToTheSelectionNotCentered() throws {
+        guard let screen = NSScreen.main else { throw XCTSkip("no screen") }
+        let visible = screen.visibleFrame
+        let store = MemorySettingsStore()
+        store.set(.popupAlignment, value: PopupBarAlignment.left.rawValue)
+        store.set(.popupVerticalPosition, value: PopupVerticalPosition.below.rawValue)
+        let isolatedPasteboard = NSPasteboard(name: NSPasteboard.Name("OpenClipTest-\(UUID().uuidString)"))
+        let controller = PopupWindowController(
+            resultHandler: DefaultActionResultHandler(pasteboard: isolatedPasteboard),
+            settingsStore: store
+        )
+        // Well away from the screen centre, so "anchored" and "centred" cannot be confused.
+        let cursor = CGPoint(x: visible.minX + 260, y: visible.maxY - 180)
+        let context = SelectionContext(
+            text: "hello world",
+            sourceApp: AppIdentity(bundleIdentifier: "com.test", localizedName: "Test"),
+            cursorPosition: cursor,
+            timestamp: Date(),
+            appPolicy: .default
+        )
+        controller.show(for: context, pasteAvailable: true, initialMode: .search)
+        defer { controller.hide() }
+        let panel = try visiblePanel()
+
+        XCTAssertEqual(panel.frame.minX, cursor.x - PopupPositioner.firstActionCenterOffset, accuracy: 1,
+                       "left alignment must anchor the palette on the selection")
+        XCTAssertLessThanOrEqual(panel.frame.maxY, cursor.y,
+                                 "vertical preference .below must place the palette under the selection")
+        XCTAssertGreaterThan(abs(panel.frame.midX - visible.midX), 100,
+                             "palette is still being centred on screen instead of anchored")
+    }
+
     private func shownPanel(for cursor: CGPoint) throws -> PopupWindowController {
         guard NSScreen.main != nil else { throw XCTSkip("no screen") }
         let isolatedPasteboard = NSPasteboard(name: NSPasteboard.Name("OpenClipTest-\(UUID().uuidString)"))

--- a/Tests/OpenClipTests/PopupPositionerTests.swift
+++ b/Tests/OpenClipTests/PopupPositionerTests.swift
@@ -184,17 +184,6 @@ final class PopupPositionerTests: XCTestCase {
         XCTAssertTrue(PopupPositioner.isPlacedAbove(frame: frame, releasePoint: release))
     }
 
-    func testCenterInScreen() {
-        let screenBounds = CGRect(x: 100, y: 50, width: 800, height: 600)
-        let popupSize = CGSize(width: 300, height: 200)
-        let centered = PopupPositioner.centerInScreen(popupSize: popupSize, screenBounds: screenBounds)
-
-        XCTAssertEqual(centered.origin.x, 100 + (800 - 300) / 2)
-        XCTAssertEqual(centered.origin.y, 50 + (600 - 200) / 2)
-        XCTAssertEqual(centered.width, 300)
-        XCTAssertEqual(centered.height, 200)
-    }
-
     func testSearchPaletteMidXAlignsWithButtonCenterWhenWithinBarEdge() {
         let screenBounds = CGRect(x: 0, y: 0, width: 1000, height: 800)
         let barMaxX: CGFloat = 700

--- a/Tests/OpenClipTests/SelectionRetrievalCoordinatorTests.swift
+++ b/Tests/OpenClipTests/SelectionRetrievalCoordinatorTests.swift
@@ -27,6 +27,25 @@ final class SelectionRetrievalCoordinatorTests: XCTestCase {
         )
     }
 
+    /// An app that exposes no usable AX role for its text (custom-drawn editors/terminals):
+    /// everything the gate could key off is absent.
+    private static func opaqueTarget(containedInRoles: Set<String> = []) -> AXElementInspector.Target {
+        AXElementInspector.Target(
+            focusedApp: nil,
+            focusedElement: nil,
+            role: nil,
+            subRole: nil,
+            parentRoles: [],
+            containedInRoles: containedInRoles,
+            webArea: nil,
+            selectedText: nil,
+            selectedTextMarkerRange: nil,
+            value: nil,
+            selectedTextRange: nil,
+            bounds: nil
+        )
+    }
+
     private static func webAreaTarget(selectedText: String) -> AXElementInspector.Target {
         AXElementInspector.Target(
             focusedApp: nil,
@@ -361,6 +380,58 @@ final class SelectionRetrievalCoordinatorTests: XCTestCase {
             isSelectAll: true
         )
         XCTAssertEqual(result?.text, "captured select-all text")
+    }
+
+    /// Regression (from a real log): in Zed a drag and a ⇧+arrow both retrieved fine through the
+    /// copy strategy one second apart, while ⌘A in the same element was refused — the guard
+    /// demanded a *known* text role, and editors/terminals that draw their own text expose none.
+    /// Only a recognized row container may refuse a select-all now.
+    func testSelectAllProceedsOnAppWithNoRecognizableAXRole() async {
+        let coordinator = SelectionRetrievalCoordinator(
+            inspect: { Self.opaqueTarget() },
+            copyCapture: { _ in TextResult(text: "captured select-all text") }
+        )
+        let policy = AppPolicyContext(retrievalMode: .keyboardCopy)
+        let result = await coordinator.retrieve(
+            for: AppIdentity(bundleIdentifier: "dev.zed.Zed"),
+            policy: policy,
+            cursor: .unknown,
+            isSelectAll: true
+        )
+        XCTAssertEqual(result?.text, "captured select-all text")
+    }
+
+    /// A row container nested above the focused element still refuses — the Finder/Mail case the
+    /// guard exists for reaches it through `containedInRoles`, not the focused role.
+    func testSelectAllSkippedInsideRowContainer() async {
+        let coordinator = SelectionRetrievalCoordinator(
+            inspect: { Self.opaqueTarget(containedInRoles: ["AXScrollArea", "AXOutline"]) },
+            copyCapture: { _ in TextResult(text: "should not copy rows") }
+        )
+        let policy = AppPolicyContext(retrievalMode: .keyboardCopy)
+        let result = await coordinator.retrieve(
+            for: AppIdentity(bundleIdentifier: "com.apple.finder"),
+            policy: policy,
+            cursor: .unknown,
+            isSelectAll: true
+        )
+        XCTAssertNil(result)
+    }
+
+    /// A text field being edited inside a table is text, not a row selection.
+    func testSelectAllProceedsInTextFieldInsideTable() async {
+        let coordinator = SelectionRetrievalCoordinator(
+            inspect: { Self.textFieldTarget(selectedText: "cell text", role: "AXTextField") },
+            copyCapture: { _ in TextResult(text: "cell text") }
+        )
+        let policy = AppPolicyContext(retrievalMode: .keyboardCopy)
+        let result = await coordinator.retrieve(
+            for: AppIdentity(bundleIdentifier: "com.apple.Numbers"),
+            policy: policy,
+            cursor: .unknown,
+            isSelectAll: true
+        )
+        XCTAssertEqual(result?.text, "cell text")
     }
 
     func testSelectAllDoesNotGateNonCopyModes() async {

--- a/docs/architecture/known-debt.md
+++ b/docs/architecture/known-debt.md
@@ -22,8 +22,12 @@ areas; stale debt notes are worse than none.
   `AIServiceManager.cloudAPIKey` is `@Published`, backed by `SecretStore` (account `aiCloudAPIKey`);
   do not convert it back to `@AppStorage`. A one-time migration reads the old `UserDefaults`
   `"aiCloudAPIKey"` key, then deletes it.
-- **`isAppEnabled` is consolidated** onto `SettingKey.isAppEnabled` — status bar, hotkey gate, and
-  the Preferences toggle all read/write through `DefaultSettingsStore`. Builtin store-backed actions
+- **`isAppEnabled` is consolidated** onto `SettingKey.isAppEnabled` — the status bar item and the
+  Preferences toggle read/write it through `DefaultSettingsStore`. It means **"Appear
+  Automatically"** (its label in both places): it owns the selection monitor's automatic popup and
+  nothing else. The ⌥⌘C hotkey is an explicit request and is deliberately *not* gated on it — off
+  is the global form of the per-app `hotkeyOnly` rule. `HotkeyManager.triggerAllowed` gates on the
+  real kill switches instead: Pause (`pauseUntilTimestamp`), app exclusion, per-app `disabled`. Builtin store-backed actions
   (`CalculateAction`, `CalendarAction`, `SearchAction`) accept an injected `SettingsStore` via
   `BuiltinRegistry.makeCoreBuiltins(settingsStore:)`.
 - **Menu bar visibility is store-backed and reversible.** `SettingKey.showMenuBarIcon` defaults to

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -85,7 +85,7 @@ graph TD
 ### 6. Action Coordinator & Composition — [`ActionCoordinator`](../../Sources/Core/Actions/ActionCoordinator.swift)
 - **Responsibility**: Orchestrates initial state loading, registers builtins, and connects disk extensions (including GUI-authored manifest packages) to the central `ActionRegistry`.
 - **Strict Rule**: `ExtensionManager` does not couple directly to the registry; it reports changes through `onRegister`/`onUnregister` callbacks wired by `ActionCoordinator.loadInitialState()`.
-- **Search catalog**: `ActionCoordinator.searchCatalog` (→ `ActionRegistry.searchCatalog`) exposes the **full** registered catalog — enabled and disabled, no context/visibility filtering — for the popup's action-search palette; [`ActionSearch.search`](../../Sources/Core/Actions/ActionSearch.swift) ranks it.
+- **Search catalog**: `ActionCoordinator.searchCatalog` (→ `ActionRegistry.searchCatalog`) exposes what the popup's action-search palette may offer: the registered catalog minus anything switched off in settings (per action, whole package, a disabled group's members, an AI preset toggled off) and minus anything that cannot run against the current context. It is the bar's visibility rules on a flat, unpaginated surface; [`ActionSearch.search`](../../Sources/Core/Actions/ActionSearch.swift) ranks it.
 
 ---
 

--- a/docs/architecture/popup-window.md
+++ b/docs/architecture/popup-window.md
@@ -158,6 +158,11 @@ already visible; the bar's command-glyph button enters search via `onEnterSearch
 - **Escape** clears the query first, then exits to the actions bar. In a **scoped** sub-action
   palette, Escape instead drops the scope (`PopupSearchView.exitSearch()` → `onExitScope`) and
   closes back to the bar.
+- **Row shortcuts**: ⌘1…⌘9 run the first nine rows outright (`PopupSearchView.runRow(at:)`), with
+  the label drawn on the row (`shortcutHint(forRow:)`); rows past the ninth have none, and a digit
+  with no matching row falls through to the field rather than being swallowed. The keys hang off
+  the palette's focused field, so they exist only while the palette is open — alongside the arrows
+  + Return, hover, and click.
 - **Placement is the same for both entry points.** A palette opened directly by the hotkey
   (`show(for:initialMode:.search)`) goes through `PopupPositioner.calculateFrame` /
   `positionPanel` exactly like the bar the mouse opens: anchored on the selection, honoring the

--- a/docs/architecture/popup-window.md
+++ b/docs/architecture/popup-window.md
@@ -158,6 +158,14 @@ already visible; the bar's command-glyph button enters search via `onEnterSearch
 - **Escape** clears the query first, then exits to the actions bar. In a **scoped** sub-action
   palette, Escape instead drops the scope (`PopupSearchView.exitSearch()` → `onExitScope`) and
   closes back to the bar.
+- **Placement is the same for both entry points.** A palette opened directly by the hotkey
+  (`show(for:initialMode:.search)`) goes through `PopupPositioner.calculateFrame` /
+  `positionPanel` exactly like the bar the mouse opens: anchored on the selection, honoring the
+  `popupAlignment` and `popupVerticalPosition` preferences, and clamped to the screen containing
+  the cursor. It used to be centred on the main screen, which ignored both settings and put the
+  palette nowhere near the text. Entering search *from the bar* still re-anchors to the bar
+  instead (`enterSearch(buttonLocalFrame:)` + `preSearchFrame`), so the field opens over the row
+  that was clicked.
 
 ### Scoped Sub-Action Palette
 

--- a/docs/architecture/popup-window.md
+++ b/docs/architecture/popup-window.md
@@ -147,8 +147,13 @@ already visible; the bar's command-glyph button enters search via `onEnterSearch
   store. `PopupView` branches on `modeStore.mode` in `unifiedHStack` and renders
   `PopupSearchView` — the field + result list rendered as **one surface** with the bar, results
   above or below the field by `searchResultsAbove`.
-- **Catalog & matching**: the palette searches the **full** catalog (enabled + disabled, no context
-  filtering) via `ActionCoordinator.searchCatalog` → `ActionRegistry.searchCatalog`; `ActionSearch`
+- **Catalog & matching**: the palette lists what the user can actually run — anything switched off
+  in settings is absent, matching the bar: per-action (`disabledActionIDs`), whole-package
+  (`disabledPackages`), a disabled group (its members go with it, since the palette lists members
+  rather than the row), and an AI preset whose toggle in AI → Actions is off (or with AI disabled
+  wholesale), which `AIAction.isEnabled` reports. Context gating drops the rest
+  (`isEnabled(for:)`, clipboard-fallback vs `requiresLiveSelection`). Via
+  `ActionCoordinator.searchCatalog` → `ActionRegistry.searchCatalog`; `ActionSearch`
   ranks by case-insensitive substring (prefix > contains > keyword). Up to `PopupMetrics.searchMaxRows`
   rows render (`searchMaxRows = 5`, `searchResultRowHeight = 32`, height capped by
   `PopupMetrics.popupMaxHeight`).


### PR DESCRIPTION
## Thinking Path

- I use CMD+A (select all text) or CMD+L (select line) in my Zed editor, which does not trigger OpenClip bar. I dont yet want to submit issue, because I think there is another flow that would work well for me instead (this PR includes fix for this too)
- In settings I change shortcut to my hyperkey (capslock+F, which is in reality CMD+OPT+CTRL+SHIFT+F), and disable setting for bar to appear automatically
- I notice shortcut doesnt work at all to open bar. By playing around I understand it's not problem of specific shortcut (other doesnt work, and mine works if I enable automatic appearing)
- It seems auto-appearing conflicts with shortcut behaviour, which needs to be fixed
- Even when card appears, it appears at middle of screen, not near where my text is (like the small options after selection do)
- I noticed to get to AI grammar fixes from the command pallete card, I need to do down-down-down-down-down-enter, or type "pr"(oofread), and enter. I want just Enter. That triggers search. So I re-order to move Proofread first, and I just enter instead. Moving actions in settings moved them in the card, all, except the AI tools. 
- I noticed Proofread is first, which is what I want, but if someone wanted translare, they would still not be happy. We need ability to order AI tools themselves as well
- If I wanted to use both proofread and translate, I still need to fallback to arrows and enter. It would be nicer to have shortcuts instead for that too
- With all implemented as I wanted, I spotted last tiny detail that command pallete (after hitting shortcut), shows disabled AI tools, so that needs a fix. Same is true for all actions, not just AI tools actions
- During QA of CMD+number feature, notice that AI tools dont work. When used, nothing happens. Same AI tools work from popover, so must be issue with command pallete

^ Above experience results in following fixes:

1. Shortcut to work when "appear automatically" is disabled
2. Shortcuts for text selection still open the bar automatically, like other selection methods (mouse drag, or SHIFT+OPTION+ArrowRight)
3. Card to show near selected text after pressing shortcut, respecting existing settings for placement
4. AI tools placement in actions order settings gets reflected in command pallete card
5. AI tools themselves can now be sorted similar to all other actions
6. Raycast-inspired ability to quick-select option from list by it's location. First=Enter, or CMD+1. Second=CMD+2, Third=CMD+3...
6. Disabled tools and AI tools to not show in command pallete
7. Fix so AI tools used from command pallete work properly

## Development process

PR was made with agents, I am not familiar with Swift programming language.

<details>

<summary>Prompts</summary> 

## Prompts

```
> Previously, the agent has context from this PR: https://github.com/ganeshmshetty/openclip/pull/57

Okay, we are done. Lets switch to second task now.

Lets start from fresh main again, and start a new branch for new feature.

This time, the problem is following:

When I have "Appear automatically" enable in general controls settings, and I press my grigger popup shortcut, everything works great.

But when I have appear automatically disabled, and I press shortcut, nothing happens. Shortcut seems to not be working when "appear automatically" is disabled.
```

```
Install it for me locally
```

```
Selecting text with mouse (dragging) triggers popover with quick options when "appear automatically" is enabled. Similarly, selecting text with SHIFT+OPTION+Right arrow also shows it, or SHIFT+CMD+Right arrow.
But selecting with methods like CMD+A or CMD+L does not show this popover.

Fix this, its a bug. All methods of selecting text should open the popover equally.
```

```
Next, notice we have settings for which actions are enabled/disabled, and extra
configuration for each.

We can also re-order the actions to decide what is higher and what is lower. This order
is then reflected in the popover, as well as command pallete card (shortcut).

But in command pallete there is a bug when "AI tools" placement is ignored and those
tools are always placed at the end.
Make sure that when I have AI tools as first in the list of actions (settings), and I
open command pallete with a shortcut, the AI commands will be correctly placed in the
list, at beginning.
```

```
Sorry but the fix for ordering of AI tools in command pallete is not working.

Notice this screenshot shows configuration of action sorting, where AI tools is enabled
and first in the list: [Image #3]

Then notice that after opening command pallete by pressing shortcut, the list has AI
tools at the end, not at beginning.[Image #4]
```

```
I believe there is still a bug. This time, I think its state management.

Notie this story:

1. I open command pallete, and AI tools are low in the list
2. I go to settings and I move AI tools to first place
3. I open command pallete, and AI tools are STILL low in the list
4. I restart OpenClip
5. Now when I open command pallete, AI tools are at the top of the list

Please fix this bug, make sure settings are applied instantly without need to restart the
application.
```

```
Good job, the sorting is now fixed. But we want a new feature now.

Notice in actons settings, I can drag and drop the actions to reorder them. this order is then respected in all places such as command pallete or popover.

Now notice settings of AI tools. There is list of AI tools under it's actions settings tab, but notie there I can only add, edit or delete them. I cannot drag to reorder them.

Implement this. I want ability to reorder AI tool commands, and I want this order to then be respeted when being rendered.
```

```
Your design is not consistent.

Notice what components are used in "actions" settings to re-order. There is no dragging
icon, and during dragging, blue line indicates gap in which the placement will be.

In your design, there is draggin icon, and It points to row that it will move to, insdead
to indicating gap between rows.

Fix this by making implementation of AI tool sorting more consistant with existing actio
nsorting settings.
```

```
Thanks, next...

Notice this small popover after selecting text appears near the selected text, respecting settings such as horizontal position or vertical position.

But notice that triggering card with actions by pressing a shortcut, the card appears in the middle of the screen.
Fix this by making sure behaviour of placement of the card after pressing shortcut is consistant with behaviour of popover after selecting text, respecging the verticla and horizontal appearrence preferences (configuration settings).
```

```
Nice, next task.

When command pallete is opened, I can use arrows to move around, and press ENTER to select the action. Alternatively, I could move mouse to my action, or scroll to it, and left click it.

Your task is to add one more way of selecting the option from the list.
For each item in the list, add a shortcut. First one will be CMD+1. Second row will be CMD+2. Third row will be CMD+3. And so on, until CMD+9. Remaining options will not have shortcut.
And of course, when shortcut is pressed, run that action.
Those shortcuts only work inside the command pallete, when it is opened.
```

```
The implementaton doesnt seem correct.
When I have the command pallete open, and I press CMD+nmber, like CMD+2, it doesnt work. It also makes a macos sound like if I was in a wrong context.

Double check the focus and if the implementation is tracking CMD+number shortcuts correctly when focusong on the input inside the command pallete.
```

```
It still does not work. In this state, I press CMD+2 and nothing happens, just the sound. [Image #8]

Feel free to take control over my laptop for this test, if it helps, to trigger the card and try the shortcuts.
```

```
While testign this out, I noticed AI actions does not work when used fromcommand pallete, can you fix it? It only seems to be working when used from popover.

I need you to make sure, just like any other actions (copy, cut, paste..) works from command pallete, AI actions like rewrite or proofread also works from command pallete normally.
```

```
The CMD+number still doesnt work. Have you added some logging temporarly? Have ayou seen some issue? I really need this fixed, it works in other software! For example Raccast can do this to pick a command, or Chrome can do this ot switch tabs.
```

```
Works great! Next task:

Notice the ability to disable actions, and in AI tools, even disable specific AI tool actions.

Make sure disabed actions (global or inside ai tools) do not show in the command pallete. Only enabled actions should be visible.
```

```
We are done!

Make sure everything is commited and pushed. Then submit PR towards original repository, not my fork.
Submit it as draft PR and follow PR description template in the repository.
Give me the PR link to fill missing description details.
```

</details>

## Summary

Fixes to the popup/palette trigger and placement paths, plus two palette features. Each commit stands alone:

- **⌥⌘C did nothing when "Appear Automatically" was off** — the hotkey gate read that setting as a master switch, but it owns the automatic popup only (off is the global form of the per-app `hotkeyOnly` rule).
- **⌘A and ⌘L never opened the popup** — the select-all guard required a *known* AX text role, so it refused every app that draws its own text (a drag and ⇧+arrow retrieved fine in the same element); it now refuses only recognized row/list containers. ⌘L and ⇧+Home/End/PageUp/PageDown were missing from the trigger set.
- **AI commands ignored the "AI Tools" position in the palette** — presets inherit their launcher row's placement, and a reorder in Preferences now re-derives immediately instead of applying only after a restart.
- **The shortcut-opened palette was centred on screen**, ignoring the alignment / vertical-position preferences the selection popover honors.
- **AI presets did nothing when picked from the palette** — the palette exited search (which *dismisses* a hotkey-opened palette) before handing off, clearing the action context the AI flow needs.
- **New:** ⌘1…⌘9 run the first nine palette rows. They must be global hot keys: macOS routes ⌘-combos to the active application, and the popup is a non-activating panel of an app that is never active, so the keystroke never enters this process. Held only while the palette is open.
- **New:** AI actions can be reordered by dragging in Preferences → AI → Actions, matching the Actions outline (row is the handle, blue insertion bar in the gap).
- **Disabled actions no longer appear in the palette** — per action, whole package, disabled group members, and AI presets toggled off.

Fixes # <!-- no linked issue -->

---

## Type of Change
- [x] Bug fix (non-breaking change fixing an issue)
- [x] New feature (non-breaking change adding functionality)
- [ ] Extension Runtime / Bridge update (JS host, AppleScript runner, Shell executor)
- [ ] UI / Theme / Accessibility improvement
- [ ] Performance / Concurrency optimization
- [ ] Localization (`Localizable.xcstrings`)
- [ ] Documentation update
- [ ] Build tooling / CI / Scripts

---

## Testing & Verification

### Environment Tested:
- **macOS Version:** macOS 26.5.1
- **Architecture:** Apple Silicon
- **Target Apps Verified:** Zed, Ghostty, Safari/Chrome (⌘A / ⌘L selection paths); Release build installed locally and exercised by hand for every change

### Test Execution:
- [x] Ran `./scripts/test.sh core` (< 1s domain test suite)
- [x] Ran `./scripts/test.sh` — 1096 tests. **Not 0 failures on this machine:** 4 failures, all pre-existing and unrelated (3 locale-dependent `CalculateActionTests`, 1 mouse-position-dependent `PopupPanelTests.testEnterSearchWithButtonAnchorCentersSearchOnButton`); confirmed identical on a clean `upstream/main` worktree.
- [ ] Tested live in app via `./scripts/dev_run.sh` — used a Release build installed to `/Applications` instead.

Notable coverage: `PaletteShortcutTests` (row shortcuts, hot-key scoping), `PaletteAIRunTests` (AI from the palette — verified to fail without the fix), `ActionRegistryTests` (ordering inheritance, immediate reorder, disabled visibility), `MacSelectionMonitorTests` / `SelectionRetrievalCoordinatorTests` (new gestures, select-all guard), `HotkeyManagerTests`. Three registry tests that built `ActionRegistry()` on the *real* preferences domain now use their own store, so the suite no longer depends on (or rewrites) the developer's settings.

---

## Screenshots / Screen Recordings (if applicable)
<!-- To add before merging: palette row shortcuts, AI actions drag-to-reorder. -->

select-popover-fix.mp4:

https://github.com/user-attachments/assets/216b774b-4fa3-46fc-89b8-cc032d95f983

---

appear-and-shortcut-fix.mp4

https://github.com/user-attachments/assets/8f388cfd-b97e-40a2-a36e-80e99dc59deb

---

ai-tools-order-fix.mp4

https://github.com/user-attachments/assets/91219487-581e-49ce-b390-c79708cd3c8b

---

ai-tool-reordering-feature.mp4

https://github.com/user-attachments/assets/872ede90-4a5d-48db-b6fe-de91fe6c81d6

---

relative-pallete-placement.mp4

https://github.com/user-attachments/assets/d379fa49-49de-4e66-8ffe-fd2f6442a6dc

---

cmd-number-shortcut.mp4

https://github.com/user-attachments/assets/6595fac6-4aba-4c24-b5b0-88f7c5ebcdf7

---

fix-disbled-actions.mp4

https://github.com/user-attachments/assets/52a60153-1643-4751-b8b6-cdf1c2d51abd

---

## Architectural & Code Checklist
- [x] **Swift 6 Concurrency:** builds clean under `SWIFT_STRICT_CONCURRENCY: complete`.
- [x] **Core Purity:** `Sources/Core` changes (`ActionRegistry`) import Foundation/Combine only.
- [x] **Settings & Secrets:** no new `UserDefaults.standard`; ordering/visibility go through `SettingsStore`.
- [x] **Subprocess Safety:** n/a — no new subprocesses.
- [x] **Dual-Sink Logging:** no `print()` / ad-hoc `Logger()`; one debug line on the palette hot-key path.
- [x] **Localization:** no new user-facing strings in this branch.

Docs updated: `docs/architecture/popup-window.md`, `docs/architecture/overview.md`, `docs/architecture/known-debt.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Nd1NMfeR42YrKgAkxMtic6


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Run the first nine search-palette results with ⌘1–⌘9 shortcuts.
  - Reorder AI action presets by dragging them in Preferences.
  - Directly opened palettes now appear near the current selection and follow placement settings.
  - Added support for ⌘L and extended keyboard selection gestures.

- **Bug Fixes**
  - AI presets now respect global and individual enablement settings.
  - Disabled actions, packages, groups, and presets are excluded from search results.
  - AI actions remain correctly ordered and run reliably from the palette.
  - Explicit hotkeys continue to work when automatic appearance is disabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->