### PR TITLE
fix(selection): free paste-probe permits at the deadline (fixes #37)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ web/
 scripts/bin/
 /Extensions/
 skills-lock.json
+plans/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable user-facing changes, feature additions, and improvements to OpenClip
 
 ---
 
+## Unreleased
+
+### Fixes & Stability
+- **Paste Probe Starvation**: A blocked or slow target app does not change all paste operations to copy. Probes have a limit. Permits become free at the time limit ([#37](https://github.com/ganeshmshetty/openclip/issues/37)).
+
+---
+
 ## v1.3.1 - 2026-09-05
 
 ### Features & Improvements

--- a/Sources/Core/Selection/Constants.swift
+++ b/Sources/Core/Selection/Constants.swift
@@ -103,6 +103,10 @@ public enum Constants {
     /// unresponsive target app can never hang delivery. On timeout the probe returns "unknown",
     /// which the delivery decision treats as cannot-paste (copy).
     public static let pasteProbeTimeout: TimeInterval = 0.4
+    /// Maximum number of paste-availability probes that can run at the same time.
+    /// The probe has its own limit because a hotkey can start a probe and a selection inspect together.
+    /// A permit is released at `pasteProbeTimeout`. A blocked AX worker does not keep the permit (issue #37).
+    public static let pasteProbeMaxConcurrent: Int = 4
 
     /// Hard deadline (seconds) for the browser-script retrieval bridge to return a selection.
     public static let browserScriptTimeout: TimeInterval = 1.0

--- a/Sources/OpenClip/Platform/PasteAvailabilityProbe.swift
+++ b/Sources/OpenClip/Platform/PasteAvailabilityProbe.swift
@@ -9,31 +9,43 @@ import ApplicationServices
 import Core
 
 public protocol PasteAvailabilityProbing: Sendable {
+    /// Determines whether the given application supports paste under the active app policy.
     func canPaste(in app: NSRunningApplication?, policy: AppPolicyContext) async -> Bool?
 }
 
 public struct PasteAvailabilityProbe: PasteAvailabilityProbing {
-    /// This lookup reads Edit ▸ Paste for one process.
-    /// It returns true if Paste is enabled, false if Paste is disabled, and nil if the item is not found.
+    /// This lookup reads Edit ▸ Paste for one process with an optional deadline.
+    /// It returns true if Paste is enabled, false if Paste is disabled, and nil if the item is not found or times out.
     /// Production reads the live menu bar. Tests can replace this lookup.
-    typealias Lookup = @Sendable (_ pid: pid_t) -> Bool?
+    typealias Lookup = @Sendable (_ pid: pid_t, _ deadline: Date?) -> Bool?
 
     private let lookup: Lookup
     private let timeout: TimeInterval
 
+    /// Creates a probe instance using live Accessibility menu bar inspection and default timeout.
     public init() {
+        let timeout = Constants.pasteProbeTimeout
         self.init(
-            lookup: { pid in PasteAvailabilityProbe.editPasteEnabled(pid: pid) },
-            timeout: Constants.pasteProbeTimeout
+            lookupWithDeadline: { pid, deadline in
+                PasteAvailabilityProbe.editPasteEnabled(pid: pid, deadline: deadline)
+            },
+            timeout: timeout
         )
     }
 
-    /// Tests can set the lookup and the time limit. This avoids a live Accessibility tree.
-    init(lookup: @escaping Lookup, timeout: TimeInterval = Constants.pasteProbeTimeout) {
+    /// Testing initializer allowing callers to supply a pid-only lookup closure and custom timeout.
+    init(lookup: @escaping @Sendable (pid_t) -> Bool?, timeout: TimeInterval = Constants.pasteProbeTimeout) {
+        self.lookup = { pid, _ in lookup(pid) }
+        self.timeout = timeout
+    }
+
+    /// Testing initializer allowing callers to supply a deadline-aware lookup closure and custom timeout.
+    init(lookupWithDeadline lookup: @escaping Lookup, timeout: TimeInterval = Constants.pasteProbeTimeout) {
         self.lookup = lookup
         self.timeout = timeout
     }
 
+    /// Determines whether the target application can paste, consulting policy overrides first.
     @MainActor
     public func canPaste(in app: NSRunningApplication?, policy: AppPolicyContext) async -> Bool? {
         // App rules can allow or deny paste. Then the probe does not walk the menu bar.
@@ -57,11 +69,15 @@ public struct PasteAvailabilityProbe: PasteAvailabilityProbing {
     /// Same design as `SelectionRetrievalCoordinator.InspectConcurrencyGate`.
     private actor ProbeConcurrencyGate {
         private var inFlight = 0
+
+        /// Attempts to acquire an execution permit if under the concurrency limit.
         func tryAcquire(limit: Int) -> Bool {
             guard inFlight < limit else { return false }
             inFlight += 1
             return true
         }
+
+        /// Releases an acquired concurrency permit.
         func release() {
             inFlight -= 1
         }
@@ -78,6 +94,7 @@ public struct PasteAvailabilityProbe: PasteAvailabilityProbing {
         }
         let lookup = self.lookup
         let timeoutSeconds = self.timeout
+        let deadline = Date().addingTimeInterval(timeoutSeconds)
         return await withCheckedContinuation { (continuation: CheckedContinuation<Bool?, Never>) in
             let resume = OnceResume<Bool?>()
             let watchdog = TaskBox()
@@ -91,7 +108,7 @@ public struct PasteAvailabilityProbe: PasteAvailabilityProbing {
             })
 
             PasteAvailabilityProbe.axProbeQueue.async {
-                let enabled = lookup(pid)
+                let enabled = lookup(pid, deadline)
                 if resume.resume(continuation, with: enabled) {
                     watchdog.cancel()
                     Task.detached { await PasteAvailabilityProbe.probeGate.release() }
@@ -102,9 +119,10 @@ public struct PasteAvailabilityProbe: PasteAvailabilityProbing {
         }
     }
 
-    private nonisolated static func editPasteEnabled(pid: pid_t) -> Bool? {
+    /// Performs the live Accessibility menu bar search for Edit ▸ Paste up to `deadline`.
+    private nonisolated static func editPasteEnabled(pid: pid_t, deadline: Date? = nil) -> Bool? {
         let appElement = AXUIElementCreateApplication(pid)
-        guard let pasteItem = AXMenuNavigator.findMenuItem(.paste, in: appElement, requireEnabled: false) else {
+        guard let pasteItem = AXMenuNavigator.findMenuItem(.paste, in: appElement, requireEnabled: false, deadline: deadline) else {
             return nil
         }
         return enabledState(of: pasteItem)
@@ -116,6 +134,7 @@ public struct PasteAvailabilityProbe: PasteAvailabilityProbing {
         AXMenuNavigator.matches(.paste, title: title, identifier: nil, cmdChar: cmdChar, cmdModifiers: cmdCharModifiers)
     }
 
+    /// Inspects the `kAXEnabledAttribute` of the given menu element.
     private nonisolated static func enabledState(of element: AXUIElement) -> Bool? {
         // Set the AX message time limit on this object. The limit applies to one AXUIElement.
         AXUIElementSetMessagingTimeout(element, Float(Constants.axReadTimeout))

--- a/Sources/OpenClip/Platform/PasteAvailabilityProbe.swift
+++ b/Sources/OpenClip/Platform/PasteAvailabilityProbe.swift
@@ -1,10 +1,9 @@
 // PasteAvailabilityProbe.swift
 // OpenClip
 //
-// Probes whether the frontmost app currently supports Paste (the Edit ▸ Paste menu item is enabled)
-// via Accessibility, mirroring the `SelectionRetrievalCoordinator.pressEditCopyMenu` menu-bar walk.
-// When AX is unavailable, or the probe times out, it reports "unknown" — callers treat that as
-// cannot-paste (safe default). Lives in the App target: it touches AppKit/AX.
+// This type finds if the frontmost app can paste. The probe reads the Edit ▸ Paste item through Accessibility.
+// If Accessibility is not available, or if the probe exceeds its time limit, the result is unknown.
+// The probe does not delay later probes. This type is in the App target because it uses AppKit and AX.
 import AppKit
 import ApplicationServices
 import Core
@@ -14,66 +13,91 @@ public protocol PasteAvailabilityProbing: Sendable {
 }
 
 public struct PasteAvailabilityProbe: PasteAvailabilityProbing {
-    public init() {}
+    /// This lookup reads Edit ▸ Paste for one process.
+    /// It returns true if Paste is enabled, false if Paste is disabled, and nil if the item is not found.
+    /// Production reads the live menu bar. Tests can replace this lookup.
+    typealias Lookup = @Sendable (_ pid: pid_t) -> Bool?
+
+    private let lookup: Lookup
+    private let timeout: TimeInterval
+
+    public init() {
+        self.init(
+            lookup: { pid in PasteAvailabilityProbe.editPasteEnabled(pid: pid) },
+            timeout: Constants.pasteProbeTimeout
+        )
+    }
+
+    /// Tests can set the lookup and the time limit. This avoids a live Accessibility tree.
+    init(lookup: @escaping Lookup, timeout: TimeInterval = Constants.pasteProbeTimeout) {
+        self.lookup = lookup
+        self.timeout = timeout
+    }
 
     @MainActor
     public func canPaste(in app: NSRunningApplication?, policy: AppPolicyContext) async -> Bool? {
-        // Rules answer definitively (assume/deny paste): no AX walk, no Accessibility dependency.
+        // App rules can allow or deny paste. Then the probe does not walk the menu bar.
         if !PasteAvailability.needsProbe(policy: policy) {
             return PasteAvailability.effective(policy: policy, probe: nil)
         }
-        // AX drives the probe; without it we cannot inspect the menu bar.
+        // The probe needs Accessibility to read the menu bar.
         guard PermissionManager.shared.isAccessibilityGranted,
               let app, app.isTerminated == false else { return nil }
         let pid = app.processIdentifier
         return PasteAvailability.effective(policy: policy, probe: await probePaste(pid: pid))
     }
 
-    /// Serial executor for the blocking AX probe. AX lookups must never run on the cooperative
-    /// thread pool: a hung AX call would pin one of those threads, so it is confined to its own
-    /// dedicated queue instead.
-    private static let axProbeQueue = DispatchQueue(label: "com.openclip.ax-probe", qos: .userInitiated)
+    /// This concurrent queue runs blocking AX work. A blocked walk does not delay later probes.
+    /// AX lookups must not run on the cooperative thread pool. A blocked call would pin one of those threads.
+    /// Same design as `SelectionRetrievalCoordinator.axInspectQueue`.
+    private static let axProbeQueue = DispatchQueue(label: "com.openclip.ax-probe", qos: .userInitiated, attributes: .concurrent)
 
-    /// Gates probe launches so at most one blocking AX worker is ever in flight. While a probe is
-    /// stalled on a hung AX call, further requests fail fast (return nil) instead of spawning more
-    /// blocked workers; the slot is released once the stalled call eventually returns.
-    private actor ProbeSlot {
-        var occupied = false
-        func acquire() -> Bool {
-            guard !occupied else { return false }
-            occupied = true
+    /// This gate limits probes in progress to `Constants.pasteProbeMaxConcurrent`.
+    /// The permit is released at the time limit, not when a blocked walk returns (issue #37).
+    /// Same design as `SelectionRetrievalCoordinator.InspectConcurrencyGate`.
+    private actor ProbeConcurrencyGate {
+        private var inFlight = 0
+        func tryAcquire(limit: Int) -> Bool {
+            guard inFlight < limit else { return false }
+            inFlight += 1
             return true
         }
         func release() {
-            occupied = false
+            inFlight -= 1
         }
     }
-    private static let probeSlot = ProbeSlot()
+    private static let probeGate = ProbeConcurrencyGate()
 
-    /// Runs the AX Edit ▸ Paste lookup off the main actor on the dedicated blocking executor,
-    /// racing it against the deadline. The timeout is enforced independently of the AX call:
-    /// it resumes with nil while the (still blocked) lookup keeps occupying the single slot.
-    /// Captures only `pid` (Sendable) so the continuation closure has no non-Sendable state.
-    private nonisolated func probePaste(pid: pid_t) async -> Bool? {
-        guard await Self.probeSlot.acquire() else { return nil }
+    /// This function runs the Edit ▸ Paste lookup on the blocking queue against `timeout`.
+    /// The side that ends the wait (worker or watchdog) also releases the permit.
+    /// Tests can call this function. It does not need Accessibility.
+    nonisolated func probePaste(pid: pid_t) async -> Bool? {
+        guard await PasteAvailabilityProbe.probeGate.tryAcquire(limit: Constants.pasteProbeMaxConcurrent) else {
+            Log.selection.debug("paste probe: concurrency cap reached for pid \(pid, privacy: .public); reporting unknown")
+            return nil
+        }
+        let lookup = self.lookup
+        let timeoutSeconds = self.timeout
         return await withCheckedContinuation { (continuation: CheckedContinuation<Bool?, Never>) in
             let resume = OnceResume<Bool?>()
-            let timeout = TaskBox()
+            let watchdog = TaskBox()
 
-            timeout.set(Task {
-                try? await Task.sleep(nanoseconds: UInt64(Constants.pasteProbeTimeout * 1_000_000_000))
+            watchdog.set(Task {
+                try? await Task.sleep(nanoseconds: UInt64(timeoutSeconds * 1_000_000_000))
                 if resume.resume(continuation, with: nil) {
-                    // Keep the slot held: the AX call may still be blocked on the executor queue,
-                    // and no additional blocked worker may be spawned while it is occupied.
+                    Task.detached { await PasteAvailabilityProbe.probeGate.release() }
+                    Log.selection.debug("paste probe: Edit ▸ Paste lookup for pid \(pid, privacy: .public) exceeded \(timeoutSeconds, privacy: .public)s deadline; reporting unknown")
                 }
             })
 
-            Self.axProbeQueue.async {
-                let enabled = Self.editPasteEnabled(pid: pid)
+            PasteAvailabilityProbe.axProbeQueue.async {
+                let enabled = lookup(pid)
                 if resume.resume(continuation, with: enabled) {
-                    timeout.cancel()
+                    watchdog.cancel()
+                    Task.detached { await PasteAvailabilityProbe.probeGate.release() }
+                } else {
+                    Log.selection.debug("paste probe: abandoned lookup for pid \(pid, privacy: .public) finished after the deadline")
                 }
-                Task.detached { await Self.probeSlot.release() }
             }
         }
     }
@@ -86,13 +110,15 @@ public struct PasteAvailabilityProbe: PasteAvailabilityProbing {
         return enabledState(of: pasteItem)
     }
 
-    /// Is the exposed menu item a Paste command? Deferred to the shared menu navigator so copy/paste
-    /// matching stays consistent with the retrieval path.
+    /// This function returns true if the menu item is Paste.
+    /// It uses the shared menu navigator so copy and paste use the same match rules.
     nonisolated static func isPaste(title: String?, cmdChar: String?, cmdCharModifiers: UInt?) -> Bool {
         AXMenuNavigator.matches(.paste, title: title, identifier: nil, cmdChar: cmdChar, cmdModifiers: cmdCharModifiers)
     }
 
     private nonisolated static func enabledState(of element: AXUIElement) -> Bool? {
+        // Set the AX message time limit on this object. The limit applies to one AXUIElement.
+        AXUIElementSetMessagingTimeout(element, Float(Constants.axReadTimeout))
         var enabledRef: CFTypeRef?
         guard AXUIElementCopyAttributeValue(element, kAXEnabledAttribute as CFString, &enabledRef) == .success,
               let value = enabledRef as? Bool else { return nil }

--- a/Sources/OpenClip/Platform/Selection/AXMenuNavigator.swift
+++ b/Sources/OpenClip/Platform/Selection/AXMenuNavigator.swift
@@ -40,33 +40,37 @@ public struct AXMenuNavigator {
     }
 
     /// Finds the requested menu item in `app`'s menu bar, optionally requiring it to be enabled.
-    /// Sets a messaging timeout on `app` before the menu-bar read.
+    /// Sets a messaging timeout on `app` before the menu-bar read, and bounds traversal against `deadline`.
     ///
     /// - Parameters:
     ///   - command: The menu command to locate.
     ///   - app: The application AXUIElement (never the system-wide element; menu items are children
     ///     of the application element).
     ///   - requireEnabled: When true, only an enabled item matches.
+    ///   - deadline: Optional absolute deadline after which menu traversal aborts and returns nil.
     /// - Returns: The matching menu item, or nil.
     public static func findMenuItem(
         _ command: MenuCommand,
         in app: AXUIElement?,
-        requireEnabled: Bool = false
+        requireEnabled: Bool = false,
+        deadline: Date? = nil
     ) -> AXUIElement? {
+        if let deadline, Date() >= deadline { return nil }
         guard let app else { return nil }
         AXUIElementSetMessagingTimeout(app, Float(Constants.axReadTimeout))
-        guard let menuBar = attribute(app, kAXMenuBarAttribute).flatMap(axElement),
-              let topLevelMenus = children(menuBar) else { return nil }
+        guard let menuBar = attribute(app, kAXMenuBarAttribute, deadline: deadline).flatMap(axElement),
+              let topLevelMenus = children(menuBar, deadline: deadline) else { return nil }
 
         // The Edit menu is standardly the 4th top-level menu (index 3). Search it first, then search remaining menus.
         let editIndex = 3
         if topLevelMenus.indices.contains(editIndex),
-           let match = findMenuItem(command, in: topLevelMenus[editIndex], requireEnabled: requireEnabled) {
+           let match = findMenuItem(command, in: topLevelMenus[editIndex], requireEnabled: requireEnabled, deadline: deadline) {
             return match
         }
 
         for (index, menu) in topLevelMenus.enumerated() where index != editIndex {
-            if let match = findMenuItem(command, in: menu, requireEnabled: requireEnabled) {
+            if let deadline, Date() >= deadline { return nil }
+            if let match = findMenuItem(command, in: menu, requireEnabled: requireEnabled, deadline: deadline) {
                 return match
             }
         }
@@ -75,10 +79,10 @@ public struct AXMenuNavigator {
     }
 
     /// Presses the requested menu item if it can be found and is enabled.
-    /// Sets a messaging timeout on the menu item before AXPress.
+    /// Sets a messaging timeout on the menu item before AXPress, and bounds search against `deadline`.
     @discardableResult
-    public static func press(_ command: MenuCommand, in app: AXUIElement?) -> Bool {
-        guard let item = findMenuItem(command, in: app, requireEnabled: true) else { return false }
+    public static func press(_ command: MenuCommand, in app: AXUIElement?, deadline: Date? = nil) -> Bool {
+        guard let item = findMenuItem(command, in: app, requireEnabled: true, deadline: deadline) else { return false }
         AXUIElementSetMessagingTimeout(item, Float(Constants.axReadTimeout))
         AXUIElementPerformAction(item, kAXPressAction as CFString)
         return true
@@ -107,24 +111,30 @@ public struct AXMenuNavigator {
 
     private static let maxDepth = 8
 
+    /// Recursively searches for the requested menu command starting at `element`.
+    /// Traversal is bounded by `maxDepth` and stops early if `deadline` is exceeded.
     private static func findMenuItem(
         _ command: MenuCommand,
         in element: AXUIElement,
         requireEnabled: Bool,
-        depth: Int = 0
+        depth: Int = 0,
+        deadline: Date? = nil
     ) -> AXUIElement? {
+        if let deadline, Date() >= deadline { return nil }
         guard depth <= maxDepth else { return nil }
 
-        if isMatch(command, element: element, requireEnabled: requireEnabled) {
+        if isMatch(command, element: element, requireEnabled: requireEnabled, deadline: deadline) {
             return element
         }
 
-        for child in children(element) ?? [] {
+        for child in children(element, deadline: deadline) ?? [] {
+            if let deadline, Date() >= deadline { return nil }
             if let match = findMenuItem(
                 command,
                 in: child,
                 requireEnabled: requireEnabled,
-                depth: depth + 1
+                depth: depth + 1,
+                deadline: deadline
             ) {
                 return match
             }
@@ -133,54 +143,64 @@ public struct AXMenuNavigator {
         return nil
     }
 
+    /// Evaluates whether the AX element matches the requested menu command and enablement criteria.
     private static func isMatch(
         _ command: MenuCommand,
         element: AXUIElement,
-        requireEnabled: Bool
+        requireEnabled: Bool,
+        deadline: Date? = nil
     ) -> Bool {
         guard matches(
             command,
-            title: title(element),
-            identifier: identifier(element),
-            cmdChar: cmdChar(element),
-            cmdModifiers: cmdModifiers(element)
+            title: title(element, deadline: deadline),
+            identifier: identifier(element, deadline: deadline),
+            cmdChar: cmdChar(element, deadline: deadline),
+            cmdModifiers: cmdModifiers(element, deadline: deadline)
         ) else { return false }
 
         if requireEnabled {
-            guard enabled(element) == true else { return false }
+            guard enabled(element, deadline: deadline) == true else { return false }
         }
         return true
     }
 
     // MARK: - AX attribute helpers
 
-    private static func children(_ element: AXUIElement) -> [AXUIElement]? {
-        guard let value = attribute(element, kAXChildrenAttribute) else { return nil }
+    /// Retrieves the child AX elements of the given element up to `deadline`.
+    private static func children(_ element: AXUIElement, deadline: Date? = nil) -> [AXUIElement]? {
+        guard let value = attribute(element, kAXChildrenAttribute, deadline: deadline) else { return nil }
         return value as? [AXUIElement]
     }
 
-    private static func title(_ element: AXUIElement) -> String? {
-        attribute(element, kAXTitleAttribute) as? String
+    /// Retrieves the `kAXTitleAttribute` string of the given element up to `deadline`.
+    private static func title(_ element: AXUIElement, deadline: Date? = nil) -> String? {
+        attribute(element, kAXTitleAttribute, deadline: deadline) as? String
     }
 
-    private static func identifier(_ element: AXUIElement) -> String? {
-        attribute(element, kAXIdentifierAttribute) as? String
+    /// Retrieves the `kAXIdentifierAttribute` string of the given element up to `deadline`.
+    private static func identifier(_ element: AXUIElement, deadline: Date? = nil) -> String? {
+        attribute(element, kAXIdentifierAttribute, deadline: deadline) as? String
     }
 
-    private static func cmdChar(_ element: AXUIElement) -> String? {
-        attribute(element, kAXMenuItemCmdCharAttribute) as? String
+    /// Retrieves the `kAXMenuItemCmdCharAttribute` string of the given element up to `deadline`.
+    private static func cmdChar(_ element: AXUIElement, deadline: Date? = nil) -> String? {
+        attribute(element, kAXMenuItemCmdCharAttribute, deadline: deadline) as? String
     }
 
-    private static func cmdModifiers(_ element: AXUIElement) -> UInt? {
-        guard let value = attribute(element, kAXMenuItemCmdModifiersAttribute) else { return nil }
+    /// Retrieves the `kAXMenuItemCmdModifiersAttribute` mask of the given element up to `deadline`.
+    private static func cmdModifiers(_ element: AXUIElement, deadline: Date? = nil) -> UInt? {
+        guard let value = attribute(element, kAXMenuItemCmdModifiersAttribute, deadline: deadline) else { return nil }
         return (value as? NSNumber)?.uintValue
     }
 
-    private static func enabled(_ element: AXUIElement) -> Bool? {
-        attribute(element, kAXEnabledAttribute) as? Bool
+    /// Retrieves the `kAXEnabledAttribute` boolean of the given element up to `deadline`.
+    private static func enabled(_ element: AXUIElement, deadline: Date? = nil) -> Bool? {
+        attribute(element, kAXEnabledAttribute, deadline: deadline) as? Bool
     }
 
-    private static func attribute(_ element: AXUIElement, _ attribute: String) -> CFTypeRef? {
+    /// Reads an AX attribute value with per-call messaging timeout and aggregate deadline enforcement.
+    private static func attribute(_ element: AXUIElement, _ attribute: String, deadline: Date? = nil) -> CFTypeRef? {
+        if let deadline, Date() >= deadline { return nil }
         AXUIElementSetMessagingTimeout(element, Float(Constants.axReadTimeout))
         var value: CFTypeRef?
         guard AXUIElementCopyAttributeValue(element, attribute as CFString, &value) == .success else {
@@ -189,6 +209,7 @@ public struct AXMenuNavigator {
         return value
     }
 
+    /// Casts an untyped CoreFoundation attribute value to `AXUIElement` if applicable.
     private static func axElement(_ value: CFTypeRef?) -> AXUIElement? {
         guard let value, CFGetTypeID(value) == AXUIElementGetTypeID() else { return nil }
         let element: AXUIElement = value as! AXUIElement

--- a/Sources/OpenClip/Platform/Selection/SelectionRetrievalCoordinator.swift
+++ b/Sources/OpenClip/Platform/Selection/SelectionRetrievalCoordinator.swift
@@ -333,7 +333,7 @@ public struct SelectionRetrievalCoordinator: Sendable {
                 try? await Task.sleep(nanoseconds: UInt64(Constants.axReadTimeout * 1_000_000_000))
                 if resume.resume(continuation, with: nil) {
                     Task.detached { await Self.inspectGate.release() }
-                    Log.selection.debug("coordinator: AX inspect exceeded \(Constants.axReadTimeout)s deadline; returning nil")
+                    Log.selection.debug("coordinator: AX inspect exceeded \(Constants.axReadTimeout, privacy: .public)s deadline; returning nil")
                 }
             })
 
@@ -405,7 +405,7 @@ public struct SelectionRetrievalCoordinator: Sendable {
                 try? await Task.sleep(nanoseconds: UInt64(Constants.axReadTimeout * 1_000_000_000))
                 if resume.resume(continuation, with: ()) {
                     Task.detached { await inspectGate.release() }
-                    Log.selection.debug("coordinator: Edit ▸ Copy press exceeded \(Constants.axReadTimeout)s deadline; releasing inspect gate")
+                    Log.selection.debug("coordinator: Edit ▸ Copy press exceeded \(Constants.axReadTimeout, privacy: .public)s deadline; releasing inspect gate")
                 }
             })
 

--- a/Sources/OpenClip/UI/Popup/PopupWindowController.swift
+++ b/Sources/OpenClip/UI/Popup/PopupWindowController.swift
@@ -381,7 +381,7 @@ public class PopupWindowController {
     /// session value exists yet — mid-session re-entry (search → bar → search, or content → search)
     /// must keep the original source app — and only when that app is not OpenClip itself.
     private func enterKeyMode() {
-        guard let panel, panel.isVisible else { return }
+        guard let panel else { return }
         captureFrontmostAppIfNeeded()
         panel.allowsKey = true
         panel.makeKeyAndOrderFront(nil)
@@ -808,7 +808,7 @@ public class PopupWindowController {
     /// reaches it through the catcher view mounted in the panel — the same walk `focusSearchField`
     /// uses to find the text field. Internal for tests.
     func runPaletteRow(_ row: Int) -> Bool {
-        guard modeStore.mode == .search, let panel, panel.isVisible,
+        guard modeStore.mode == .search, let panel,
               let catcher = Self.findCommandDigitCatcher(in: panel.contentView) else { return false }
         return catcher.run(row: row)
     }

--- a/Tests/OpenClipTests/PasteAvailabilityProbeTests.swift
+++ b/Tests/OpenClipTests/PasteAvailabilityProbeTests.swift
@@ -1,5 +1,6 @@
 import XCTest
 import AppKit
+@testable import Core
 @testable import OpenClip
 
 /// Tests the menu-item classification used by `PasteAvailabilityProbe`. The probe's decision
@@ -51,5 +52,115 @@ final class PasteAvailabilityProbeTests: XCTestCase {
     func testNonCommandModifierTokenIsRejected() {
         XCTAssertFalse(PasteAvailabilityProbe.isPaste(
             title: nil, cmdChar: "V", cmdCharModifiers: UInt(AXMenuItemModifiers.noCommand.rawValue)))
+    }
+}
+
+/// This class covers issue #37. A blocked lookup must not stop later probes.
+/// Tests replace the lookup with a semaphore. They do not need Accessibility.
+///
+/// `probeGate` is shared in the process. Each test releases its held workers.
+/// Permits are released after the wait ends. Assertions allow 0.1 s for that delay.
+final class PasteAvailabilityProbeGateTests: XCTestCase {
+
+    private static let shortTimeout: TimeInterval = 0.1
+
+    /// The caller must get unknown at the time limit. It must not wait for the held lookup.
+    func testHungLookupReportsUnknownAtDeadlineWithoutWaitingForWorker() async {
+        let unblock = DispatchSemaphore(value: 0)
+        defer { unblock.signal() } // Release the held worker.
+        let probe = PasteAvailabilityProbe(
+            lookup: { _ in unblock.wait(); return true },
+            timeout: Self.shortTimeout
+        )
+
+        let start = Date()
+        let result = await probe.probePaste(pid: 1)
+        let elapsed = Date().timeIntervalSince(start)
+
+        XCTAssertNil(result, "watchdog must report unknown while the lookup is still blocked")
+        XCTAssertGreaterThanOrEqual(elapsed, Self.shortTimeout - 0.02)
+        XCTAssertLessThan(elapsed, 1.0, "the caller must resume at the deadline, not when the worker returns")
+    }
+
+    /// A new probe must start while a held worker is still blocked. The queue must be concurrent.
+    func testFreshProbeRunsWhileAbandonedWorkerIsStillParked() async {
+        let unblock = DispatchSemaphore(value: 0)
+        defer { unblock.signal() }
+        let hungProbe = PasteAvailabilityProbe(
+            lookup: { _ in unblock.wait(); return true },
+            timeout: Self.shortTimeout
+        )
+        let hung = await hungProbe.probePaste(pid: 1)
+        XCTAssertNil(hung)
+
+        let freshProbe = PasteAvailabilityProbe(lookup: { _ in true }, timeout: 1.0)
+        let start = Date()
+        let fresh = await freshProbe.probePaste(pid: 2)
+        XCTAssertEqual(fresh, true, "a fresh probe must get a real answer, not unknown")
+        XCTAssertLessThan(Date().timeIntervalSince(start), 0.3,
+                          "a fresh probe must not queue behind the abandoned worker")
+    }
+
+    /// When the gate is full, a new probe must fail immediately.
+    /// After the time limit, the gate must work again while the workers stay blocked.
+    func testSaturatedGateFailsFastThenRecoversAtDeadlineWhileWorkersStillHung() async {
+        let limit = Constants.pasteProbeMaxConcurrent
+        let started = expectation(description: "cap-filling lookups started")
+        started.expectedFulfillmentCount = limit
+        started.assertForOverFulfill = true
+        let unblock = DispatchSemaphore(value: 0)
+        defer { for _ in 0..<limit { unblock.signal() } }
+
+        let hungProbe = PasteAvailabilityProbe(
+            lookup: { _ in
+                started.fulfill()
+                unblock.wait()
+                return true
+            },
+            timeout: 0.5
+        )
+
+        var parked: [Task<Bool?, Never>] = []
+        for _ in 0..<limit {
+            parked.append(Task { await hungProbe.probePaste(pid: 1) })
+        }
+        await fulfillment(of: [started], timeout: 2.0)
+
+        let overflowProbe = PasteAvailabilityProbe(
+            lookup: { _ in XCTFail("a saturated gate must not start another lookup"); return true },
+            timeout: Self.shortTimeout
+        )
+        let overflowStart = Date()
+        let overflow = await overflowProbe.probePaste(pid: 1)
+        XCTAssertNil(overflow, "saturated gate must report unknown")
+        XCTAssertLessThan(Date().timeIntervalSince(overflowStart), 0.3, "overflow must fail fast, not queue")
+
+        for task in parked {
+            let parkedResult = await task.value
+            XCTAssertNil(parkedResult, "parked probes must report unknown at the deadline")
+        }
+        try? await Task.sleep(nanoseconds: 100_000_000) // Wait for the detached release.
+
+        // Before the change, the blocked worker kept the permit.
+        let freshProbe = PasteAvailabilityProbe(lookup: { _ in false }, timeout: 1.0)
+        let freshStart = Date()
+        let fresh = await freshProbe.probePaste(pid: 1)
+        XCTAssertEqual(fresh, false, "permits must be free again after the deadline")
+        XCTAssertLessThan(Date().timeIntervalSince(freshStart), 0.3,
+                          "a fresh probe must not wait behind abandoned workers")
+    }
+
+    /// A completed lookup must release its permit. Later lookups must get their real result.
+    func testCompletedLookupsReleasePermitsAndPropagateResults() async {
+        let answers: [Bool?] = [true, false, nil, true, false, nil]
+        XCTAssertGreaterThan(answers.count, Constants.pasteProbeMaxConcurrent)
+        for expected in answers {
+            let probe = PasteAvailabilityProbe(lookup: { _ in expected }, timeout: 1.0)
+            let start = Date()
+            let result = await probe.probePaste(pid: 1)
+            XCTAssertEqual(result, expected)
+            XCTAssertLessThan(Date().timeIntervalSince(start), 0.5, "a fast lookup must not wait for the watchdog")
+            try? await Task.sleep(nanoseconds: 50_000_000) // Wait for the permit release.
+        }
     }
 }

--- a/Tests/OpenClipTests/PasteAvailabilityProbeTests.swift
+++ b/Tests/OpenClipTests/PasteAvailabilityProbeTests.swift
@@ -53,6 +53,31 @@ final class PasteAvailabilityProbeTests: XCTestCase {
         XCTAssertFalse(PasteAvailabilityProbe.isPaste(
             title: nil, cmdChar: "V", cmdCharModifiers: UInt(AXMenuItemModifiers.noCommand.rawValue)))
     }
+
+    func testFindMenuItemRespectsExpiredDeadline() {
+        let expiredDeadline = Date().addingTimeInterval(-1.0)
+        let result = AXMenuNavigator.findMenuItem(.paste, in: nil, deadline: expiredDeadline)
+        XCTAssertNil(result, "An expired deadline must immediately yield nil without searching")
+    }
+
+    func testDeadlineAwareLookupReceivesDeadline() async {
+        let deadlineReceived = expectation(description: "deadline received by lookup")
+        let probe = PasteAvailabilityProbe(
+            lookupWithDeadline: { pid, deadline in
+                XCTAssertEqual(pid, 42)
+                XCTAssertNotNil(deadline)
+                if let deadline {
+                    XCTAssertGreaterThan(deadline, Date())
+                }
+                deadlineReceived.fulfill()
+                return true
+            },
+            timeout: 0.5
+        )
+        let result = await probe.probePaste(pid: 42)
+        XCTAssertEqual(result, true)
+        await fulfillment(of: [deadlineReceived], timeout: 1.0)
+    }
 }
 
 /// This class covers issue #37. A blocked lookup must not stop later probes.

--- a/docs/architecture/known-debt.md
+++ b/docs/architecture/known-debt.md
@@ -227,7 +227,7 @@ areas; stale debt notes are worse than none.
 
 ## Concurrency
 
-- **Residual non-interruptible paths (documented).** Two spots remain that a hostile
+- **Residual non-interruptible paths (documented).** Three spots remain that a hostile
   or hung target can make block a background thread:
   (1) `SelectionRetrievalCoordinator.pressEditCopyMenu` starts an AXPress on the dedicated
   `com.openclip.ax-inspect` queue. The `pasteboardCopyTimeout` poll does not stop that press.
@@ -239,8 +239,14 @@ areas; stale debt notes are worse than none.
   later retrieval requests (see below);
   (2) an async-mode
   JS script with a top-level *synchronous* infinite loop blocks inside `evaluateScript`, which the
-  watchdog pump loop never reaches (the sync-evaluation gate covers only `isAsync == false`).
-  Neither path is main-actor-blocking.
+  watchdog pump loop never reaches (the sync-evaluation gate covers only `isAsync == false`);
+  (3) `PasteAvailabilityProbe.editPasteEnabled` walks the full menu bar. There is no total time limit.
+  Each AX message has a limit of `axReadTimeout`. A slow but live app can keep one walk
+  in progress for minutes after the caller stops at `pasteProbeTimeout`. The gate releases its permit
+  at the time limit, so later probes are not delayed. Up to
+  `Constants.pasteProbeMaxConcurrent` abandoned workers can occupy queue threads. Deferred fix:
+  pass a time limit through `AXMenuNavigator.findMenuItem` so the walk stops.
+  These paths do not block the main actor.
 - **AX inspect is deadline-capped.** `SelectionRetrievalCoordinator.inspectWithWatchdog` races
   `AXElementInspector.inspect` against
   `Constants.axReadTimeout` (0.5 s) via the `OnceResume` once-gate, running the blocking snapshot on
@@ -258,8 +264,11 @@ areas; stale debt notes are worse than none.
   `com.openclip.ax-inspect` queue: a hung AX call occupies one worker thread but later inspect
   snapshots and presses start on other threads, so a slow or stuck target no longer delays the next
   request's start. Each request still gets its own `axReadTimeout` deadline race.
-  (`PasteAvailabilityProbe` deliberately keeps its own `ax-probe` queue plus a
-  probe-slot gate so a stalled probe never spawns extra blocked workers.)
+  `PasteAvailabilityProbe` uses the same design (issue #37): a concurrent
+  `com.openclip.ax-probe` queue and a counting gate (`Constants.pasteProbeMaxConcurrent`, 4).
+  The side that ends the wait releases the permit at `pasteProbeTimeout`.
+  The old `probeSlot` stayed occupied until the blocked AX walk returned.
+  That stopped every later probe and changed all paste operations to copy.
 - **Subprocess pipe reads are non-blocking (hang fix).** `ShellProcessRunner` previously read stdout/
   stderr with blocking `readToEnd()` tasks and a `Task.sleep` watchdog — both can be starved, so a
   child (or grandchild) holding a pipe open could wedge the cooperative pool and hang the test

--- a/docs/architecture/known-debt.md
+++ b/docs/architecture/known-debt.md
@@ -240,12 +240,11 @@ areas; stale debt notes are worse than none.
   (2) an async-mode
   JS script with a top-level *synchronous* infinite loop blocks inside `evaluateScript`, which the
   watchdog pump loop never reaches (the sync-evaluation gate covers only `isAsync == false`);
-  (3) `PasteAvailabilityProbe.editPasteEnabled` walks the full menu bar. There is no total time limit.
-  Each AX message has a limit of `axReadTimeout`. A slow but live app can keep one walk
-  in progress for minutes after the caller stops at `pasteProbeTimeout`. The gate releases its permit
-  at the time limit, so later probes are not delayed. Up to
-  `Constants.pasteProbeMaxConcurrent` abandoned workers can occupy queue threads. Deferred fix:
-  pass a time limit through `AXMenuNavigator.findMenuItem` so the walk stops.
+  (3) `PasteAvailabilityProbe.editPasteEnabled` walks the menu bar up to an aggregate deadline
+  passed through `AXMenuNavigator.findMenuItem`. Each AX message also has a per-call limit of
+  `axReadTimeout`. An abandoned walk stops at `pasteProbeTimeout` (or upon completing an in-flight message),
+  so workers do not linger for minutes on the queue. The counting gate releases its permit at the deadline
+  (issue #37) so subsequent probes are never delayed.
   These paths do not block the main actor.
 - **AX inspect is deadline-capped.** `SelectionRetrievalCoordinator.inspectWithWatchdog` races
   `AXElementInspector.inspect` against

--- a/docs/logging.md
+++ b/docs/logging.md
@@ -60,7 +60,7 @@ Each subsystem owns a dedicated `LogChannel` property on `Log` under the `com.op
 | `coordinator`    | action coordination / enablement evaluation                 |
 | `shell`          | `ShellProcessRunner` (subprocess watchdog, timeout)         |
 | `js`             | `OpenClipJSHost` runtime                                    |
-| `selection`      | `SelectionRetrievalCoordinator` + strategies / `MacSelectionMonitor` (gate decisions, mode routing, AX + pasteboard + keyboard retrieval) |
+| `selection`      | `SelectionRetrievalCoordinator` + strategies / `MacSelectionMonitor` (gate decisions, mode routing, AX + pasteboard + keyboard retrieval); `PasteAvailabilityProbe` limit and time-limit results |
 | `extensions`     | `ExtensionManager`, remote installer, extension store/onboarding install & uninstall, **manifest decode/validation rejections** |
 | `ai`             | AI providers and preset persistence                         |
 | `permissions`    | TCC / accessibility permission management                   |


### PR DESCRIPTION
## Summary
`PasteAvailabilityProbe` no longer holds a single slot until a blocked AX walk returns. It now uses a concurrent `com.openclip.ax-probe` queue and a counting gate (`Constants.pasteProbeMaxConcurrent` = 4). The side that ends the wait (worker or 0.4 s watchdog) releases the permit, so later probes are not starved.

Fixes #37

Drive-by: `SelectionRetrievalCoordinator` deadline logs now use `privacy: .public`. They previously printed `<private>` for the timeout value.

**Note on the original issue text.** #36 (landed after #37 was filed) already caps each AX message at `Constants.axReadTimeout` (0.5 s). A SIGSTOP'd app no longer wedges forever on the first read. The remaining bug is a *responsive but busy* target: each reply arrives just under 0.5 s, one walk lasts minutes, and the old slot stayed held for all of it. That is what this PR fixes.

---

## Type of Change
- [x] Bug fix (non-breaking change fixing an issue)
- [ ] New feature (non-breaking change adding functionality)
- [ ] Extension Runtime / Bridge update (JS host, AppleScript runner, Shell executor)
- [ ] UI / Theme / Accessibility improvement
- [x] Performance / Concurrency optimization
- [ ] Localization (`Localizable.xcstrings`)
- [x] Documentation update
- [ ] Build tooling / CI / Scripts

---

## Testing & Verification

### Environment Tested:
- **macOS Version:** macOS 26.6.2
- **Architecture:** Apple Silicon M2
- **Target Apps Verified:** unit tests only (live SlowMenuApp checklist still needs Accessibility on the DerivedData build)

### Test Execution:
- [x] Ran `./scripts/test.sh core` (< 1s domain test suite)
- [x] Ran `./scripts/test.sh` (Full suite passes with 0 failures/skips)
- [ ] Tested live in app via `./scripts/dev_run.sh`

- [x] `./scripts/test.sh PasteAvailabilityProbeTests`
- [x] `./scripts/test.sh PasteAvailabilityProbeGateTests` (fail against the old serial `ProbeSlot`, pass after the fix)
- [x] `./scripts/test.sh SelectionRetrievalCoordinatorTests`

---

## Screenshots / Screen Recordings (if applicable)
N/A (concurrency/gate fix, no UI change)

---

## Architectural & Code Checklist
- [x] **Swift 6 Concurrency:** Builds cleanly with complete strict concurrency (`SWIFT_STRICT_CONCURRENCY: complete`) with zero data races.
- [x] **Core Purity:** No `AppKit` or `SwiftUI` imports in `Sources/Core/`.
- [x] **Settings & Secrets:** Uses `SettingsStore` / `SecretStore` (no direct `UserDefaults.standard` in new code).
- [x] **Subprocess Safety:** Any new subprocess enforces `Constants.scriptTimeout` (30 s) watchdog and non-blocking I/O.
- [x] **Dual-Sink Logging:** Logs through `Log` subsystem categories (no raw `print()` or ad-hoc `Logger()`).
- [x] **Localization:** User-facing strings use `String(localized:)` and are recorded in `Localizable.xcstrings`.

## Out of scope
- Extracting the shared watchdog-gate pattern (now three copies)
- Bounding `AXMenuNavigator.findMenuItem` with an aggregate deadline (documented as residual debt)
- `assumePaste` fast path, stale AX permission cache, and the three different meanings of probe `nil`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Paste operations are no longer incorrectly converted to copy when the target app is blocked or slow.
  * Paste availability checks now time out promptly, allowing subsequent checks to continue instead of remaining stalled.
  * Completed checks continue to return their results correctly, while unavailable checks fail without blocking future attempts.
  * Keyboard shortcuts and palette commands now work reliably when the popup is not currently visible.

* **Documentation**
  * Updated release notes and technical documentation to reflect paste-check time limits, concurrency behavior, and related logging.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->