### PR TITLE
fix(preferences): show the settings cog on extension commands that declare options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable user-facing changes, feature additions, and improvements to OpenClip
 ## Unreleased
 
 ### Fixes & Stability
+- **Per-Command Extension Settings**: Commands inside a multi-command extension now show the settings cog in Preferences › Actions whenever that command declares options, so per-command settings (an endpoint, a project ID, an API key) can be configured without leaving the list. Saving that editor for a command no longer rewrites its parent group's manifest entry.
 - **Intel Mac Support Restored**: Released builds are universal again. Every release since the CI runner moved to Apple Silicon shipped an arm64-only app, so Intel Macs refused to launch it with "not supported on this type of Mac" — the `.zip` and the `.dmg` now both carry arm64 and x86_64 slices, and the release fails rather than publishing if either one does not.
 
 ### Improvements

--- a/OpenClip.xcodeproj/project.pbxproj
+++ b/OpenClip.xcodeproj/project.pbxproj
@@ -48,6 +48,7 @@
 		1FE3827A972D8AE670A453F4 /* TopLevelActionResolverTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D472E48BB7CBCC599EE48E92 /* TopLevelActionResolverTests.swift */; };
 		2140964D90DA799B312DED49 /* GoldenExtensionPlatformTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0A5C800BE48C74A05B33DDA /* GoldenExtensionPlatformTests.swift */; };
 		220A6F48497F91FA31273426 /* CalendarActionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D1221805EFDD065CA543A00 /* CalendarActionTests.swift */; };
+		22D5F64A56A4688BE5272FE2 /* ActionRowControlsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DF89ACBE81E50696C1CCF2F3 /* ActionRowControlsTests.swift */; };
 		24ABC449CE3810541D898C48 /* PermissionManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4BB115DCDCB4749A1DDB8222 /* PermissionManager.swift */; };
 		2625F61BBDA95D300AA8BBC4 /* LocalizedStringValue.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7F0E732D2DCAF53EDEB6653D /* LocalizedStringValue.swift */; };
 		264760E3D025E183E831C7C0 /* ActionVisibility.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5CA2E8ED39FAF909162A8023 /* ActionVisibility.swift */; };
@@ -695,6 +696,7 @@
 		DDF25B7CA70822AE323518F8 /* MemorySettingsStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MemorySettingsStore.swift; sourceTree = "<group>"; };
 		DECAB4B5213F632283318CD6 /* SelectionMonitoring.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SelectionMonitoring.swift; sourceTree = "<group>"; };
 		DF42F1F38524FF53F4FF61B2 /* PopupPageLayoutTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PopupPageLayoutTests.swift; sourceTree = "<group>"; };
+		DF89ACBE81E50696C1CCF2F3 /* ActionRowControlsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActionRowControlsTests.swift; sourceTree = "<group>"; };
 		DFEB96F8C47927BF0E4EF7FD /* GroupSubActionBarView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GroupSubActionBarView.swift; sourceTree = "<group>"; };
 		DFEE1DAE171FE965EB13F090 /* PopupPanelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PopupPanelTests.swift; sourceTree = "<group>"; };
 		E05FFC96E0F041907FD0B7E2 /* PasteboardCopyEngine.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PasteboardCopyEngine.swift; sourceTree = "<group>"; };
@@ -1275,6 +1277,7 @@
 				7A37D90BFF87CB9EFE573551 /* ActionResultDeliveryTests.swift */,
 				30E6ABB38EB5BC9DD5A41259 /* ActionResultDismissPolicyTests.swift */,
 				A4A87CFA084BCF3B940A37EC /* ActionResultHandlerTests.swift */,
+				DF89ACBE81E50696C1CCF2F3 /* ActionRowControlsTests.swift */,
 				0A76FF3CB8BB271D95028A50 /* ActionSearchTests.swift */,
 				CE52A2746613B843A8CD5AB5 /* ActionUsageStoreTests.swift */,
 				6D2CD73334B7B4D222062C30 /* ActionVisibilityTests.swift */,
@@ -1543,6 +1546,7 @@
 				D9F558084161AE5A3782CDA8 /* ActionResultDeliveryTests.swift in Sources */,
 				869D8DE376911B2D5633501D /* ActionResultDismissPolicyTests.swift in Sources */,
 				12645EE314DA461467D5F2F4 /* ActionResultHandlerTests.swift in Sources */,
+				22D5F64A56A4688BE5272FE2 /* ActionRowControlsTests.swift in Sources */,
 				DA6A2127C40D94FF8C182A2B /* ActionSearchTests.swift in Sources */,
 				C63E6C48A533FAF5D6C89CA6 /* ActionUsageStoreTests.swift in Sources */,
 				1A67EEB5C426858848AD9B5C /* ActionVisibilityTests.swift in Sources */,

--- a/Sources/OpenClip/UI/Preferences/ActionsOutlineView.swift
+++ b/Sources/OpenClip/UI/Preferences/ActionsOutlineView.swift
@@ -130,9 +130,12 @@ final class OutlineNode: NSObject {
             sig += "gm:\(parentGroupID):\(p.title):\(String(describing: p.icon))"
         case .extensionSubAction(let action, let parentGroupID):
             let p = customization.presented(action, surface: .table)
-            // Option count is part of the identity so a hot-reloaded manifest that adds or drops
-            // options re-renders the row's settings cog even when title and icon are unchanged.
-            sig += "es:\(parentGroupID):\(p.title):\(String(describing: p.icon)):\(action.actionOptions.count)"
+            // Option schema is part of the identity so a hot-reloaded manifest that adds, drops,
+            // or modifies options re-renders the row's settings cog even when title and icon are unchanged.
+            let optionsSig = action.actionOptions.map { opt in
+                "\(opt.identifier):\(opt.type.rawValue):\(opt.label):\(opt.defaultValue ?? ""):\(opt.options?.joined(separator: "|") ?? "")"
+            }.joined(separator: ",")
+            sig += "es:\(parentGroupID):\(p.title):\(String(describing: p.icon)):\(optionsSig)"
         }
         if !children.isEmpty {
             sig += "[" + children.map(\.signature).joined(separator: ";") + "]"

--- a/Sources/OpenClip/UI/Preferences/ActionsOutlineView.swift
+++ b/Sources/OpenClip/UI/Preferences/ActionsOutlineView.swift
@@ -85,6 +85,21 @@ final class OutlineNode: NSObject {
         }
     }
 
+    /// Trailing controls for this row's `ActionRowView`. An extension sub-action is removed with
+    /// its package, so it never gets the delete control; it gets the settings cog only when the
+    /// command declares options (a multi-command extension configures each command on its own
+    /// row — the group's cog opens the group editor, which has no option fields).
+    var rowControls: ActionRowControls {
+        switch kind {
+        case .extensionSubAction(let action, _):
+            return action.actionOptions.isEmpty ? [] : .settings
+        case .packageHeader:
+            return []
+        case .customGroup, .extensionGroup, .standaloneAction, .groupMember:
+            return .all
+        }
+    }
+
     override var hash: Int { id.hashValue }
     override func isEqual(_ object: Any?) -> Bool {
         guard let other = object as? OutlineNode else { return false }
@@ -115,7 +130,9 @@ final class OutlineNode: NSObject {
             sig += "gm:\(parentGroupID):\(p.title):\(String(describing: p.icon))"
         case .extensionSubAction(let action, let parentGroupID):
             let p = customization.presented(action, surface: .table)
-            sig += "es:\(parentGroupID):\(p.title):\(String(describing: p.icon))"
+            // Option count is part of the identity so a hot-reloaded manifest that adds or drops
+            // options re-renders the row's settings cog even when title and icon are unchanged.
+            sig += "es:\(parentGroupID):\(p.title):\(String(describing: p.icon)):\(action.actionOptions.count)"
         }
         if !children.isEmpty {
             sig += "[" + children.map(\.signature).joined(separator: ";") + "]"
@@ -552,17 +569,13 @@ final class ActionsOutlineCoordinator: NSObject, NSOutlineViewDataSource, NSOutl
              .standaloneAction(let action), .groupMember(let action, _),
              .extensionSubAction(let action, _):
             let presentation = parent.customizationManager.presented(action, surface: .table)
-            let showsControls: Bool = {
-                if case .extensionSubAction = node.kind { return false }
-                return true
-            }()
 
             cellView.setContent(
                 ActionRowView(
                     action: action,
                     presentationModel: presentation,
                     isEnabled: enabledBinding(for: action),
-                    showsControls: showsControls
+                    controls: node.rowControls
                 )
             )
         }

--- a/Sources/OpenClip/UI/Preferences/ActionsTabView.swift
+++ b/Sources/OpenClip/UI/Preferences/ActionsTabView.swift
@@ -75,23 +75,35 @@ struct ActionsTab: View {
 
 // MARK: - Action Row View
 
+/// The trailing controls an Actions-tab row exposes besides its enable toggle. Rows opt out per
+/// control rather than all-or-nothing: an extension sub-action is removed with its package, so it
+/// never gets the delete control, but it still needs the settings cog when the command declares
+/// options (`OutlineNode.rowControls` makes that call).
+struct ActionRowControls: OptionSet, Sendable {
+    let rawValue: Int
+
+    static let delete = ActionRowControls(rawValue: 1 << 0)
+    static let settings = ActionRowControls(rawValue: 1 << 1)
+    static let all: ActionRowControls = [.delete, .settings]
+}
+
 @MainActor
 struct ActionRowView: View {
     let action: any Action
     let presentationModel: ActionPresentationModel
     let isEnabled: Binding<Bool>
-    let showsControls: Bool
+    let controls: ActionRowControls
 
     init(
         action: any Action,
         presentationModel: ActionPresentationModel,
         isEnabled: Binding<Bool>,
-        showsControls: Bool = true
+        controls: ActionRowControls = .all
     ) {
         self.action = action
         self.presentationModel = presentationModel
         self.isEnabled = isEnabled
-        self.showsControls = showsControls
+        self.controls = controls
     }
 
     private var isAI: Bool {
@@ -146,7 +158,7 @@ struct ActionRowView: View {
             HStack(alignment: .center, spacing: 8) {
                 // Delete: only for custom actions, extension packages, or custom groups (builtins cannot be uninstalled)
                 let canDelete: Bool = {
-                    if !showsControls { return false }
+                    if !controls.contains(.delete) { return false }
                     if action.chrome.rowStyle == .actionGroup { return true }
                     switch action.chrome.source {
                     case .custom, .extensionPkg: return true
@@ -203,7 +215,7 @@ struct ActionRowView: View {
                 }
 
                 // Settings
-                if showsControls {
+                if controls.contains(.settings) {
                     Button(action: {
                         openConfigPopover()
                     }) {

--- a/Sources/OpenClip/UI/Preferences/EditActionSheet.swift
+++ b/Sources/OpenClip/UI/Preferences/EditActionSheet.swift
@@ -350,6 +350,16 @@ public struct EditActionSheet: View {
         ExtensionManifestStore.locateManifest(for: action, in: directory)
     }
 
+    /// True when the located manifest entry is `actionID` itself. The locator resolves a nested
+    /// sub-action to its parent group's top-level index, so for a group member this is false and
+    /// the sheet must not write the entry — doing so would stamp the member's title and icon onto
+    /// the whole group. Pure, unit-tested.
+    static func locatedEntryBacks(actionID: String, in state: LocatedManifest) -> Bool {
+        guard state.manifest.actions.indices.contains(state.targetIndex) else { return false }
+        let meta = state.manifest.actions[state.targetIndex]
+        return ExtensionManager.uniformActionID(metadata: meta, manifest: state.manifest, index: state.targetIndex) == actionID
+    }
+
     // MARK: - State loading
 
     private func loadInitialState() {
@@ -606,6 +616,11 @@ public struct EditActionSheet: View {
             showingSaveAlert = true
             return false
         }
+
+        // A sub-action of an extension group resolves to the group's manifest entry. Its
+        // appearance override was persisted above and its option values save as they are edited,
+        // so there is nothing left to write — and writing here would rename the parent group.
+        guard Self.locatedEntryBacks(actionID: action.id, in: state) else { return true }
 
         let meta = state.manifest.actions[state.targetIndex]
         let finalTitle = customTitle.trimmingCharacters(in: .whitespacesAndNewlines)

--- a/Tests/OpenClipTests/ActionRowControlsTests.swift
+++ b/Tests/OpenClipTests/ActionRowControlsTests.swift
@@ -55,6 +55,21 @@ final class ActionRowControlsTests: XCTestCase {
         XCTAssertNotEqual(before.signature, after.signature)
     }
 
+    func testSubActionOptionIdentifierChangesChangeTheNodeSignature() {
+        // A hot-reloaded manifest that replaces options with a different schema of the same count
+        // must re-render the row so stale option fields are not retained.
+        let customization = ActionCustomizationManager(settingsStore: MemorySettingsStore())
+        let first = OptionedAction(id: "\(groupID).execute", packageID: packageID, options: [endpointOption()])
+        let second = OptionedAction(
+            id: "\(groupID).execute",
+            packageID: packageID,
+            options: [ExtensionOption(identifier: "apiKey", label: "API Key", type: .secret)]
+        )
+        let node1 = OutlineNode(id: first.id, kind: .extensionSubAction(action: first, parentGroupID: groupID), customization: customization)
+        let node2 = OutlineNode(id: second.id, kind: .extensionSubAction(action: second, parentGroupID: groupID), customization: customization)
+        XCTAssertNotEqual(node1.signature, node2.signature)
+    }
+
     // MARK: - Other rows
 
     func testTopLevelRowsKeepBothControls() {

--- a/Tests/OpenClipTests/ActionRowControlsTests.swift
+++ b/Tests/OpenClipTests/ActionRowControlsTests.swift
@@ -1,0 +1,128 @@
+// ActionRowControlsTests.swift
+// OpenClip
+//
+// Pins which trailing controls an Actions-tab row exposes. A command inside a multi-command
+// extension (an extension-group sub-action) gets the settings cog when — and only when — it
+// declares options, and never the delete control. It also pins the edit sheet's guard against
+// rewriting the parent group's manifest entry when the sheet was opened for a nested sub-action.
+import XCTest
+@testable import Core
+@testable import OpenClip
+
+@MainActor
+final class ActionRowControlsTests: XCTestCase {
+    private let packageID = "io.appwrite.openclip.function-runner"
+    private var groupID: String { "\(packageID).appwrite" }
+
+    private func subActionNode(_ action: any Action) -> OutlineNode {
+        OutlineNode(id: action.id, kind: .extensionSubAction(action: action, parentGroupID: groupID))
+    }
+
+    private func endpointOption() -> ExtensionOption {
+        ExtensionOption(identifier: "endpoint", label: "Endpoint", defaultValue: "https://cloud.appwrite.io/v1")
+    }
+
+    // MARK: - Sub-action rows
+
+    func testSubActionWithOptionsShowsSettingsButNotDelete() {
+        let action = OptionedAction(id: "\(groupID).execute", packageID: packageID, options: [endpointOption()])
+        let controls = subActionNode(action).rowControls
+        XCTAssertTrue(controls.contains(.settings), "A command that declares options needs the settings cog")
+        XCTAssertFalse(controls.contains(.delete), "A command is removed with its package, never on its own")
+    }
+
+    func testSubActionWithoutOptionsShowsNoControls() {
+        let action = OptionedAction(id: "\(groupID).plain", packageID: packageID, options: [])
+        XCTAssertTrue(subActionNode(action).rowControls.isEmpty)
+    }
+
+    func testDecoratedSubActionForwardsOptionsToControls() {
+        // The factory wraps sub-actions that declare keywords / delivery / menu relevance; the cog
+        // decision must see the options through the wrapper.
+        let base = OptionedAction(id: "\(groupID).execute", packageID: packageID, options: [endpointOption()])
+        let wrapped = KeywordDecoratedAction(base: base, keywords: ["run"])
+        XCTAssertTrue(subActionNode(wrapped).rowControls.contains(.settings))
+    }
+
+    func testSubActionOptionsChangeTheNodeSignature() {
+        // A hot-reloaded manifest that adds options must re-render the row, so options are part
+        // of the node identity even when title and icon are unchanged.
+        let customization = ActionCustomizationManager(settingsStore: MemorySettingsStore())
+        let plain = OptionedAction(id: "\(groupID).execute", packageID: packageID, options: [])
+        let optioned = OptionedAction(id: "\(groupID).execute", packageID: packageID, options: [endpointOption()])
+        let before = OutlineNode(id: plain.id, kind: .extensionSubAction(action: plain, parentGroupID: groupID), customization: customization)
+        let after = OutlineNode(id: optioned.id, kind: .extensionSubAction(action: optioned, parentGroupID: groupID), customization: customization)
+        XCTAssertNotEqual(before.signature, after.signature)
+    }
+
+    // MARK: - Other rows
+
+    func testTopLevelRowsKeepBothControls() {
+        let standalone = OptionedAction(id: "\(packageID).single", packageID: packageID, options: [])
+        XCTAssertEqual(OutlineNode(id: standalone.id, kind: .standaloneAction(standalone)).rowControls, .all)
+
+        let group = GroupAction(
+            id: groupID,
+            title: "Appwrite",
+            icon: .symbol("bolt"),
+            chrome: ActionChrome(rowStyle: .actionGroup, popupBehavior: .showSubActions, source: .extensionPkg(packageID: packageID))
+        )
+        XCTAssertEqual(OutlineNode(id: group.id, kind: .extensionGroup(group)).rowControls, .all)
+    }
+
+    func testPackageHeaderHasNoControls() {
+        let node = OutlineNode(id: "header:\(packageID)", kind: .packageHeader(packageID: packageID, title: "Appwrite", gatedReason: nil))
+        XCTAssertTrue(node.rowControls.isEmpty)
+    }
+
+    // MARK: - Edit sheet manifest-save guard
+
+    private func groupManifest() -> ExtensionMetadata {
+        let sub = ExtensionActionMetadata(id: "execute", title: "Execute Function", script: "main.js", type: "javascript")
+        let group = ExtensionActionMetadata(id: "appwrite", title: "Appwrite", type: "group", subActions: [sub])
+        return ExtensionMetadata(identifier: packageID, name: "Appwrite Function Runner", actions: [group], options: nil)
+    }
+
+    func testLocatedEntryBacksTopLevelAction() {
+        let state = LocatedManifest(manifestURL: URL(fileURLWithPath: "/tmp/openclip.json"), manifest: groupManifest(), targetIndex: 0)
+        XCTAssertTrue(EditActionSheet.locatedEntryBacks(actionID: groupID, in: state))
+    }
+
+    func testLocatedEntryDoesNotBackNestedSubAction() {
+        // The locator resolves a sub-action to its parent's index; saving there would rename the group.
+        let state = LocatedManifest(manifestURL: URL(fileURLWithPath: "/tmp/openclip.json"), manifest: groupManifest(), targetIndex: 0)
+        XCTAssertFalse(EditActionSheet.locatedEntryBacks(actionID: "\(groupID).execute", in: state))
+    }
+
+    func testLocateManifestResolvesSubActionToParentEntryThatDoesNotBackIt() throws {
+        let tempDir = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        let packageDir = tempDir.appendingPathComponent("AppwriteFunctionRunner.openclipext")
+        try FileManager.default.createDirectory(at: packageDir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: tempDir) }
+        try ExtensionManifestStore.writeManifest(groupManifest(), to: packageDir.appendingPathComponent(Constants.manifestFileName))
+
+        let subAction = OptionedAction(id: "\(groupID).execute", packageID: packageID, options: [endpointOption()])
+        let located = try XCTUnwrap(EditActionSheet.locateManifest(for: subAction, in: tempDir))
+        XCTAssertEqual(located.targetIndex, 0)
+        XCTAssertFalse(EditActionSheet.locatedEntryBacks(actionID: subAction.id, in: located))
+    }
+}
+
+/// A sub-action-shaped test double that declares options, mirroring a `javascript` command inside
+/// an extension `group` (the factory stamps `.standard` chrome sourced from the package).
+private struct OptionedAction: Action, Sendable {
+    let id: String
+    let title: String = "Execute Function"
+    var icon: ActionIcon { .symbol("bolt") }
+    let chrome: ActionChrome
+    let actionOptions: [ExtensionOption]
+
+    init(id: String, packageID: String, options: [ExtensionOption]) {
+        self.id = id
+        self.chrome = ActionChrome(badge: .none, rowStyle: .standard, popupBehavior: .perform, source: .extensionPkg(packageID: packageID))
+        self.actionOptions = options
+    }
+
+    @MainActor func isEnabled(for context: ActionContext) -> Bool { true }
+    @MainActor func perform(_ context: ActionContext) async throws -> ActionResult { .none }
+}


### PR DESCRIPTION
## Summary
Commands inside a multi-command extension (an extension-group sub-action) had no way to reach their own settings. The Actions tab hid every trailing control on sub-action rows, and the group's own cog opens the group editor, which has no option fields. The Appwrite Function Runner extension declares its endpoint, project ID, function ID and API key options on its **Execute Function** command and could not be configured at all.

**What changed**
- Rows now opt into their trailing controls individually (`ActionRowControls`) instead of one all-or-nothing flag. A sub-action still never gets the delete control (it is removed with its package) but gets the settings cog whenever it declares options. `OutlineNode.rowControls` makes that decision, and the option count joins the node signature so a hot-reloaded manifest that adds options re-renders the row.
- Opening the editor for a sub-action exposed a latent save bug: the manifest locator resolves a nested sub-action to its parent group's index, so **Save** would have stamped the command's title and icon onto the whole group. `EditActionSheet.locatedEntryBacks` now guards the manifest write; the appearance override and the live-saved option values already cover everything a sub-action can edit. This also protects the popup's "needs configuration" path, which opens the same sheet.
- New `ActionRowControlsTests` pin the per-row control decisions (with and without options, through a keyword-decorated wrapper, top-level rows, package header), the signature change, and the save guard including a temp-directory manifest round trip.
- CHANGELOG entry under Unreleased.

**Out of scope, noticed while here:** uninstalling an extension clears stored option values for top-level actions only, so a sub-action's saved options (e.g. the Appwrite API key in the secret store) survive removal. Worth a small follow-up.

Fixes # <!-- no tracked issue; reported directly against the Appwrite Function Runner extension -->

---

## Type of Change
- [x] Bug fix (non-breaking change fixing an issue)
- [ ] New feature (non-breaking change adding functionality)
- [ ] Extension Runtime / Bridge update (JS host, AppleScript runner, Shell executor)
- [ ] UI / Theme / Accessibility improvement
- [ ] Performance / Concurrency optimization
- [ ] Localization (`Localizable.xcstrings`)
- [ ] Documentation update
- [ ] Build tooling / CI / Scripts

---

## Testing & Verification

### Environment Tested:
- **macOS Version:** macOS 26.6.2
- **Architecture:** Apple Silicon
- **Target Apps Verified:** N/A — the change is confined to Preferences › Actions and the action editor; no target-app interaction.

### Test Execution:
- [x] Ran `./scripts/test.sh core` — 176 tests. The single failure is `CalculateActionTests.testExtendedMathExpressionsAndSanitization`, which fails identically on `main` on this machine (the host locale treats `,` as the decimal separator).
- [x] Ran `./scripts/test.sh` — 1212 tests, no new failures. The only failures are the three machine-local ones that also fail on `main` here: `PopupPanelTests.testEnterSearchWithButtonAnchorCentersSearchOnButton` (screen geometry), `CalculateActionTests.testExtendedMathExpressionsAndSanitization` (locale), `ActionCoordinatorTests.testActionCoordinatorResolvesActionsForContext` (environment). The new `ActionRowControlsTests`, `ActionGroupIntegrationTests`, `EditActionSheetAppearanceTests` and `CustomActionManifestWriterTests` all pass.
- [x] Tested live in app — Release build of this branch installed over `/Applications/OpenClip.app` with the Appwrite Function Runner extension installed; manual before/after QA captured below.

---

## Screenshots / Screen Recordings (if applicable)
<!-- If this PR changes UI or visual behavior, include a before/after screenshot or video. -->

Before:

https://github.com/user-attachments/assets/d8b5ffae-8157-425e-bc4e-3f8436564893

After:

https://github.com/user-attachments/assets/f0f7b2c1-a243-4b9a-9cf5-e6ab800a0073


---

## Architectural & Code Checklist
- [x] **Swift 6 Concurrency:** Builds cleanly with complete strict concurrency (`SWIFT_STRICT_CONCURRENCY: complete`) with zero data races.
- [x] **Core Purity:** No `AppKit` or `SwiftUI` imports in `Sources/Core/` — this PR touches no Core files.
- [x] **Settings & Secrets:** Uses `SettingsStore` / `SecretStore` (no direct `UserDefaults.standard` in new code) — no new storage; option values keep flowing through the existing `SecretActionOptionStore`.
- [x] **Subprocess Safety:** N/A — no subprocesses added.
- [x] **Dual-Sink Logging:** N/A — no new log statements.
- [x] **Localization:** No new user-facing strings; the cog reuses the existing "Configure Action" help text.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a settings cog for commands within multi-command extensions when configurable options are available.
  * Settings controls now appear correctly for supported extension commands without enabling unrelated controls.

* **Bug Fixes**
  * Saving settings for an individual extension command no longer alters or renames its parent group.
  * The Actions preferences view now refreshes the settings control when command options change.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->