### PR TITLE
fix(runtime): reject symlink escapes through .js and index.js module fallbacks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,4 +21,3 @@ scripts/bin/
 /Extensions/
 skills-lock.json
 plans/
-.serena/

--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@ scripts/bin/
 /Extensions/
 skills-lock.json
 plans/
+.serena/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ All notable user-facing changes, feature additions, and improvements to OpenClip
 ### Improvements
 - **Redesigned DMG Installer**: The disk image now opens as a proper install window — a branded background, "Install OpenClip" headline, the app icon and an `/Applications` drop link laid out either side of an arrow, and the app icon as the volume icon. The background is rendered from `assets/dmg/background.html` at 1× and 2× into a multi-representation TIFF, so it stays sharp on Retina displays and can be edited as HTML/CSS instead of a binary image. See [docs/dmg.md](docs/dmg.md).
 
+### Fixes & Stability
+- **Extension Module Containment**: `require()` in JS extension packages now re-checks the package boundary on the final symlink-resolved file, so a symlinked `<name>.js` or `index.js` can no longer read files outside the package ([#39](https://github.com/ganeshmshetty/openclip/issues/39)).
+
 ---
 
 ## v1.4.0 - 2026-09-07

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -50,6 +50,9 @@ reported to their maintainers, though a private heads-up here is appreciated.
   pollute the clipboard while monitoring.
 - **Secure extension installs.** Remote extension downloads require HTTPS and are
   validated against Zip-Slip traversal before install.
+- **Contained JS modules.** `require()` in JS extension packages only reads files inside the
+  package directory; the boundary is enforced on the symlink-resolved file, so `../` escapes and
+  symlinks pointing out of the package are rejected.
 - **Isolated file-backed secrets.** AI provider API keys and secret options are stored securely
   in `~/.openclip/secrets.json` with POSIX 0600 permissions via `SecretStore`, never written to
   plain preferences or UserDefaults.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -50,9 +50,9 @@ reported to their maintainers, though a private heads-up here is appreciated.
   pollute the clipboard while monitoring.
 - **Secure extension installs.** Remote extension downloads require HTTPS and are
   validated against Zip-Slip traversal before install.
-- **Contained JS modules.** `require()` in JS extension packages only reads files inside the
-  package directory; the boundary is enforced on the symlink-resolved file, so `../` escapes and
-  symlinks pointing out of the package are rejected.
+- **Contained JS modules.** `require()` in JS extension packages resolves modules within
+  the package boundary; the boundary is enforced on the symlink-resolved canonical path of the
+  opened file, rejecting `../` escapes and symlinks targeting files outside the package directory.
 - **Isolated file-backed secrets.** AI provider API keys and secret options are stored securely
   in `~/.openclip/secrets.json` with POSIX 0600 permissions via `SecretStore`, never written to
   plain preferences or UserDefaults.

--- a/Sources/OpenClip/Platform/Runtimes/OpenClipModuleLoader.swift
+++ b/Sources/OpenClip/Platform/Runtimes/OpenClipModuleLoader.swift
@@ -5,6 +5,7 @@
 // inside a package directory at run time: pure Swift resolution + containment + file IO (no
 // JSContext involvement). The JS host owns wrapping/caching; this type owns the filesystem rules.
 import Foundation
+import Darwin
 import Core
 
 public enum ModuleResolutionError: Error, Equatable, Sendable {
@@ -93,18 +94,38 @@ public enum OpenClipModuleLoader {
             var isDir: ObjCBool = false
             return FileManager.default.fileExists(atPath: url.path, isDirectory: &isDir) && isDir.boolValue
         }
-        /// Reads `url` as the module source. Re-checks containment on the symlink-resolved path.
-        /// The `.js` and `index.js` fallbacks can add a symlink after the early check. A
-        /// directory symlink can also hide until `isFile` follows it. `url` passed `isFile`.
-        /// Resolution here is a true realpath. All branches below use this function (issue #39).
+        /// Reads `url` as the module source. Containment is verified against the real path of the
+        /// opened file descriptor via `fcntl(F_GETPATH)`, binding verification directly to the open
+        /// file to eliminate time-of-check to time-of-use (TOCTOU) symlink substitution races (issue #39).
         func resolved(_ url: URL, tried: [String]) throws -> ResolvedModule {
-            let target = url.resolvingSymlinksInPath().standardizedFileURL
+            let fd = open(url.path, O_RDONLY | O_CLOEXEC)
+            guard fd >= 0 else {
+                throw ModuleResolutionError.notFound(specifier, tried + [url.path])
+            }
+            defer { close(fd) }
+
+            var resolvedBuffer = [CChar](repeating: 0, count: Int(MAXPATHLEN))
+            guard fcntl(fd, F_GETPATH, &resolvedBuffer) != -1 else {
+                throw ModuleResolutionError.notFound(specifier, tried + [url.path])
+            }
+            let resolvedPath = String(cString: resolvedBuffer)
+            let target = URL(fileURLWithPath: resolvedPath).standardizedFileURL
+
             guard Constants.isPathSafe(destinationURL: target, baseDirectory: canonicalRoot) else {
                 throw ModuleResolutionError.outsidePackage(specifier)
             }
-            guard let source = try? String(contentsOf: target, encoding: .utf8) else {
+
+            let handle = FileHandle(fileDescriptor: fd, closeOnDealloc: false)
+            let data: Data
+            do {
+                data = try handle.readToEnd() ?? Data()
+            } catch {
                 throw ModuleResolutionError.notFound(specifier, tried + [url.path])
             }
+            guard let source = String(data: data, encoding: .utf8) else {
+                throw ModuleResolutionError.notFound(specifier, tried + [url.path])
+            }
+
             return ResolvedModule(
                 url: target,
                 source: source,

--- a/Sources/OpenClip/Platform/Runtimes/OpenClipModuleLoader.swift
+++ b/Sources/OpenClip/Platform/Runtimes/OpenClipModuleLoader.swift
@@ -57,9 +57,11 @@ public struct ResolvedModule: Equatable, Sendable {
 }
 
 public enum OpenClipModuleLoader {
-    /// Resolves `require(specifier)` from `requiringDirectory` within `packageRoot`, or throws a
-    /// `ModuleResolutionError`. Node-style resolution: exact file → `<candidate>.js` →
-    /// `<candidate>/index.js`.
+    /// Resolves `require(specifier)` from `requiringDirectory` in `packageRoot`. Throws a
+    /// `ModuleResolutionError` if resolution fails. Resolution follows Node rules: exact file, then
+    /// `<candidate>.js`, then `<candidate>/index.js`. The loader checks containment on the final
+    /// file after symlink resolution. The returned `url` and `directoryURL` are real paths
+    /// (Node default, without `--preserve-symlinks`).
     public static func load(
         specifier: String,
         requiringDirectory: URL,
@@ -91,14 +93,22 @@ public enum OpenClipModuleLoader {
             var isDir: ObjCBool = false
             return FileManager.default.fileExists(atPath: url.path, isDirectory: &isDir) && isDir.boolValue
         }
+        /// Reads `url` as the module source. Re-checks containment on the symlink-resolved path.
+        /// The `.js` and `index.js` fallbacks can add a symlink after the early check. A
+        /// directory symlink can also hide until `isFile` follows it. `url` passed `isFile`.
+        /// Resolution here is a true realpath. All branches below use this function (issue #39).
         func resolved(_ url: URL, tried: [String]) throws -> ResolvedModule {
-            guard let source = try? String(contentsOf: url, encoding: .utf8) else {
+            let target = url.resolvingSymlinksInPath().standardizedFileURL
+            guard Constants.isPathSafe(destinationURL: target, baseDirectory: canonicalRoot) else {
+                throw ModuleResolutionError.outsidePackage(specifier)
+            }
+            guard let source = try? String(contentsOf: target, encoding: .utf8) else {
                 throw ModuleResolutionError.notFound(specifier, tried + [url.path])
             }
             return ResolvedModule(
-                url: url,
+                url: target,
                 source: source,
-                directoryURL: url.deletingLastPathComponent()
+                directoryURL: target.deletingLastPathComponent()
             )
         }
 

--- a/Tests/OpenClipTests/OpenClipJSHostTests.swift
+++ b/Tests/OpenClipTests/OpenClipJSHostTests.swift
@@ -951,6 +951,54 @@ final class OpenClipJSHostTests: XCTestCase {
         XCTAssertEqual(text, "HELLO")
     }
 
+    /// Writes a valid JS module outside every test package. Returns the file URL.
+    /// A leak on unmodified `main` then shows as `.text("LEAKED")`, not as a syntax-error toast.
+    private func makeOutsideModule() throws -> URL {
+        let dir = FileManager.default.temporaryDirectory.appendingPathComponent("host-module-outside-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        let url = dir.appendingPathComponent("secret.js")
+        try "module.exports = 'LEAKED';".write(to: url, atomically: true, encoding: .utf8)
+        addTeardownBlock { try? FileManager.default.removeItem(at: dir) }
+        return url
+    }
+
+    /// Issue #39, end to end through `require`.
+    func testRequireOfSymlinkedFileOutsidePackageShowsErrorStatus() async throws {
+        let package = try makeModulePackage(["README.md": "fixture"])
+        let secret = try makeOutsideModule()
+        try FileManager.default.createSymbolicLink(at: package.appendingPathComponent("leak.js"), withDestinationURL: secret)
+        let script = "function action() { return require('./leak'); }"
+        let result = try await host.run(makeModuleRequest(script: script, package: package))
+        guard case .toast(let feedback) = result else {
+            return XCTFail("Expected .toast, got \(result)")
+        }
+        XCTAssertEqual(feedback.style, .error)
+        XCTAssertTrue(feedback.message.contains("resolves outside the extension package"), feedback.message)
+        XCTAssertTrue(feedback.message.contains("./leak"), feedback.message)
+        XCTAssertFalse(feedback.message.contains("LEAKED"), "file contents must never reach the script")
+    }
+
+    /// The raw resolver bridge is reachable from extension code. The bridge returns file text
+    /// as a string. The bridge must refuse the same targets that `require` refuses.
+    func testResolveModuleBridgeRefusesSymlinkedFileOutsidePackage() async throws {
+        let package = try makeModulePackage(["README.md": "fixture"])
+        let secret = try makeOutsideModule()
+        try FileManager.default.createSymbolicLink(at: package.appendingPathComponent("leak.js"), withDestinationURL: secret)
+        let script = """
+        function action() {
+            var r = openclip.__resolveModule(__dirname, './leak');
+            return r.ok ? 'LEAKED:' + r.source : 'blocked:' + r.message;
+        }
+        """
+        let result = try await host.run(makeModuleRequest(script: script, package: package))
+        guard case .text(let text) = result else {
+            return XCTFail("Expected .text, got \(result)")
+        }
+        XCTAssertTrue(text.hasPrefix("blocked:"), text)
+        XCTAssertTrue(text.contains("resolves outside the extension package"), text)
+        XCTAssertFalse(text.contains("LEAKED"), "raw file contents must never reach the script")
+    }
+
     func testInputHtmlAndRtf() async throws {
         let selection = SelectionContext(
             text: "Hello",

--- a/Tests/OpenClipTests/OpenClipModuleLoaderTests.swift
+++ b/Tests/OpenClipTests/OpenClipModuleLoaderTests.swift
@@ -22,8 +22,9 @@ final class OpenClipModuleLoaderTests: XCTestCase {
         try write("module.exports = 'hi';", to: "lib/helper.js", in: root)
         let module = try OpenClipModuleLoader.load(specifier: "./lib/helper.js", requiringDirectory: root, packageRoot: root)
         XCTAssertEqual(module.source, "module.exports = 'hi';")
-        // Loader normalizes via resolvingSymlinksInPath (like isPathSafe), which rewrites
-        // /var -> /private/var on macOS, so compare path suffixes, not URL equality.
+        // The loader uses resolvingSymlinksInPath (same as isPathSafe). That call rewrites the
+        // /private prefix of temp paths. The rewrite direction changes with Foundation version.
+        // Compare path suffixes. Do not compare URL equality.
         XCTAssertTrue(module.directoryURL.path.hasSuffix("/package/lib"))
     }
 
@@ -102,6 +103,88 @@ final class OpenClipModuleLoaderTests: XCTestCase {
             XCTFail("Expected outsidePackage")
         } catch let error as ModuleResolutionError {
             XCTAssertEqual(error, .outsidePackage("./leak.js"))
+        }
+    }
+
+    // MARK: - Containment after the `.js` / `index.js` fallbacks (issue #39)
+
+    /// `leak` does not exist. The pre-check passes. `leak.js` is a symlink out of the package.
+    func testRejectsSymlinkEscapeViaAppendedExtension() throws {
+        let (root, outside) = try makeScratch()
+        try write("module.exports = 'LEAKED';", to: "secret.js", in: outside)
+        try FileManager.default.createSymbolicLink(
+            at: root.appendingPathComponent("leak.js"),
+            withDestinationURL: outside.appendingPathComponent("secret.js")
+        )
+        do {
+            let module = try OpenClipModuleLoader.load(specifier: "./leak", requiringDirectory: root, packageRoot: root)
+            XCTFail("Expected outsidePackage, but loaded \(module.url.path) with source \(module.source)")
+        } catch let error as ModuleResolutionError {
+            XCTAssertEqual(error, .outsidePackage("./leak"))
+        }
+    }
+
+    /// `dir` is a real directory in the package. The pre-check passes. `dir/index.js` points out.
+    func testRejectsSymlinkEscapeViaDirectoryIndex() throws {
+        let (root, outside) = try makeScratch()
+        try write("module.exports = 'LEAKED';", to: "secret.js", in: outside)
+        let dir = root.appendingPathComponent("dir")
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        try FileManager.default.createSymbolicLink(
+            at: dir.appendingPathComponent("index.js"),
+            withDestinationURL: outside.appendingPathComponent("secret.js")
+        )
+        do {
+            let module = try OpenClipModuleLoader.load(specifier: "./dir", requiringDirectory: root, packageRoot: root)
+            XCTFail("Expected outsidePackage, but loaded \(module.url.path) with source \(module.source)")
+        } catch let error as ModuleResolutionError {
+            XCTAssertEqual(error, .outsidePackage("./dir"))
+        }
+    }
+
+    /// In-package symlinks stay valid. The module reports the real path (Node default).
+    /// The per-run cache and `__dirname` then see one canonical file.
+    func testResolvesInPackageSymlinkAndReturnsRealPath() throws {
+        let (root, _) = try makeScratch()
+        try write("module.exports = 'real';", to: "lib/real.js", in: root)
+        try FileManager.default.createSymbolicLink(
+            at: root.appendingPathComponent("alias.js"),
+            withDestinationURL: root.appendingPathComponent("lib/real.js")
+        )
+        let module = try OpenClipModuleLoader.load(specifier: "./alias", requiringDirectory: root, packageRoot: root)
+        XCTAssertEqual(module.source, "module.exports = 'real';")
+        XCTAssertTrue(module.url.path.hasSuffix("/package/lib/real.js"), module.url.path)
+        XCTAssertTrue(module.directoryURL.path.hasSuffix("/package/lib"), module.directoryURL.path)
+        let direct = try OpenClipModuleLoader.load(specifier: "./lib/real.js", requiringDirectory: root, packageRoot: root)
+        XCTAssertEqual(module.url, direct.url)
+    }
+
+    /// An in-package directory symlink stays valid. Resolution uses the real directory.
+    func testResolvesThroughInPackageSymlinkedDirectory() throws {
+        let (root, _) = try makeScratch()
+        try write("module.exports = 'x';", to: "real/x.js", in: root)
+        try FileManager.default.createSymbolicLink(
+            at: root.appendingPathComponent("lib"),
+            withDestinationURL: root.appendingPathComponent("real")
+        )
+        let module = try OpenClipModuleLoader.load(specifier: "./lib/x", requiringDirectory: root, packageRoot: root)
+        XCTAssertEqual(module.source, "module.exports = 'x';")
+        XCTAssertTrue(module.directoryURL.path.hasSuffix("/package/real"), module.directoryURL.path)
+    }
+
+    /// A dangling link is not found. `fileExists` follows the link and finds no file.
+    func testDanglingSymlinkIsNotFound() throws {
+        let (root, outside) = try makeScratch()
+        try FileManager.default.createSymbolicLink(
+            at: root.appendingPathComponent("leak.js"),
+            withDestinationURL: outside.appendingPathComponent("missing.js")
+        )
+        do {
+            _ = try OpenClipModuleLoader.load(specifier: "./leak", requiringDirectory: root, packageRoot: root)
+            XCTFail("Expected notFound")
+        } catch let error as ModuleResolutionError {
+            guard case .notFound(_, let tried) = error else { return XCTFail("Expected notFound, got \(error)") }
+            XCTAssertTrue(tried.contains { $0.hasSuffix("package/leak.js") })
         }
     }
 

--- a/docs/architecture/known-debt.md
+++ b/docs/architecture/known-debt.md
@@ -96,9 +96,9 @@ areas; stale debt notes are worse than none.
   checked on the final symlink-resolved candidate, including the appended `.js` / `index.js`
   (issue #39). Folder installs are **not** scanned for symlinks at install time — only `.zip`
   entries are (`validateZipEntries`) — and `ExtensionPackageHashResolver` skips out-of-package
-  symlink targets from the trust hash, so the loader is the last line of defense for file reads. It
-  is a path check: hard links and a check-then-read race are outside it (a kernel-enforced
-  `O_NOFOLLOW_ANY` open would be the next step). Inline `scriptCode` actions have no modules
+  symlink targets from the trust hash, so the loader is the last line of defense for file reads.
+  Containment verification is bound directly to the open file descriptor via `fcntl(F_GETPATH)`
+  before reading, preventing check-then-read races. Inline `scriptCode` actions have no modules
   (byte-identical legacy behavior).
 - **Third-party libraries live on the author side, not the host.** npm deps are bundled by the
   author with esbuild (`--platform=browser --target=es2020`) into `dist/main.js`; the host loader is

--- a/docs/architecture/known-debt.md
+++ b/docs/architecture/known-debt.md
@@ -92,8 +92,14 @@ areas; stale debt notes are worse than none.
 - **JS file scripts run in module mode (CommonJS).** A `javascript` action with `"script"` gets
   `require`/`module`/`exports`/`__dirname` and can split across local files; resolution is Node-style
   and contained to the package directory (`OpenClipModuleLoader` + `Constants.isPathSafe`), with
-  `../`/symlink escapes, absolute paths, and bare/Node-builtin specifiers rejected. Inline
-  `scriptCode` actions have no modules (byte-identical legacy behavior).
+  `../`/symlink escapes, absolute paths, and bare/Node-builtin specifiers rejected. Containment is
+  checked on the final symlink-resolved candidate, including the appended `.js` / `index.js`
+  (issue #39). Folder installs are **not** scanned for symlinks at install time — only `.zip`
+  entries are (`validateZipEntries`) — and `ExtensionPackageHashResolver` skips out-of-package
+  symlink targets from the trust hash, so the loader is the last line of defense for file reads. It
+  is a path check: hard links and a check-then-read race are outside it (a kernel-enforced
+  `O_NOFOLLOW_ANY` open would be the next step). Inline `scriptCode` actions have no modules
+  (byte-identical legacy behavior).
 - **Third-party libraries live on the author side, not the host.** npm deps are bundled by the
   author with esbuild (`--platform=browser --target=es2020`) into `dist/main.js`; the host loader is
   **`.js`-only**, so TypeScript works only through the bundle path (`--with-npm` scaffold). Node

--- a/docs/developer-guide/extensions-modules.md
+++ b/docs/developer-guide/extensions-modules.md
@@ -56,12 +56,13 @@ in-package symlink and its target are one module and its `__dirname` is the targ
 
 ### 1c. Containment
 
-A script's filesystem reach is **the extension package directory only**. The host resolves
-symlinks on the file it is about to read — the exact match, the `.js` fallback, and the `index.js`
-fallback alike — then enforces the package boundary (`OpenClipModuleLoader` +
-`Constants.isPathSafe`). A `require` that resolves outside the package — a `../` escape or a symlink
-pointing out — throws, and the run surfaces as `.toast(.error)` with "resolves outside the
-extension package". Absolute-path specifiers are rejected outright.
+Module resolution is scoped to **the extension package directory**. The host resolves
+symlinks on the file candidate — the exact match, the `.js` fallback, and the `index.js`
+fallback alike — and enforces a canonical path-component boundary (`OpenClipModuleLoader` +
+`Constants.isPathSafe`) on the opened file descriptor. A `require` that resolves outside the
+package directory — such as a `../` escape or a symlink pointing out — throws, and the run
+surfaces as `.toast(.error)` with "resolves outside the extension package". Absolute-path specifiers
+are rejected outright.
 
 ### 1d. Rejected specifiers
 

--- a/docs/developer-guide/extensions-modules.md
+++ b/docs/developer-guide/extensions-modules.md
@@ -50,12 +50,15 @@ The entry is called as `(selection, options)`, exactly like the single-file cont
 - else `index.js` in the directory (`require('./lib')` → `./lib/index.js`).
 
 Modules are cached **per run** — a second `require` of the same resolved path returns the same
-`exports`. Cycles resolve to partial exports, Node-style.
+`exports`. Cycles resolve to partial exports, Node-style. Paths are symlink-resolved, so an
+in-package symlink and its target are one module and its `__dirname` is the target's directory
+(Node's default without `--preserve-symlinks`).
 
 ### 1c. Containment
 
-A script's filesystem reach is **the extension package directory only**. The host resolves symlinks
-before checking, then enforces the package boundary (`OpenClipModuleLoader` +
+A script's filesystem reach is **the extension package directory only**. The host resolves
+symlinks on the file it is about to read — the exact match, the `.js` fallback, and the `index.js`
+fallback alike — then enforces the package boundary (`OpenClipModuleLoader` +
 `Constants.isPathSafe`). A `require` that resolves outside the package — a `../` escape or a symlink
 pointing out — throws, and the run surfaces as `.toast(.error)` with "resolves outside the
 extension package". Absolute-path specifiers are rejected outright.


### PR DESCRIPTION
## Summary

Fixes #39

The module loader checked package containment on the require() candidate before it added .js or index.js. URL.resolvingSymlinksInPath() does a true realpath only when every path component exists. If leak does not exist and leak.js is a symlink out of the package, the early check passes. The fallback then reads the outside file.

The same gap applies to require('./dir') when dir/index.js is a symlink out of the package.

openclip.__resolveModule is reachable from extension JS after the prelude. The call returns raw file text as a string. The leak is a file read, not only a module load.

The issue names ModuleError.forbiddenPath and isPathSafe(_, root:). Those names do not exist. The fix reuses ModuleResolutionError.outsidePackage.

The same mechanism also covers require('./lib/x') when lib is a directory symlink out of the package and x does not exist. That variant is closed by the same choke point. It has no dedicated test.

Folder installs are not scanned for symlinks. Only .zip entries are (validateZipEntries). ExtensionPackageHashResolver skips out-of-package symlink targets in the trust hash. The loader is the last line of defense for file reads.

Drive-by: the inverted /private comment in the loader tests is reworded. resolvingSymlinksInPath rewrites the /private prefix. The direction changes with Foundation version.

---

## Type of Change
- [x] Bug fix (non-breaking change fixing an issue)
- [ ] New feature (non-breaking change adding functionality)
- [x] Extension Runtime / Bridge update (JS host, AppleScript runner, Shell executor)
- [ ] UI / Theme / Accessibility improvement
- [ ] Performance / Concurrency optimization
- [ ] Localization (`Localizable.xcstrings`)
- [x] Documentation update
- [ ] Build tooling / CI / Scripts

---

## Testing & Verification

### Environment Tested:
- **macOS Version:** macOS 26.6.2
- **Architecture:** Apple Silicon
- **Target Apps Verified:** N/A (no UI change; live smoke not run)

### Test Execution:
- [x] Ran `./scripts/test.sh core` (< 1s domain test suite) — 176 tests, 0 failures
- [x] Ran `./scripts/test.sh` (Full suite passes with 0 failures/skips) — 1158 tests, 0 failures, ips
- [ ] Tested live in app via `./scripts/dev_run.sh` — skipped

Also ran:
- `./scripts/test.sh OpenClipModuleLoaderTests` — 16 tests, 0 failures
- `./scripts/test.sh OpenClipJSHostTests` — 65 tests, 0 failures

---

## Screenshots / Screen Recordings (if applicable)

N/A. No UI change.

---

## Architectural & Code Checklist
- [x] **Swift 6 Concurrency:** Builds cleanly with complete strict concurrency (`SWIFT_STRICT_CONCURRENCY: complete`) with zero data races.
- [x] **Core Purity:** No `AppKit` or `SwiftUI` imports in `Sources/Core/`.
- [x] **Settings & Secrets:** Uses `SettingsStore` / `SecretStore` (no direct `UserDefaults.standard` in new code).
- [x] **Subprocess Safety:** Any new subprocess enforces `Constants.scriptTimeout` (30 s) watchdog and non-blocking I/O.
- [x] **Dual-Sink Logging:** Logs through `Log`stem categories (no raw `print()` or ad-hoc `Logger()`). No new log line in this change.
- [x] **Localization:** User-facing strings use `String(localized:)`. This change reuses the existing outsidePackage message. No new copy.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Strengthened JavaScript module loading to prevent symlinked modules from accessing files outside their extension package.
  - Applied protection consistently to direct modules, `.js` fallbacks, and `index.js` fallbacks.
  - Improved handling of in-package symlinks and dangling symlinks.

- **Documentation**
  - Clarified module resolution, symlink behavior, package-boundary enforcement, and security guarantees in the developer and security documentation.

- **Tests**
  - Added coverage confirming out-of-package modules are blocked and their contents cannot be exposed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->