### PR TITLE
fix(preferences): reuse the Settings window after it is minimised

### DIFF
--- a/Sources/OpenClip/StatusBarController.swift
+++ b/Sources/OpenClip/StatusBarController.swift
@@ -593,8 +593,15 @@ class StatusBarController: NSObject, NSMenuDelegate {
     }
 
     public func showPreferences(tab: PreferenceTab = .general) {
-        if let window = preferencesWindow, window.isVisible {
+        // Reuse the window whatever state it is in. `isVisible` is false for a
+        // miniaturised window, so testing it here built a second Preferences
+        // window every time the user minimised the first one and reopened
+        // Settings from the menu — leaving a stack of them in the Dock.
+        if let window = preferencesWindow {
             notificationCenter.post(name: .openClipSelectPreferencesTab, object: tab)
+            if window.isMiniaturized {
+                window.deminiaturize(nil)
+            }
             window.makeKeyAndOrderFront(nil)
             NSApp.activate(ignoringOtherApps: true)
             return
@@ -606,6 +613,11 @@ class StatusBarController: NSObject, NSMenuDelegate {
         window.styleMask = [.titled, .closable, .miniaturizable, .resizable, .fullSizeContentView]
         window.titlebarAppearsTransparent = true
         window.titleVisibility = .hidden
+        // Closing the window must not deallocate it while `preferencesWindow`
+        // still points at it — the reuse check above reads the window back
+        // after a close, and the default (release on close) makes that a read
+        // of a freed object.
+        window.isReleasedWhenClosed = false
         window.center()
         self.preferencesWindow = window
         window.makeKeyAndOrderFront(nil)


### PR DESCRIPTION
## The bug

Open **Settings** from the menu bar, click the yellow minimise button, then open Settings from the menu bar again — a second Preferences window appears while the first stays in the Dock. Repeat and you get as many Preferences windows as you like.

## Cause

`StatusBarController.showPreferences(tab:)` guards its reuse path with `window.isVisible`. `isVisible` is `false` for a miniaturised window, so the guard falls through and builds a fresh `NSWindow`, overwriting `preferencesWindow` and orphaning the minimised one.

## The fix

- Reuse the stored window whatever state it is in, calling `deminiaturize(nil)` first when it is minimised.
- Set `isReleasedWhenClosed = false` on the window. The reuse check now reads the window back after a close too, and the AppKit default (release on close) would make that a read of a freed object.

Closing and reopening Settings now also restores the same window rather than centring a new one, which matches how System Settings behaves.

## Testing

- `xcodebuild -project OpenClip.xcodeproj -scheme OpenClip -destination 'platform=macOS' build` — succeeds.
- `./scripts/test.sh` — 1063 tests, same single pre-existing failure (`PopupPanelTests.testEnterSearchWithButtonAnchorCentersSearchOnButton`) on `main` with and without this change; nothing else regressed.
- By hand: menu bar → Settings → minimise → menu bar → Settings restores the same window; also checked close → reopen, and switching tabs via the menu (Actions entry) while the window is minimised.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the Preferences window behavior when reopening it after it has been minimized or closed.
  * Preferences now reliably reappear and come to the front instead of creating unnecessary duplicate windows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->