### PR TITLE
fix(preferences): keep the Actions-tab settings editor open while the list updates

### DIFF
--- a/OpenClip.xcodeproj/project.pbxproj
+++ b/OpenClip.xcodeproj/project.pbxproj
@@ -307,6 +307,7 @@
 		E41B0CF982FE94FFB711273A /* PasteAvailability.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B1CAECD556B1DF6245E0DED /* PasteAvailability.swift */; };
 		E4CB48BC0B86980657AD96F0 /* PopupPreview.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7F86844851929D68343D9230 /* PopupPreview.swift */; };
 		E4E9D257A248FF4238EFC61C /* ExtensionManifestTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 042DA17A2486356DBB307B2F /* ExtensionManifestTests.swift */; };
+		E608393D5F9381DF53E10B4E /* ActionSettingsPopover.swift in Sources */ = {isa = PBXBuildFile; fileRef = BECF1DDAD474C3F734FE36E8 /* ActionSettingsPopover.swift */; };
 		E61E4C2DC3230E70EA105D27 /* InstalledAppsScanner.swift in Sources */ = {isa = PBXBuildFile; fileRef = 86C9A6B8F1602DED59E0237E /* InstalledAppsScanner.swift */; };
 		E633AA96EC390407FA06DDC2 /* AboutTabView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 36016F74951C9B2E0CAA6894 /* AboutTabView.swift */; };
 		E6C58D0747EA41DECA6FFFA2 /* ShortcutAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = C612A5C65039CA80623072E4 /* ShortcutAction.swift */; };
@@ -625,6 +626,7 @@
 		BA944AA0BF898427FF2F4784 /* PopupGesturePolicyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PopupGesturePolicyTests.swift; sourceTree = "<group>"; };
 		BB70FC227E05CD8269458C89 /* PopupWindowController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PopupWindowController.swift; sourceTree = "<group>"; };
 		BCD2E8E311CD870FA0E955A9 /* AppIdentifying+NSRunningApplication.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AppIdentifying+NSRunningApplication.swift"; sourceTree = "<group>"; };
+		BECF1DDAD474C3F734FE36E8 /* ActionSettingsPopover.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActionSettingsPopover.swift; sourceTree = "<group>"; };
 		BF33081FB4BA95A0DF2F7A87 /* SecretStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SecretStore.swift; sourceTree = "<group>"; };
 		BFAE9387022DAE9253AC0D77 /* PopupThemeModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PopupThemeModel.swift; sourceTree = "<group>"; };
 		C0A5C800BE48C74A05B33DDA /* GoldenExtensionPlatformTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GoldenExtensionPlatformTests.swift; sourceTree = "<group>"; };
@@ -1132,6 +1134,7 @@
 			children = (
 				36016F74951C9B2E0CAA6894 /* AboutTabView.swift */,
 				4284E18DE06D8BB8FF933E15 /* ActionAppearanceFields.swift */,
+				BECF1DDAD474C3F734FE36E8 /* ActionSettingsPopover.swift */,
 				57D60E95E942E1B268E615D3 /* ActionsOutlineView.swift */,
 				9DF924D3E090E601038084E0 /* ActionsTabView.swift */,
 				F092B5E7205F765F5BBB69A4 /* AddCustomActionSheet.swift */,
@@ -1708,6 +1711,7 @@
 				5A14DE3CC0CA1D776F8A6036 /* ActionIconImageHelper.swift in Sources */,
 				6A92D05EC5B07D80B3C833C3 /* ActionIconView.swift in Sources */,
 				6B40A0FD70FC637EF0736DDC /* ActionResultHandler.swift in Sources */,
+				E608393D5F9381DF53E10B4E /* ActionSettingsPopover.swift in Sources */,
 				36AA21AC4ACFF3351BC40330 /* ActionsOutlineView.swift in Sources */,
 				E34CD08587E1C1A2C1FB1B6B /* ActionsTabView.swift in Sources */,
 				482FF0F2EAC56B62831A0106 /* AddCustomActionSheet.swift in Sources */,

--- a/Sources/OpenClip/UI/Preferences/AITab.swift
+++ b/Sources/OpenClip/UI/Preferences/AITab.swift
@@ -260,10 +260,21 @@ struct EditAIPresetSheet: View {
 @MainActor
 public struct ConfigureAISheet: View {
     @Environment(\.dismiss) private var dismiss
+    /// Set when the editor is shown in the Actions tab's settings popover, which closes itself
+    /// only on request; `nil` when it is presented as a sheet.
+    @Environment(\.popoverDismiss) private var popoverDismiss
     @State private var selectedSubTab: AISubTab
 
     public init(initialSubTab: AISubTab = .configure) {
         _selectedSubTab = State(initialValue: initialSubTab)
+    }
+
+    private func close() {
+        if let popoverDismiss {
+            popoverDismiss()
+        } else {
+            dismiss()
+        }
     }
 
     public var body: some View {
@@ -285,7 +296,7 @@ public struct ConfigureAISheet: View {
 
                 Spacer()
 
-                Button(action: { dismiss() }) {
+                Button(action: { close() }) {
                     Image(systemName: "xmark.circle.fill")
                         .font(.system(size: 15))
                         .foregroundColor(.secondary)

--- a/Sources/OpenClip/UI/Preferences/ActionSettingsPopover.swift
+++ b/Sources/OpenClip/UI/Preferences/ActionSettingsPopover.swift
@@ -1,0 +1,133 @@
+// ActionSettingsPopover.swift
+// OpenClip
+//
+// Presents the per-row settings editors of the Actions preferences tab (AI Tools, custom group,
+// action) in an AppKit `NSPopover` with `.applicationDefined` behavior, so the editor stays open
+// while the user keeps working in the list behind it.
+//
+// SwiftUI's `.popover` is always *transient*: the first click outside it — flipping an action's
+// enable toggle, selecting another row — dismisses it. The outline is also an `NSOutlineView`
+// that reloads its rows on every model change, which tears down the row-hosted view a SwiftUI
+// popover would be anchored to. Anchoring to the window's content view instead keeps the editor
+// alive across both, and it is closed explicitly: the gear again, the editor's own close/save
+// buttons, Escape, or leaving the tab.
+
+import AppKit
+import SwiftUI
+
+// MARK: - Popover Dismissal Environment
+
+/// Closes the settings popover an editor is presented in. `nil` when the same editor is presented
+/// as a sheet instead, in which case the editors fall back to SwiftUI's own `dismiss`.
+private struct PopoverDismissKey: EnvironmentKey {
+    // Computed rather than stored: a `@MainActor` closure is not `Sendable`, so a static stored
+    // property of this type is rejected under strict concurrency.
+    static var defaultValue: (@MainActor () -> Void)? { nil }
+}
+
+extension EnvironmentValues {
+    var popoverDismiss: (@MainActor () -> Void)? {
+        get { self[PopoverDismissKey.self] }
+        set { self[PopoverDismissKey.self] = newValue }
+    }
+}
+
+// MARK: - Anchor
+
+/// Holds the real `NSView` behind a SwiftUI control so the popover can be positioned against it.
+@MainActor
+final class PopoverAnchorBox {
+    weak var view: NSView?
+}
+
+/// Invisible AppKit view planted behind the gear button, purely to supply the anchor rect.
+struct PopoverAnchorView: NSViewRepresentable {
+    let box: PopoverAnchorBox
+
+    func makeNSView(context: Context) -> NSView {
+        let view = NSView()
+        box.view = view
+        return view
+    }
+
+    func updateNSView(_ nsView: NSView, context: Context) {
+        box.view = nsView
+    }
+}
+
+// MARK: - Presenter
+
+@MainActor
+final class ActionSettingsPopover: NSObject, ObservableObject, NSPopoverDelegate {
+    static let shared = ActionSettingsPopover()
+
+    /// Id of the row whose editor is open, so its gear can render in the accent tint.
+    @Published private(set) var openRowID: String?
+
+    private var popover: NSPopover?
+
+    private override init() {
+        super.init()
+    }
+
+    /// Opens `content` for `rowID`, or closes it again when that row's editor is already showing.
+    func toggle(
+        rowID: String,
+        anchor: PopoverAnchorBox,
+        @ViewBuilder content: () -> some View
+    ) {
+        let wasOpen = openRowID == rowID
+        close()
+        guard !wasOpen else { return }
+
+        guard let anchorView = anchor.view, let host = anchorView.window?.contentView else { return }
+        let rect = host.convert(anchorView.bounds, from: anchorView)
+
+        let controller = ActionSettingsHostingController(
+            rootView: AnyView(
+                content().environment(\.popoverDismiss, { [weak self] in self?.close() })
+            )
+        )
+        controller.sizingOptions = [.preferredContentSize]
+        controller.onCancel = { [weak self] in self?.close() }
+
+        let popover = NSPopover()
+        popover.behavior = .applicationDefined
+        popover.delegate = self
+        popover.contentViewController = controller
+        // Size to the SwiftUI content up front; `sizingOptions` keeps it in step afterwards
+        // (the editors grow and shrink as options are revealed).
+        let fitting = controller.view.fittingSize
+        if fitting.width > 0, fitting.height > 0 {
+            popover.contentSize = fitting
+        }
+        popover.show(relativeTo: rect, of: host, preferredEdge: .minX)
+
+        self.popover = popover
+        openRowID = rowID
+    }
+
+    func close() {
+        let presented = popover
+        popover = nil
+        openRowID = nil
+        presented?.performClose(nil)
+    }
+
+    // MARK: NSPopoverDelegate
+
+    func popoverDidClose(_ notification: Notification) {
+        popover = nil
+        openRowID = nil
+    }
+}
+
+/// Hosting controller that routes Escape to closing the popover — `.applicationDefined` popovers
+/// never close on their own.
+private final class ActionSettingsHostingController: NSHostingController<AnyView> {
+    var onCancel: (() -> Void)?
+
+    override func cancelOperation(_ sender: Any?) {
+        onCancel?()
+    }
+}

--- a/Sources/OpenClip/UI/Preferences/ActionsTabView.swift
+++ b/Sources/OpenClip/UI/Preferences/ActionsTabView.swift
@@ -65,6 +65,11 @@ struct ActionsTab: View {
                 EditGroupSheet(groupID: editingGroupID)
             }
         }
+        // The row settings editor is an application-defined popover: it never closes itself, so
+        // it has to go when the tab it belongs to does.
+        .onDisappear {
+            ActionSettingsPopover.shared.close()
+        }
     }
 }
 
@@ -97,8 +102,28 @@ struct ActionRowView: View {
         action.chrome.launchesAI
     }
 
-    @State private var showingConfigSheet = false
     @State private var isHovered = false
+    /// Anchor for the settings editor. It is presented as a non-transient AppKit popover
+    /// (`ActionSettingsPopover`) rather than SwiftUI's `.popover`, so toggling an action in the
+    /// list behind it — or the outline reloading its rows — leaves the editor open.
+    @State private var configAnchor = PopoverAnchorBox()
+    @ObservedObject private var settingsPopover = ActionSettingsPopover.shared
+
+    private var isConfigPopoverOpen: Bool {
+        settingsPopover.openRowID == action.id
+    }
+
+    private func openConfigPopover() {
+        settingsPopover.toggle(rowID: action.id, anchor: configAnchor) {
+            if isAITools {
+                ConfigureAISheet()
+            } else if action.chrome.rowStyle == .actionGroup {
+                EditGroupSheet(groupID: action.id)
+            } else {
+                EditActionSheet(action: action)
+            }
+        }
+    }
 
     var body: some View {
         HStack(alignment: .center, spacing: 8) {
@@ -177,25 +202,17 @@ struct ActionRowView: View {
                 // Settings
                 if showsControls {
                     Button(action: {
-                        showingConfigSheet.toggle()
+                        openConfigPopover()
                     }) {
                         Image(systemName: "gearshape")
                             .font(.system(size: 12))
-                            .foregroundColor(showingConfigSheet ? .accentColor : .secondary)
+                            .foregroundColor(isConfigPopoverOpen ? .accentColor : .secondary)
                     }
                     .buttonStyle(.plain)
                     .frame(width: 20, height: 20)
+                    .background(PopoverAnchorView(box: configAnchor))
                     .help(isAITools ? String(localized: "Open AI settings") : (action.chrome.rowStyle == .actionGroup ? String(localized: "Configure Group") : String(localized: "Configure Action")))
                     .accessibilityLabel(isAITools ? String(localized: "Open AI settings") : (action.chrome.rowStyle == .actionGroup ? String(localized: "Configure Group") : String(localized: "Configure Action")))
-                    .popover(isPresented: $showingConfigSheet, arrowEdge: .leading) {
-                        if isAITools {
-                            ConfigureAISheet()
-                        } else if action.chrome.rowStyle == .actionGroup {
-                            EditGroupSheet(groupID: action.id)
-                        } else {
-                            EditActionSheet(action: action)
-                        }
-                    }
                 } else {
                     Color.clear
                         .frame(width: 20, height: 20)

--- a/Sources/OpenClip/UI/Preferences/EditActionSheet.swift
+++ b/Sources/OpenClip/UI/Preferences/EditActionSheet.swift
@@ -15,6 +15,9 @@ public struct EditActionSheet: View {
     /// reason banner and highlights the missing option rows in the unified editor (Phase 7).
     let configurationRequest: ConfigurationRequest?
     @Environment(\.dismiss) private var dismiss
+    /// Set when the editor is shown in the Actions tab's settings popover, which closes itself
+    /// only on request; `nil` when it is presented as a sheet.
+    @Environment(\.popoverDismiss) private var popoverDismiss
 
     @State private var customTitle: String = ""
     @State private var iconSymbol: String = ""
@@ -63,6 +66,14 @@ public struct EditActionSheet: View {
         ActionIdentity.isBuiltin(action)
     }
 
+    private func close() {
+        if let popoverDismiss {
+            popoverDismiss()
+        } else {
+            dismiss()
+        }
+    }
+
     /// Banner text when the sheet was opened because the action needs configuration. Falls back to a
     /// generic message when the request has no reason but does name missing options.
     private var configurationBannerText: String? {
@@ -85,7 +96,7 @@ public struct EditActionSheet: View {
                 Text("Configure Action")
                     .font(.system(size: 13, weight: .semibold))
                 Spacer()
-                Button(action: { dismiss() }) {
+                Button(action: { close() }) {
                     Image(systemName: "xmark.circle.fill")
                         .font(.system(size: 15))
                         .foregroundColor(.secondary)
@@ -261,13 +272,13 @@ public struct EditActionSheet: View {
 
                 Spacer()
 
-                Button("Cancel") { dismiss() }
+                Button("Cancel") { close() }
                     .keyboardShortcut(.cancelAction)
 
                 Button("Save Changes") {
                     Task {
                         if await saveChanges() {
-                            dismiss()
+                            close()
                         }
                     }
                 }

--- a/Sources/OpenClip/UI/Preferences/EditGroupSheet.swift
+++ b/Sources/OpenClip/UI/Preferences/EditGroupSheet.swift
@@ -9,6 +9,9 @@ import Core
 public struct EditGroupSheet: View {
     let groupID: String
     @Environment(\.dismiss) private var dismiss
+    /// Set when the editor is shown in the Actions tab's settings popover, which closes itself
+    /// only on request; `nil` when it is presented as a sheet.
+    @Environment(\.popoverDismiss) private var popoverDismiss
     @ObservedObject private var coordinator = ActionCoordinator.shared
 
     @State private var title: String = ""
@@ -28,6 +31,14 @@ public struct EditGroupSheet: View {
         groupDef != nil
     }
 
+    private func close() {
+        if let popoverDismiss {
+            popoverDismiss()
+        } else {
+            dismiss()
+        }
+    }
+
     public var body: some View {
         VStack(alignment: .leading, spacing: 14) {
             HStack {
@@ -35,7 +46,7 @@ public struct EditGroupSheet: View {
                     .font(.headline)
                 Spacer()
                 Button {
-                    dismiss()
+                    close()
                 } label: {
                     Image(systemName: "xmark.circle.fill")
                         .foregroundColor(.secondary)
@@ -146,7 +157,7 @@ public struct EditGroupSheet: View {
                 if isCustomGroup {
                     Button("Ungroup", role: .destructive) {
                         coordinator.ungroup(groupID: groupID)
-                        dismiss()
+                        close()
                     }
                     .buttonStyle(.plain)
                     .foregroundColor(.red)
@@ -154,7 +165,7 @@ public struct EditGroupSheet: View {
 
                 Spacer()
 
-                Button("Cancel") { dismiss() }
+                Button("Cancel") { close() }
                     .keyboardShortcut(.cancelAction)
 
                 Button("Save") {
@@ -175,7 +186,7 @@ public struct EditGroupSheet: View {
                             text: nil
                         )
                     }
-                    dismiss()
+                    close()
                 }
                 .disabled(title.trimmingCharacters(in: .whitespaces).isEmpty || (isCustomGroup ? memberIDs.count < 2 : memberIDs.isEmpty))
                 .keyboardShortcut(.defaultAction)

--- a/scripts/dev_run.sh
+++ b/scripts/dev_run.sh
@@ -10,9 +10,18 @@ echo "⚡️ Building Debug build..."
 xcodegen
 xcodebuild -scheme OpenClip -configuration Debug -destination 'platform=macOS,arch=arm64' build > /dev/null
 
-APP_PATH="$(find "$HOME/Library/Developer/Xcode/DerivedData/OpenClip-"*/Build/Products/Debug -name "OpenClip.app" | head -n 1)"
+# Ask Xcode where it just built, rather than globbing DerivedData: several OpenClip-*
+# folders can exist (the hash changes with the project path) and picking the wrong one
+# silently launches a stale binary.
+BUILT_PRODUCTS_DIR="$(xcodebuild -scheme OpenClip -configuration Debug -destination 'platform=macOS,arch=arm64' -showBuildSettings 2>/dev/null | awk -F' = ' '/[[:space:]]BUILT_PRODUCTS_DIR = /{print $2; exit}')"
+APP_PATH="$BUILT_PRODUCTS_DIR/OpenClip.app"
 
-if [ -z "$APP_PATH" ]; then
+if [ ! -d "$APP_PATH" ]; then
+  # Fall back to the most recently built bundle.
+  APP_PATH="$(ls -dt "$HOME/Library/Developer/Xcode/DerivedData/OpenClip-"*/Build/Products/Debug/OpenClip.app 2>/dev/null | head -n 1)"
+fi
+
+if [ -z "$APP_PATH" ] || [ ! -d "$APP_PATH" ]; then
   echo "Error: Could not find built OpenClip.app in DerivedData"
   exit 1
 fi


### PR DESCRIPTION
## Summary

The per-row settings editors in **Preferences → Actions** (the gear icon: AI Tools, custom group, action) close themselves as soon as anything happens in the list behind them.

Two independent causes:

1. SwiftUI's `.popover` is always **transient** — the first click outside it dismisses it, so flipping an action's enable toggle closed the open editor.
2. The list is an `NSOutlineView` whose `updateNSView` calls `reloadData()` on every model change, tearing down the row-hosted view the popover is anchored to. That is the one users actually hit: open AI Tools settings → *Actions* sub-tab → edit a preset → **Save** → the whole popover disappears. Saving re-registers the AI actions (`AIActionSync`) → `ActionCoordinator.actions` republishes → `PreferencesView` re-renders → the outline reloads → the popover's anchor row is gone.

**Fix:** present those editors through a new `ActionSettingsPopover` — an AppKit `NSPopover` with `.applicationDefined` behavior, anchored to the window's content view instead of the reloadable row. It now closes only on request: the gear again, the editor's own ✕ / Cancel / Save, Escape, or leaving the Actions tab. The editors reach that close through a new `popoverDismiss` environment value and fall back to SwiftUI's `dismiss` when the same views are presented as sheets (Preferences' `configure` route, the group sheet), so those paths are unchanged.

The second commit is a `scripts/dev_run.sh` fix I hit while verifying this: it globbed `DerivedData/OpenClip-*` and took the first `find` hit, so with more than one of those folders present it built the current sources and then launched a **stale binary** from another folder — changes appear to do nothing. It now asks `xcodebuild` for `BUILT_PRODUCTS_DIR`. Happy to split that out if you'd rather keep this PR single-purpose.

Fixes # <!-- no issue filed -->

---

## Type of Change
- [x] Bug fix (non-breaking change fixing an issue)
- [ ] New feature (non-breaking change adding functionality)
- [ ] Extension Runtime / Bridge update (JS host, AppleScript runner, Shell executor)
- [x] UI / Theme / Accessibility improvement
- [ ] Performance / Concurrency optimization
- [ ] Localization (`Localizable.xcstrings`)
- [ ] Documentation update
- [ ] Build tooling / CI / Scripts

---

## Testing & Verification

### Environment Tested:
- **macOS Version:** macOS 26.5.1 (25F80)
- **Architecture:** Apple Silicon (arm64)
- **Target Apps Verified:** n/a — the change is confined to the Preferences window

### Test Execution:
- [x] Ran `./scripts/test.sh core` (< 1s domain test suite)
- [x] Ran `./scripts/test.sh` — see the baseline comparison below, **not** a clean 0-failure run on this machine
- [x] Tested live in app

Full-suite detail (this branch vs. `main`, same machine, back to back):

| | `main` | this branch |
| :--- | :--- | :--- |
| `CalculateActionTests.testExtendedMathExpressionsAndSanitization` | fails | fails |
| `PopupPanelTests.testEnterSearchWithButtonAnchorCentersSearchOnButton` | fails | fails |
| `PopupPanelTests.testAICardResizesPanelToIncludeBody` | passes | flaky — fails in the full suite, passes running `PopupPanelTests` alone |
| `ScriptActionExecutionTests` | passes | flaky — a *different* test in the class fails on each run |

The first two reproduce on unmodified `main` here (locale-dependent thousand separators; panel centering). The two flaky ones are in files this PR does not touch and are not reproducible in isolation. Everything else passes: 1063 tests.

Live verification: the model-change paths that used to kill the popover — an AI preset save (`AIServiceManager.presets` → `AIActionSync` re-register → outline `reloadData()`) and a `disabledActionIDs` write — were driven against a running build with the Actions tab open and the editor showing. The popover stayed open through both (`NSPopoverDelegate.popoverDidClose` never fired). A click-through of the recorded flow below by a second pair of eyes would be welcome.

---

## Screenshots / Screen Recordings (if applicable)

No media attached; the reproduction in words:

| Before | After |
| :--- | :--- |
| Preferences → Actions → gear on **AI Tools** → *Actions* sub-tab → pencil on a preset → change the title → **Save** ⇒ the AI Tools popover vanishes with the sheet. Same for flipping any action's toggle while an editor is open. | The editor stays open and up to date; it closes on the gear, its own ✕ / Cancel / Save, Escape, or switching tabs. |

Before: 


https://github.com/user-attachments/assets/2ebbaec9-12d3-48e8-9774-fb5807acce5b


After


https://github.com/user-attachments/assets/b1b47c2a-e288-406a-9585-53655ca9a214



---

## Architectural & Code Checklist
- [x] **Swift 6 Concurrency:** Builds cleanly with complete strict concurrency (`SWIFT_STRICT_CONCURRENCY: complete`) with zero data races.
- [x] **Core Purity:** No `AppKit` or `SwiftUI` imports in `Sources/Core/` — the new file lives in `Sources/OpenClip/UI/Preferences/`.
- [x] **Settings & Secrets:** Uses `SettingsStore` / `SecretStore` (no direct `UserDefaults.standard` in new code).
- [x] **Subprocess Safety:** No new subprocesses.
- [x] **Dual-Sink Logging:** No new logging; no raw `print()` or ad-hoc `Logger()`.
- [x] **Localization:** No new user-facing copy — the existing `String(localized:)` strings are reused verbatim.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TXrBkCy9q3WcCQ6ivRuBtW


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a popover-based editor for configuring actions from the Actions preferences tab.
  * Added consistent close, cancel, save, and Escape-key behavior for action and group editors.
  * The active action settings control now indicates when its editor is open.

* **Bug Fixes**
  * Improved app launching during development by reliably locating the latest build artifact.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->