### PR TITLE
ci(release): attest build provenance for release artifacts

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,6 +8,10 @@ on:
 
 permissions:
   contents: write
+  # Sigstore signs the provenance keylessly: id-token mints the OIDC token that
+  # identifies this workflow to Fulcio, attestations stores the resulting bundle.
+  id-token: write
+  attestations: write
 
 jobs:
   package-and-release:
@@ -52,6 +56,18 @@ jobs:
           SHA256=$(shasum -a 256 "$ZIP_FILE" | awk '{print $1}')
           echo "sha256=$SHA256" >> "$GITHUB_OUTPUT"
           echo "Built OpenClip v$VERSION with SHA256: $SHA256"
+
+      # The Sparkle appcast is signed, so the auto-update path is already covered.
+      # This covers the other one: a .zip or .dmg downloaded straight off the
+      # Releases page can be traced back to the tag and workflow run that built it.
+      #   gh attestation verify OpenClip-v<version>.dmg --repo ganeshmshetty/openclip \
+      #     --signer-workflow ganeshmshetty/openclip/.github/workflows/release.yml
+      - name: Attest Build Provenance
+        uses: actions/attest-build-provenance@v4
+        with:
+          subject-path: |
+            build/release/*.zip
+            build/release/*.dmg
 
       - name: Extract Release Notes from CHANGELOG
         run: |

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -60,5 +60,10 @@ reported to their maintainers, though a private heads-up here is appreciated.
   indefinitely.
 - **Hardened runtime.** The app target builds with `ENABLE_HARDENED_RUNTIME`
   enabled (see `project.yml`).
+- **Verifiable release builds.** Release `.zip` and `.dmg` artifacts carry a
+  Sigstore build-provenance attestation binding them to the tag and workflow run
+  that produced them, so any download can be checked against its origin:
+  `gh attestation verify OpenClip-v<version>.dmg --repo ganeshmshetty/openclip`.
+  Sparkle auto-updates are separately signed with an Ed25519 key.
 - **Private-by-default logging.** Text, clipboard, and extension data stay
   default-private in logs; only ids and URLs are logged publicly.


### PR DESCRIPTION
## Summary

Adds a Sigstore build-provenance attestation to the release job so release artifacts can be traced back to the workflow run that built them.

The Sparkle appcast is signed with an Ed25519 key, so the **auto-update** path is already covered — a swapped update is rejected. The **direct download** path is not: a `.zip` or `.dmg` on the Releases page has nothing tying it to the tag it claims to come from, and the release job runs with `contents: write` and is `workflow_dispatch`-able, so an asset attached by hand (or by a leaked token) is indistinguishable from a real build.

`actions/attest-build-provenance@v4` signs a SLSA provenance statement binding each artifact's SHA-256 digest to this repo, commit and workflow run. Signing is keyless via Sigstore (short-lived Fulcio cert issued against the job's OIDC identity, recorded in Rekor), so **there is no new secret to store or rotate** — only the `id-token: write` and `attestations: write` permissions.

Verify a download:

```
gh attestation verify OpenClip-v<version>.dmg --repo ganeshmshetty/openclip \
  --signer-workflow ganeshmshetty/openclip/.github/workflows/release.yml
```

### Scope / non-goals

- This does **not** change Gatekeeper behaviour. The app is still ad-hoc signed (`codesign -s -`), so the "unidentified developer" prompt stays until Developer ID signing + notarization land. Provenance and notarization are complementary, not alternatives.
- No change to the Sparkle signing flow, the artifacts themselves, or the Homebrew tap step.

Fixes # <!-- no issue -->

---

## Type of Change
- [x] Build tooling / CI / Scripts
- [x] Documentation update (`SECURITY.md` bullet documenting the guarantee + verify command)

---

## Testing & Verification

### Environment Tested:
- **macOS Version:** n/a — CI-only change
- **Architecture:** n/a
- **Target Apps Verified:** n/a

### Test Execution:
- [ ] Ran `./scripts/test.sh core`
- [ ] Ran `./scripts/test.sh`
- [ ] Tested live in app via `./scripts/dev_run.sh`

No app code is touched, so the Swift suites are unaffected. Verified instead that:

- `release.yml` parses and the new step lands between **Build & Package Release** and **Extract Release Notes**, so the artifacts exist when it runs.
- `subject-path` globs match the paths `release_update.sh` actually writes (`build/release/*.zip`, `build/release/*.dmg`).
- `subject-path` is still the correct input name on `v4` (confirmed against the action's `action.yml` at the `v4` tag).

The attestation itself can only be exercised by a real tag push — it is a no-op for PRs and cannot run from a fork.

---

## Architectural & Code Checklist
- [x] **Swift 6 Concurrency:** n/a — no Swift changes.
- [x] **Core Purity:** n/a.
- [x] **Settings & Secrets:** n/a — Sigstore is keyless, no new secret added.
- [x] **Subprocess Safety:** n/a.
- [x] **Dual-Sink Logging:** n/a.
- [x] **Localization:** n/a — no user-facing strings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Release `.zip` and `.dmg` files now include verifiable build-provenance attestations, helping confirm they were produced by the expected release process.
  * Sparkle auto-updates continue to use Ed25519 signatures for authenticity.

* **Documentation**
  * Added guidance for verifying release attestations and confirming that downloaded artifacts are linked to the appropriate release and workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->