### PR TITLE
fix(release): build universal binaries so Intel Macs can install OpenClip

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ All notable user-facing changes, feature additions, and improvements to OpenClip
 
 ## Unreleased
 
+### Fixes & Stability
+- **Intel Mac Support Restored**: Released builds are universal again. Every release since the CI runner moved to Apple Silicon shipped an arm64-only app, so Intel Macs refused to launch it with "not supported on this type of Mac" — the `.zip` and the `.dmg` now both carry arm64 and x86_64 slices, and the release fails rather than publishing if either one does not.
+
 ### Improvements
 - **Redesigned DMG Installer**: The disk image now opens as a proper install window — a branded background, "Install OpenClip" headline, the app icon and an `/Applications` drop link laid out either side of an arrow, and the app icon as the volume icon. The background is rendered from `assets/dmg/background.html` at 1× and 2× into a multi-representation TIFF, so it stays sharp on Retina displays and can be edited as HTML/CSS instead of a binary image. See [docs/dmg.md](docs/dmg.md).
 

--- a/scripts/package_app.sh
+++ b/scripts/package_app.sh
@@ -22,6 +22,10 @@ fi
 echo "Signing app bundle and embedded frameworks ad-hoc..."
 codesign --force --deep --sign - "$BUILT_APP"
 
+# CI runs this script on every push, so this is where an arm64-only regression gets caught
+# before it can reach a tag.
+"$PROJECT_DIR/scripts/verify_universal.sh" "$BUILT_APP" "OpenClip.app"
+
 mkdir -p "$PROJECT_DIR/build"
 OUTPUT_ZIP="$PROJECT_DIR/build/OpenClip.zip"
 OUTPUT_DMG="$PROJECT_DIR/build/OpenClip.dmg"

--- a/scripts/release_update.sh
+++ b/scripts/release_update.sh
@@ -46,11 +46,18 @@ echo "==> Building OpenClip v$VERSION (Release)..."
 mkdir -p "$BUILD_DIR"
 rm -rf "${BUILD_DIR:?}"/*
 
+# Without an explicit destination xcodebuild resolves the scheme's default one — "My Mac" —
+# and narrows the build to that Mac's architecture, so on an Apple Silicon runner it emits an
+# arm64-only app however ARCHS is configured. 'generic/platform=macOS' plus the explicit ARCHS
+# is what keeps the release universal; scripts/package_app.sh builds the same way.
 xcodebuild \
     -project "$PROJECT_DIR/OpenClip.xcodeproj" \
     -scheme OpenClip \
     -configuration Release \
     -derivedDataPath "$DERIVED_DATA" \
+    -destination 'generic/platform=macOS' \
+    ARCHS='arm64 x86_64' \
+    ONLY_ACTIVE_ARCH=NO \
     CODE_SIGN_IDENTITY="-" \
     CODE_SIGN_STYLE=Manual \
     DEVELOPMENT_TEAM="" \
@@ -65,6 +72,8 @@ fi
 echo "==> Ad-hoc signing (required for Apple Silicon)..."
 codesign --force --deep -s - "$APP_PATH"
 
+"$SCRIPT_DIR/verify_universal.sh" "$APP_PATH" "build product"
+
 echo "==> Packaging OpenClip-v$VERSION.zip..."
 ZIP_NAME="OpenClip-v$VERSION.zip"
 cd "$BUILD_DIR"
@@ -72,6 +81,16 @@ cd "$BUILD_DIR"
 rm -f "$ZIP_NAME" "$BUILD_DIR/appcast.xml"
 rm -rf ~/Library/Caches/Sparkle_generate_appcast
 ditto -c -k --sequesterRsrc --keepParent "$APP_PATH" "$ZIP_NAME"
+
+# Check the archive itself, not just the bundle it was cut from, and do it before the appcast
+# is signed so a bad build can never be handed to Sparkle. The scratch directory lives outside
+# BUILD_DIR because generate_appcast scans BUILD_DIR for release archives.
+VERIFY_DIR="$PROJECT_DIR/build/.verify"
+rm -rf "$VERIFY_DIR"
+mkdir -p "$VERIFY_DIR"
+ditto -x -k "$BUILD_DIR/$ZIP_NAME" "$VERIFY_DIR"
+"$SCRIPT_DIR/verify_universal.sh" "$VERIFY_DIR/OpenClip.app" "$ZIP_NAME"
+rm -rf "$VERIFY_DIR"
 
 echo "==> Generating appcast.xml with Ed25519 signature..."
 
@@ -163,6 +182,17 @@ fi
 echo "==> Packaging OpenClip-v$VERSION.dmg..."
 DMG_NAME="OpenClip-v$VERSION.dmg"
 "$SCRIPT_DIR/make_dmg.sh" "$APP_PATH" "$BUILD_DIR/$DMG_NAME"
+
+# The .dmg is the download the website points at, so it gets the same check as the .zip.
+MOUNT_POINT="$(mktemp -d)"
+hdiutil attach "$BUILD_DIR/$DMG_NAME" -mountpoint "$MOUNT_POINT" -nobrowse -readonly -quiet
+if ! "$SCRIPT_DIR/verify_universal.sh" "$MOUNT_POINT/OpenClip.app" "$DMG_NAME"; then
+    hdiutil detach "$MOUNT_POINT" -quiet || true
+    rmdir "$MOUNT_POINT" 2>/dev/null || true
+    exit 1
+fi
+hdiutil detach "$MOUNT_POINT" -quiet
+rmdir "$MOUNT_POINT" 2>/dev/null || true
 
 echo ""
 echo "==> Done! Release artifacts created:"

--- a/scripts/verify_universal.sh
+++ b/scripts/verify_universal.sh
@@ -1,0 +1,64 @@
+#!/bin/bash
+# verify_universal.sh
+#
+# Fails if any Mach-O binary inside an app bundle is missing the arm64 or x86_64 slice.
+#
+# Release artifacts are built on an Apple Silicon runner, where an arm64-only build looks
+# completely healthy right up until an Intel user tries to launch it and macOS refuses with
+# "not supported on this type of Mac". Checking the build settings is not enough to catch
+# that: `xcodebuild -showBuildSettings` reports the universal ARCHS even for invocations
+# that go on to produce a thin arm64 binary. So this inspects the finished bundle instead,
+# and release_update.sh runs it against the .zip and the .dmg separately rather than only
+# against the build product they are cut from.
+#
+# Usage: ./scripts/verify_universal.sh <path-to-OpenClip.app> [label]
+
+set -euo pipefail
+
+APP_PATH="${1:-}"
+
+if [ -z "$APP_PATH" ]; then
+    echo "usage: $0 <path-to-OpenClip.app> [label]" >&2
+    exit 2
+fi
+
+if [ ! -d "$APP_PATH" ]; then
+    echo "error: app bundle not found at $APP_PATH" >&2
+    exit 1
+fi
+
+LABEL="${2:-$(basename "$APP_PATH")}"
+REQUIRED_ARCHS="arm64 x86_64"
+CHECKED=0
+FAILED=0
+
+# Sparkle ships prebuilt and is already universal; the app binary and Core.framework are the
+# ones we compile, so they are the ones that go thin. Walk everything anyway — a future
+# embedded helper should not be able to slip through unchecked.
+while IFS= read -r CANDIDATE; do
+    file -b "$CANDIDATE" | grep -q "Mach-O" || continue
+    FOUND="$(lipo -archs "$CANDIDATE" 2>/dev/null || true)"
+    [ -n "$FOUND" ] || continue
+    CHECKED=$((CHECKED + 1))
+    for ARCH in $REQUIRED_ARCHS; do
+        case " $FOUND " in
+            *" $ARCH "*) ;;
+            *)
+                echo "error: ${CANDIDATE#"$APP_PATH"/} is missing the $ARCH slice (has: $FOUND)" >&2
+                FAILED=1
+                ;;
+        esac
+    done
+done < <(find "$APP_PATH" -type f)
+
+if [ "$CHECKED" -eq 0 ]; then
+    echo "error: no Mach-O binaries found under $APP_PATH — wrong path?" >&2
+    exit 1
+fi
+
+if [ "$FAILED" -ne 0 ]; then
+    echo "error: $LABEL is not a universal build; Intel Macs cannot launch it." >&2
+    exit 1
+fi
+
+echo "==> Verified $LABEL: $CHECKED Mach-O binaries, all universal ($REQUIRED_ARCHS)."


### PR DESCRIPTION
## Summary

Every published OpenClip release is **arm64-only**, so Intel Macs cannot launch it — macOS rejects it with *"not supported on this type of Mac."* This was reported by a user on macOS 15.7.7, which is well within our supported range.

Running `lipo -archs` on the shipped `OpenClip-v1.4.0.zip` asset:

| Binary | Architectures |
| --- | --- |
| `Contents/MacOS/OpenClip` | `arm64` |
| `Core.framework/Versions/A/Core` | `arm64` |
| `Sparkle.framework/…/Sparkle` | `x86_64 arm64` |
| `Sparkle.framework/…/Autoupdate` | `x86_64 arm64` |
| `Sparkle.framework/…/Updater` | `x86_64 arm64` |
| `Sparkle…/Downloader.xpc` | `x86_64 arm64` |
| `Sparkle…/Installer.xpc` | `x86_64 arm64` |

Only the two binaries **we** compile are thin. Sparkle ships prebuilt and was universal all along.

### Root cause

93d2c67 added `-destination 'generic/platform=macOS' ARCHS='arm64 x86_64' ONLY_ACTIVE_ARCH=NO` to `package_app.sh` and CI when the runner moved to `macos-26` — but not to `scripts/release_update.sh`, which is the script `release.yml` actually runs to produce the published `.zip` and `.dmg`. It passes no `-destination`, so xcodebuild resolves the scheme's default — `{ platform:macOS, arch:arm64, name:My Mac }` — and narrows the build to that architecture.

The reason this went unnoticed for so long: **`xcodebuild -showBuildSettings` reports `ARCHS = arm64 x86_64` for that exact invocation**, so the configuration looks correct while the output is thin. CI has also been proving a universal build on every push via `package_app.sh` and then shipping a different, arm64-only one.

### Changes

- **`scripts/release_update.sh`** — build with `-destination 'generic/platform=macOS'`, `ARCHS='arm64 x86_64'`, `ONLY_ACTIVE_ARCH=NO`, matching `package_app.sh`.
- **`scripts/verify_universal.sh`** *(new)* — walks every Mach-O in a bundle and fails if any is missing the `arm64` or `x86_64` slice. Since the build settings lie, this inspects the finished artifact instead.
- **Both published files are verified as shipped**, not inferred from the bundle they were cut from: the `.zip` is unpacked and checked (before the appcast is signed, so a bad build can never be handed to Sparkle), and the `.dmg` is mounted and checked. Either one failing aborts the release.
- **`scripts/package_app.sh`** — runs the same check, making CI the gate that catches a regression before it reaches a tag.

### Follow-up (not in this PR)

A new tag is needed to actually get a universal build to users; every existing asset is arm64-only. Homebrew's cask bump follows automatically from `release.yml`.

Fixes # <!-- link the Intel install report if one is filed -->

---

## Type of Change
- [x] Bug fix (non-breaking change fixing an issue)
- [ ] New feature (non-breaking change adding functionality)
- [ ] Extension Runtime / Bridge update (JS host, AppleScript runner, Shell executor)
- [ ] UI / Theme / Accessibility improvement
- [ ] Performance / Concurrency optimization
- [ ] Localization (`Localizable.xcstrings`)
- [ ] Documentation update
- [x] Build tooling / CI / Scripts

---

## Testing & Verification

### Environment Tested:
- **macOS Version:** macOS 26 (Darwin 25.6.0), Xcode 26.6
- **Architecture:** Apple Silicon (the arch that produces the bad build)
- **Target Apps Verified:** n/a — build tooling only, no app code changed

### Test Execution:
- [ ] Ran `./scripts/test.sh core` (< 1s domain test suite)
- [ ] Ran `./scripts/test.sh` (Full suite passes with 0 failures/skips)
- [ ] Tested live in app via `./scripts/dev_run.sh`

> No Swift sources changed, so the test suite is unaffected and was left to CI. Verification focused on the release pipeline:

**Reproduced the bug.** Ran `release_update.sh`'s exact pre-fix `xcodebuild` invocation → `arm64` for both the app binary and `Core.framework`, matching the shipped asset.

**Confirmed the fix.** Same build with the new flags → `==> Verified build product: 7 Mach-O binaries, all universal (arm64 x86_64).`

**Exercised both publish paths** with the real scripts:
- `.zip` — `ditto -c -k` → unpack → verify ✅
- `.dmg` — `make_dmg.sh` → `hdiutil attach` → verify → detach ✅ (no leftover mounts)

**Checked the guard actually fails**, rather than passing vacuously:
- shipped `OpenClip-v1.4.0.zip` → correctly rejected, naming both thin binaries
- local repro of the old build → correctly rejected
- nonexistent path → exit 1
- directory containing no Mach-O → exit 1 (so a wrong path can't silently "pass")
- no arguments → exit 2 with usage
- the `.dmg` failure branch → detaches and removes the mountpoint before exiting

---

## Architectural & Code Checklist
- [x] **Swift 6 Concurrency:** No Swift sources changed.
- [x] **Core Purity:** No Swift sources changed.
- [x] **Settings & Secrets:** N/A — build scripts only.
- [x] **Subprocess Safety:** N/A — build scripts only.
- [x] **Dual-Sink Logging:** N/A — build scripts only.
- [x] **Localization:** N/A — no user-facing strings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Restored support for Intel-based Macs.
  - Release ZIP and DMG downloads now include both Apple silicon and Intel architectures.
  - Releases are blocked when either required architecture is missing.

- **Reliability**
  - Added validation to ensure packaged applications contain compatible binaries before release.
  - ZIP and DMG applications are verified before distribution to help prevent incomplete builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->