### PR TITLE
Developer ID signing, hardened runtime, and notarization

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,5 +32,22 @@ jobs:
       - name: Run Full Test Suite (0 skips)
         run: ./scripts/test.sh
 
-      - name: Build App (Release)
+      # Deliberately ad-hoc. Pull requests from forks get no access to secrets, so a signing
+      # certificate here would only work for branches pushed by collaborators — and a check that
+      # silently does nothing on fork PRs is worse than one that runs the same way for everyone.
+      # An ad-hoc build still exercises the whole signing path: hardened runtime, the real
+      # entitlements, and the inside-out pass over Sparkle's nested helpers.
+      - name: Build App (Release, ad-hoc signed)
         run: ./scripts/package_app.sh
+
+      # package_app.sh already gates this, but asserting it here too keeps the guarantee visible
+      # in the workflow and independent of that script's internals. Verifying the app unpacked
+      # from the archive rather than the build product also covers the archive itself. This is the
+      # regression that shipped for months unnoticed: project.yml asked for the hardened runtime,
+      # Xcode honoured it, and a `codesign --deep` at packaging time quietly stripped it back off.
+      - name: Verify Hardening & Entitlements
+        run: |
+          rm -rf /tmp/ci-verify
+          mkdir -p /tmp/ci-verify
+          ditto -x -k build/OpenClip.zip /tmp/ci-verify
+          ./scripts/verify_signing.sh /tmp/ci-verify/OpenClip.app --require any

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,10 +24,127 @@ jobs:
         with:
           submodules: recursive
 
+      # Signing degrades rather than fails. If the certificate or the notary credentials are
+      # missing — a fork, or secrets that were rotated away — the release still builds and
+      # publishes, ad-hoc signed, with a warning on the run. Gatekeeper refuses an ad-hoc build
+      # on every Mac but the one that produced it, so this is a visible degradation and not a
+      # silent one. All five secrets are required together: a certificate without notary
+      # credentials would sign successfully and then fail minutes later at the notarization step.
+      - name: Determine signing mode
+        id: signing
+        env:
+          CERT_P12: ${{ secrets.MACOS_CERTIFICATE_P12 }}
+          CERT_PASSWORD: ${{ secrets.MACOS_CERTIFICATE_PASSWORD }}
+          NOTARY_KEY_P8: ${{ secrets.NOTARY_KEY_P8 }}
+          NOTARY_KEY_ID: ${{ secrets.NOTARY_KEY_ID }}
+          NOTARY_ISSUER_ID: ${{ secrets.NOTARY_ISSUER_ID }}
+        run: |
+          MISSING=""
+          [ -n "$CERT_P12" ] || MISSING="$MISSING MACOS_CERTIFICATE_P12"
+          [ -n "$CERT_PASSWORD" ] || MISSING="$MISSING MACOS_CERTIFICATE_PASSWORD"
+          [ -n "$NOTARY_KEY_P8" ] || MISSING="$MISSING NOTARY_KEY_P8"
+          [ -n "$NOTARY_KEY_ID" ] || MISSING="$MISSING NOTARY_KEY_ID"
+          [ -n "$NOTARY_ISSUER_ID" ] || MISSING="$MISSING NOTARY_ISSUER_ID"
+
+          if [ -z "$MISSING" ]; then
+            echo "mode=developer-id" >> "$GITHUB_OUTPUT"
+            # "auto" resolves against the keychain rather than naming the certificate here. The
+            # temporary keychain built below holds exactly one Developer ID Application identity,
+            # and scripts/signing_config.sh fails loudly if it ever finds none or several — so the
+            # Team ID never has to be repeated as a secret where it could drift.
+            echo "identity=auto" >> "$GITHUB_OUTPUT"
+            echo "allow_unsigned=0" >> "$GITHUB_OUTPUT"
+            echo "Signing mode: Developer ID (signed, notarized, stapled)"
+          else
+            echo "::warning title=Unsigned release::Missing signing secrets:$MISSING. Building ad-hoc and skipping notarization — Gatekeeper will refuse these artifacts. See docs/developer-guide/signing-and-notarization.md."
+            echo "mode=adhoc" >> "$GITHUB_OUTPUT"
+            echo "identity=-" >> "$GITHUB_OUTPUT"
+            echo "allow_unsigned=1" >> "$GITHUB_OUTPUT"
+            echo "Signing mode: ad-hoc (NOT distributable)"
+          fi
+
       - name: Select Xcode 26
         uses: maxim-lobanov/setup-xcode@v1
         with:
           xcode-version: '26.6'
+
+      # Plain `security` commands rather than a third-party action: the private key for OpenClip's
+      # signing certificate passes through this step, and the same reasoning that pins the Sparkle
+      # download by SHA-256 applies to anything handling it. The keychain is created in RUNNER_TEMP,
+      # is never the default keychain, and is deleted by the cleanup step below whatever happens.
+      - name: Import Developer ID certificate
+        if: steps.signing.outputs.mode == 'developer-id'
+        env:
+          CERT_P12: ${{ secrets.MACOS_CERTIFICATE_P12 }}
+          CERT_PASSWORD: ${{ secrets.MACOS_CERTIFICATE_PASSWORD }}
+        run: |
+          set -euo pipefail
+          KEYCHAIN_PATH="$RUNNER_TEMP/openclip-signing.keychain-db"
+          CERT_PATH="$RUNNER_TEMP/certificate.p12"
+          # Random per-run: this password only ever guards a keychain that is destroyed with the
+          # runner, so there is nothing to gain by making it a secret.
+          KEYCHAIN_PASSWORD="$(openssl rand -base64 24)"
+          echo "KEYCHAIN_PATH=$KEYCHAIN_PATH" >> "$GITHUB_ENV"
+
+          (umask 077; printf '%s' "$CERT_P12" | base64 --decode > "$CERT_PATH")
+          if [ ! -s "$CERT_PATH" ]; then
+            echo "error: MACOS_CERTIFICATE_P12 did not base64-decode to anything." >&2
+            echo "       Re-create it with: base64 -i Certificates.p12 | pbcopy" >&2
+            exit 1
+          fi
+
+          security create-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
+          # Without this the keychain re-locks on a timeout partway through a long build and
+          # codesign starts failing with "User interaction is not allowed".
+          security set-keychain-settings -lut 21600 "$KEYCHAIN_PATH"
+          security unlock-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
+
+          security import "$CERT_PATH" \
+            -k "$KEYCHAIN_PATH" \
+            -P "$CERT_PASSWORD" \
+            -f pkcs12 \
+            -T /usr/bin/codesign \
+            -T /usr/bin/security
+          rm -f "$CERT_PATH"
+
+          # -T above grants the tools access; this is the half that stops the keychain prompting
+          # for confirmation on a runner where no one can click anything.
+          security set-key-partition-list \
+            -S apple-tool:,apple:,codesign: \
+            -s -k "$KEYCHAIN_PASSWORD" \
+            "$KEYCHAIN_PATH" > /dev/null
+
+          # Prepend to the user search list, keeping the existing keychains so nothing else in the
+          # job loses access to the login keychain.
+          #
+          # Each entry is unquoted and trimmed individually into an array rather than being
+          # word-split out of a command substitution. `security list-keychains` prints its paths
+          # indented and in quotes, and feeding that output straight back in is how a search list
+          # ends up holding one mangled entry instead of a path — at which point every identity
+          # silently disappears and codesign fails with no useful message.
+          EXISTING_KEYCHAINS=()
+          while IFS= read -r kc; do
+            kc="$(printf '%s' "$kc" | sed -e 's/^[[:space:]]*"\{0,1\}//' -e 's/"\{0,1\}[[:space:]]*$//')"
+            [ -n "$kc" ] && EXISTING_KEYCHAINS+=("$kc")
+          done < <(security list-keychains -d user)
+
+          # "${arr[@]}" on an empty array is an unbound-variable error under set -u in bash 3.2,
+          # which is what macOS ships.
+          if [ "${#EXISTING_KEYCHAINS[@]}" -gt 0 ]; then
+            security list-keychains -d user -s "$KEYCHAIN_PATH" "${EXISTING_KEYCHAINS[@]}"
+          else
+            security list-keychains -d user -s "$KEYCHAIN_PATH"
+          fi
+          echo "Search list is now:"
+          security list-keychains -d user
+
+          FOUND="$(security find-identity -v -p codesigning | grep -c "Developer ID Application" || true)"
+          if [ "$FOUND" -ne 1 ]; then
+            echo "error: expected exactly 1 Developer ID Application identity after import, found $FOUND." >&2
+            security find-identity -v -p codesigning >&2
+            exit 1
+          fi
+          echo "Imported the signing certificate into a temporary keychain."
 
       - name: Install XcodeGen
         run: brew install xcodegen
@@ -48,13 +165,13 @@ jobs:
         id: build_package
         env:
           SPARKLE_ED_PRIVATE_KEY: ${{ secrets.SPARKLE_ED_PRIVATE_KEY }}
-          # TODO: remove once Developer ID signing is wired into CI, which needs the certificate
-          # and notary credentials as repository secrets plus a temporary keychain to import them
-          # into. Until then this downgrades the run to an ad-hoc, un-notarized build so tagging
-          # keeps working; releases built this way are refused by Gatekeeper on every Mac but the
-          # runner. Signed releases are cut locally with ./scripts/release_update.sh — see
-          # docs/developer-guide/signing-and-notarization.md.
-          OPENCLIP_ALLOW_UNSIGNED_RELEASE: "1"
+          OPENCLIP_SIGN_IDENTITY: ${{ steps.signing.outputs.identity }}
+          OPENCLIP_ALLOW_UNSIGNED_RELEASE: ${{ steps.signing.outputs.allow_unsigned }}
+          # scripts/notarize_artifact.sh accepts the key as inline PEM text as well as a path, so
+          # the .p8 never has to be written to the workspace by this workflow.
+          NOTARY_KEY: ${{ secrets.NOTARY_KEY_P8 }}
+          NOTARY_KEY_ID: ${{ secrets.NOTARY_KEY_ID }}
+          NOTARY_ISSUER: ${{ secrets.NOTARY_ISSUER_ID }}
         run: |
           VERSION="${GITHUB_REF_NAME#v}"
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
@@ -128,3 +245,16 @@ jobs:
             git push origin master
             echo "Successfully updated ganeshmshetty/homebrew-tap Casks/openclip.rb to v${VERSION} (${SHA256})"
           fi
+
+      # if: always() so a failed build, or a cancelled run, still takes the private key with it.
+      # GitHub discards the runner either way, but leaving an unlocked keychain holding a
+      # Developer ID private key behind for the rest of the job is not something to rely on
+      # cleanup-by-VM-teardown for.
+      - name: Remove signing keychain
+        if: always()
+        run: |
+          if [ -n "${KEYCHAIN_PATH:-}" ] && [ -f "$KEYCHAIN_PATH" ]; then
+            security delete-keychain "$KEYCHAIN_PATH" || true
+            echo "Deleted the temporary signing keychain."
+          fi
+          rm -f "$RUNNER_TEMP/certificate.p12"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,6 +48,13 @@ jobs:
         id: build_package
         env:
           SPARKLE_ED_PRIVATE_KEY: ${{ secrets.SPARKLE_ED_PRIVATE_KEY }}
+          # TODO: remove once Developer ID signing is wired into CI, which needs the certificate
+          # and notary credentials as repository secrets plus a temporary keychain to import them
+          # into. Until then this downgrades the run to an ad-hoc, un-notarized build so tagging
+          # keeps working; releases built this way are refused by Gatekeeper on every Mac but the
+          # runner. Signed releases are cut locally with ./scripts/release_update.sh — see
+          # docs/developer-guide/signing-and-notarization.md.
+          OPENCLIP_ALLOW_UNSIGNED_RELEASE: "1"
         run: |
           VERSION="${GITHUB_REF_NAME#v}"
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"

--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@ scripts/bin/
 /Extensions/
 skills-lock.json
 plans/
+keys/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,7 +15,18 @@ git submodule update --init            # populate Extensions/ catalog submodule 
 ./scripts/package_app.sh               # Release build -> build/OpenClip.zip + build/OpenClip.dmg
 ./scripts/make_dmg.sh <app> <dmg>      # styled DMG only (see docs/dmg.md)
 ./scripts/clean.sh                     # wipe DerivedData/build caches
+./scripts/verify_signing.sh <artifact> # gate signature/hardening/notarization (--require any|developer-id|notarized)
+./scripts/sign_artifact.sh <artifact>  # inside-out re-sign of an .app, or sign a .dmg
+./scripts/notarize_artifact.sh <path>  # submit to Apple's notary service and staple the ticket
 ```
+
+**Signing is opt-in and defaults to ad-hoc**, so a clone builds with no Apple Developer account,
+certificate, or network. Never re-introduce `codesign --deep` — it re-signs outside-in and drops
+the hardened runtime and entitlements, which is how every release before this shipped unhardened.
+Adding an entitlement means editing `Sources/OpenClip/OpenClip.entitlements` (no XML comments in
+it; `codesign`'s parser rejects them), because `verify_signing.sh` fails on any difference between
+that file and the signed artifact. Full reference:
+[`docs/developer-guide/signing-and-notarization.md`](docs/developer-guide/signing-and-notarization.md).
 
 All Swift is Swift 6 with `SWIFT_STRICT_CONCURRENCY: complete`. Targets (see `project.yml`): **Core** (pure domain framework), **OpenClip** (app), **OpenClipTests**. SPM deps: KeyboardShortcuts, SDWebImageSwiftUI/SVGCoder.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ All notable user-facing changes, feature additions, and improvements to OpenClip
 
 ## Unreleased
 
+### Security & Distribution
+- **Signed, Hardened & Notarized Builds**: OpenClip is now signed with an Apple Developer ID certificate, built with the hardened runtime genuinely enabled, and notarized and stapled by Apple — the app and the disk image both. macOS opens it without a Gatekeeper warning, and nothing has to strip a quarantine attribute to make it launch. Every previous release was ad-hoc signed: the packaging step finished with `codesign --deep`, which replaced Xcode's hardened signature with an unhardened ad-hoc one, so the app could not be notarized and Gatekeeper refused it on every Mac but the one that built it.
+- **Accessibility Permission Survives Updates**: An ad-hoc signature identifies an app by a hash that changes with every build, so macOS treated each update as a brand-new application and dropped the Accessibility grant. A Developer ID signature identifies it by bundle ID and team instead, so the permission now persists across updates. Upgrading to this version needs the Accessibility toggle re-granted one last time.
+- **Minimal Entitlements**: The hardened runtime is granted exactly one exception, for the Apple events that AppleScript actions send. JIT, library-validation, and dynamic-linker exceptions are all withheld, and the release scripts fail if a build's entitlements ever differ from the file that declares them. Building from source still needs no Apple Developer account: local builds are ad-hoc signed with the same hardening and entitlements.
+
 ### Fixes & Stability
 - **Per-Command Extension Settings**: Commands inside a multi-command extension now show the settings cog in Preferences › Actions whenever that command declares options, so per-command settings (an endpoint, a project ID, an API key) can be configured without leaving the list. Saving that editor for a command no longer rewrites its parent group's manifest entry.
 - **Intel Mac Support Restored**: Released builds are universal again. Every release since the CI runner moved to Apple Silicon shipped an arm64-only app, so Intel Macs refused to launch it with "not supported on this type of Mac" — the `.zip` and the `.dmg` now both carry arm64 and x86_64 slices, and the release fails rather than publishing if either one does not.

--- a/OpenClip.xcodeproj/project.pbxproj
+++ b/OpenClip.xcodeproj/project.pbxproj
@@ -507,6 +507,7 @@
 		4B24E324403AA01B89814FF7 /* Localizable.xcstrings */ = {isa = PBXFileReference; lastKnownFileType = text.json.xcstrings; path = Localizable.xcstrings; sourceTree = "<group>"; };
 		4BA6733CB7FD55544834DC9B /* PopupSearchView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PopupSearchView.swift; sourceTree = "<group>"; };
 		4BB115DCDCB4749A1DDB8222 /* PermissionManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PermissionManager.swift; sourceTree = "<group>"; };
+		4C6012F951674D4CC529611B /* OpenClip.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = OpenClip.entitlements; sourceTree = "<group>"; };
 		4C75D3BF228023DEA93C5D3D /* Core.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Core.swift; sourceTree = "<group>"; };
 		4CAAD1C6555C630BEDB8C746 /* AXTextControlStrategy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AXTextControlStrategy.swift; sourceTree = "<group>"; };
 		4D47BAB3F6C14A0AB8D0B870 /* HotkeyManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HotkeyManager.swift; sourceTree = "<group>"; };
@@ -969,6 +970,7 @@
 				287DF09DC26BE3ACE16F3B53 /* AppDelegate.swift */,
 				2582277236A4342581920E66 /* Assets.xcassets */,
 				8B521F6AE4BA6FD8516E8A1B /* Info.plist */,
+				4C6012F951674D4CC529611B /* OpenClip.entitlements */,
 				871B6048B7968E61FCB53537 /* OpenClipApp.swift */,
 				0F3B8C9AB19BEC2ACF890FEB /* StatusBarController.swift */,
 				15E13C36EF68E62BC6FCD64A /* AI */,
@@ -1930,6 +1932,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CODE_SIGN_ENTITLEMENTS = Sources/OpenClip/OpenClip.entitlements;
 				CODE_SIGN_IDENTITY = "-";
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
@@ -1959,6 +1962,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CODE_SIGN_ENTITLEMENTS = Sources/OpenClip/OpenClip.entitlements;
 				CODE_SIGN_IDENTITY = "-";
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;

--- a/README.md
+++ b/README.md
@@ -163,9 +163,16 @@ xcodegen generate
 # Run the test suite
 ./scripts/test.sh
 
-# Build a Release app + build/OpenClip.zip
+# Build a Release app + build/OpenClip.zip + build/OpenClip.dmg
 ./scripts/package_app.sh
 ```
+
+> [!NOTE]
+> Local builds are signed **ad-hoc**, so no Apple Developer account, certificate, or network
+> access is needed to build or run OpenClip from source. They carry the same hardened runtime and
+> entitlements as a release, and Gatekeeper will refuse them on any other Mac. Producing a
+> distributable build is opt-in — see
+> [Code Signing, Hardened Runtime & Notarization](docs/developer-guide/signing-and-notarization.md).
 
 > [!NOTE]
 > The repo is split into a pure-domain **Core** framework and the **OpenClip** app target (AppKit +

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -77,7 +77,10 @@ reported to their maintainers, though a private heads-up here is appreciated.
   Apple's notary service and stapled, so the app and the disk image both carry
   their ticket offline. The signature's designated requirement pins the bundle
   identifier and Team ID rather than a per-build hash, which is also what lets
-  the Accessibility grant survive an update.
+  the Accessibility grant survive an update. If the signing secrets are absent
+  from a release run, the workflow degrades to an ad-hoc build and says so with
+  a warning rather than failing; artifacts produced that way are not
+  distributable and are not published as releases.
 - **Verifiable release builds.** Release `.zip` and `.dmg` artifacts carry a
   Sigstore build-provenance attestation binding them to the tag and workflow run
   that produced them, so any download can be checked against its origin:

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -61,8 +61,23 @@ reported to their maintainers, though a private heads-up here is appreciated.
 - **Subprocess sandboxing.** Script actions run under a 30-second watchdog that
   terminates stuck processes (process-group kill) so scripts cannot run or hang
   indefinitely.
-- **Hardened runtime.** The app target builds with `ENABLE_HARDENED_RUNTIME`
-  enabled (see `project.yml`).
+- **Hardened runtime, verified on the artifact.** Release builds are signed with
+  `--options runtime` and a minimal entitlements file that grants one exception,
+  `com.apple.security.automation.apple-events`, needed by AppleScript actions.
+  JIT, library-validation, and `DYLD_*` exceptions are all deliberately withheld.
+  The build setting alone was not enough to trust: the packaging scripts used to
+  finish with `codesign --deep`, which silently replaced Xcode's hardened
+  signature with an ad-hoc one, so `scripts/verify_signing.sh` now reads the
+  finished bundle — every nested binary included — and fails the build if the
+  hardened runtime is missing or the signed entitlements differ from the
+  checked-in file. See
+  [docs/developer-guide/signing-and-notarization.md](docs/developer-guide/signing-and-notarization.md).
+- **Developer ID signing and notarization.** Releases are signed with a
+  Developer ID Application certificate and a secure timestamp, then submitted to
+  Apple's notary service and stapled, so the app and the disk image both carry
+  their ticket offline. The signature's designated requirement pins the bundle
+  identifier and Team ID rather than a per-build hash, which is also what lets
+  the Accessibility grant survive an update.
 - **Verifiable release builds.** Release `.zip` and `.dmg` artifacts carry a
   Sigstore build-provenance attestation binding them to the tag and workflow run
   that produced them, so any download can be checked against its origin:

--- a/Sources/OpenClip/Info.plist
+++ b/Sources/OpenClip/Info.plist
@@ -39,9 +39,13 @@
 	<string>1</string>
 	<key>LSUIElement</key>
 	<true/>
-	<key>SUEnableAutomaticChecks</key>
-	<true/>
+	<key>NSAppleEventsUsageDescription</key>
+	<string>OpenClip needs to control other apps to run your AppleScript actions and to paste results back into the app you were using.</string>
+	<key>NSHumanReadableCopyright</key>
+	<string>Copyright © 2026 Ganesh M and OpenClip Contributors. MIT licensed.</string>
 	<key>SUAutomaticallyUpdate</key>
+	<true/>
+	<key>SUEnableAutomaticChecks</key>
 	<true/>
 	<key>SUFeedURL</key>
 	<string>https://github.com/ganeshmshetty/openclip/releases/latest/download/appcast.xml</string>

--- a/Sources/OpenClip/OpenClip.entitlements
+++ b/Sources/OpenClip/OpenClip.entitlements
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>com.apple.security.automation.apple-events</key>
+	<true/>
+</dict>
+</plist>

--- a/docs/developer-guide/signing-and-notarization.md
+++ b/docs/developer-guide/signing-and-notarization.md
@@ -236,9 +236,48 @@ gh attestation verify OpenClip-v1.4.0.dmg --repo ganeshmshetty/openclip \
 
 ## Continuous integration
 
-CI is **not** wired up for signing yet — that is deliberately a separate change. `.github/workflows/ci.yml`
-builds ad-hoc, which is correct: pull requests from forks get no secrets. `.github/workflows/release.yml`
-still needs the certificate and notary credentials as repository secrets, a temporary keychain to
-import them into, and a cleanup step; until then it passes `OPENCLIP_ALLOW_UNSIGNED_RELEASE=1`,
-which downgrades the run to ad-hoc and skips notarization so the pipeline keeps working. Artifacts
-built that way must not be published as a real release.
+`.github/workflows/ci.yml` builds **ad-hoc on every push and pull request**, and that is the right
+choice rather than a limitation: pull requests from forks get no access to secrets, so a signing
+certificate there would only ever work for collaborator branches, and a check that silently does
+nothing for outside contributors is worse than one that behaves identically for everyone. An
+ad-hoc build still exercises the entire signing path — hardened runtime, real entitlements, and the
+inside-out pass over Sparkle's nested helpers — and a dedicated step verifies the app unpacked from
+the archive, so the hardening regression that shipped unnoticed for months cannot recur.
+
+`.github/workflows/release.yml` signs, notarizes, and staples when the secrets below are present.
+
+| Secret | Value |
+|---|---|
+| `MACOS_CERTIFICATE_P12` | The Developer ID Application certificate and private key, base64 encoded: `base64 -i Certificates.p12 \| pbcopy` |
+| `MACOS_CERTIFICATE_PASSWORD` | The password set when exporting that .p12 from Keychain Access |
+| `NOTARY_KEY_P8` | The full contents of `AuthKey_XXXXXXXXXX.p8`, including the BEGIN and END lines |
+| `NOTARY_KEY_ID` | The `XXXXXXXXXX` from that filename |
+| `NOTARY_ISSUER_ID` | The issuer UUID from App Store Connect, **Users and Access › Integrations › Team Keys** |
+
+`SPARKLE_ED_PRIVATE_KEY` and `TAP_GITHUB_TOKEN` are separate and already configured.
+
+There is deliberately **no secret for the Team ID or the certificate name**. The workflow imports
+the .p12 into a temporary keychain that holds exactly one Developer ID Application identity and
+then runs with `OPENCLIP_SIGN_IDENTITY=auto`, which resolves the identity from that keychain and
+fails loudly if it finds none or more than one. A Team ID stored separately is a value that can
+drift out of step with the certificate it is supposed to describe.
+
+### Behaviour when secrets are missing
+
+All five are required **together**. A certificate without notary credentials would sign
+successfully and then fail minutes later at the notarization step, so the workflow checks for the
+whole set up front. If any are absent — a fork, or secrets rotated away — the release still builds
+and publishes, ad-hoc signed, with a `::warning::` naming exactly which secrets were missing.
+
+This keeps tagging working under any configuration, but the degradation is real: **an ad-hoc
+release is refused by Gatekeeper on every Mac except the one that built it, and must not be
+published as a real release.** Check the run's warnings before announcing a version.
+
+### How the certificate is handled
+
+Plain `security` commands, no third-party action — the same reasoning that pins the Sparkle
+download by SHA-256 applies to anything that handles OpenClip's signing key. The keychain is
+created under `RUNNER_TEMP`, is never made the default keychain, is only prepended to the user
+search list, and is deleted by a step marked `if: always()` so a failed or cancelled run takes the
+private key with it. The .p8 is passed to `notarize_artifact.sh` as inline PEM text through the
+environment and never written into the workspace.

--- a/docs/developer-guide/signing-and-notarization.md
+++ b/docs/developer-guide/signing-and-notarization.md
@@ -231,6 +231,7 @@ gh attestation verify OpenClip-v1.4.0.dmg --repo ganeshmshetty/openclip \
 | `no secure timestamp` | Signed while offline. The timestamp needs Apple's timestamp server. |
 | Notary status `Invalid` | The script prints Apple's log; it names the offending binary and reason. |
 | `rejected ... source=Unnotarized Developer ID` | Signed correctly but not notarized yet. |
+| `resource fork, Finder information, or similar detritus not allowed` | An extended attribute on the bundle. `com.apple.FinderInfo` is the usual culprit; dmgbuild's `hide_extensions` writes one, which is why `make_dmg.sh` does not use it. Clear with `xattr -cr`. |
 | `The staple and validate action failed! Error 65` | No ticket for that exact build. Re-notarize; a ticket is tied to the cdhash. |
 
 ## Continuous integration

--- a/docs/developer-guide/signing-and-notarization.md
+++ b/docs/developer-guide/signing-and-notarization.md
@@ -1,0 +1,243 @@
+# Code Signing, Hardened Runtime & Notarization
+
+How an OpenClip build goes from a local Release build to something macOS will open on a stranger's
+Mac, and what each step is defending against.
+
+Inspect any build with [Apparency](https://mothersruin.com/software/Apparency/) or the commands in
+[Checking a build by hand](#checking-a-build-by-hand). A distributable build shows a Developer ID
+signature, the hardened runtime enabled, a stapled notarization ticket, and a Gatekeeper verdict of
+`Notarized Developer ID`.
+
+---
+
+## Two build modes
+
+Signing is **opt-in**, and everything works without it.
+
+| | Ad-hoc (default) | Developer ID |
+|---|---|---|
+| Apple Developer account | not needed | required |
+| Network access | not needed | required (timestamp + notary) |
+| Hardened runtime | yes | yes |
+| Entitlements | yes | yes |
+| Opens on another Mac | no | yes |
+| Used for | local builds, tests, PR/fork CI | releases |
+
+A fresh clone builds, packages, and runs with no certificate at all. The only thing an ad-hoc build
+cannot do is leave the machine that produced it: Gatekeeper has nothing to trust, so it refuses to
+launch. Everything else — the hardened runtime, the entitlements, the inside-out signing order — is
+identical in both modes, so a contributor is exercising the same code path a release does.
+
+```bash
+./scripts/package_app.sh                                # ad-hoc
+OPENCLIP_SIGN_IDENTITY=auto ./scripts/package_app.sh    # Developer ID signed
+OPENCLIP_SIGN_IDENTITY=auto OPENCLIP_NOTARIZE=1 \
+    ./scripts/package_app.sh                            # signed, notarized, stapled
+./scripts/release_update.sh 1.4.0                       # full release; signing is mandatory
+```
+
+## Configuration
+
+`scripts/signing_config.sh` resolves the identity, highest precedence first:
+
+1. `--identity <name>` on `sign_artifact.sh` or `verify_signing.sh`
+2. `OPENCLIP_SIGN_IDENTITY` in the environment
+3. `keys/signing.env`, if it exists
+4. `-` (ad-hoc)
+
+`OPENCLIP_SIGN_IDENTITY=auto` picks the single `Developer ID Application` identity in the keychain
+and fails if there is none or more than one, so `auto` can never silently pick a different team.
+
+`keys/signing.env` is a gitignored shell fragment — the whole `keys/` directory is ignored — that
+makes a local signed build a single command:
+
+```bash
+OPENCLIP_SIGN_IDENTITY="Developer ID Application: Your Name (TEAMID)"
+NOTARY_KEY="$PROJECT_DIR/keys/AuthKey_XXXXXXXXXX.p8"
+NOTARY_KEY_ID="XXXXXXXXXX"
+NOTARY_ISSUER="xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
+```
+
+Notary credentials come from one of three groups, and `scripts/notarize_artifact.sh` takes the
+first that is complete:
+
+| Group | Variables |
+|---|---|
+| Keychain profile | `NOTARY_PROFILE` (from `xcrun notarytool store-credentials`) |
+| App Store Connect API key | `NOTARY_KEY`, `NOTARY_KEY_ID`, `NOTARY_ISSUER` |
+| Apple ID | `NOTARY_APPLE_ID`, `NOTARY_PASSWORD`, `NOTARY_TEAM_ID` |
+
+The Key ID is the `XXXXXXXXXX` in the `AuthKey_XXXXXXXXXX.p8` filename. The Issuer ID is a UUID
+shown above the key list in App Store Connect under **Users and Access › Integrations › Team
+Keys**; it is not stored in the key file. `NOTARY_KEY` accepts either a path or the key text
+itself, so a CI secret can be passed inline without ever touching the disk in a readable state.
+
+## The pipeline
+
+`scripts/release_update.sh` runs these in order. `scripts/package_app.sh` runs the same steps
+minus the appcast.
+
+1. **Build** — `xcodebuild`, universal, deliberately left **ad-hoc signed**.
+2. **Sign** — `scripts/sign_artifact.sh` re-signs the finished bundle inside out.
+3. **Verify architectures** — `scripts/verify_universal.sh`.
+4. **Verify signature** — `scripts/verify_signing.sh --require developer-id`.
+5. **Notarize and staple** — `scripts/notarize_artifact.sh`.
+6. **Verify again** — `scripts/verify_signing.sh --require notarized`.
+7. **Archive** — `ditto` the stapled bundle into the release `.zip`.
+8. **Appcast** — Sparkle's `generate_appcast` signs the archive with the Ed25519 key.
+9. **Disk image** — built from the stapled app, then signed, notarized, stapled, and verified in
+   its own right.
+
+Order is load-bearing in three places.
+
+- **Signing before archiving.** Obvious, but it also means the build step never needs the
+  certificate, so the slow part of a release can run before credentials are checked. The scripts
+  resolve the identity up front anyway, because a missing certificate should be a five-second
+  failure and not a five-minute one.
+- **Stapling before archiving.** Stapling writes the ticket into the bundle. A zip cut beforehand
+  would contain an unstapled app, and Gatekeeper would have to ask Apple at first launch — which
+  fails for anyone offline or behind a filtered network. It also means the Sparkle signature and
+  the Homebrew `sha256` describe the stapled bundle, because they are taken from the archive in
+  step 7.
+- **Appcast before the disk image.** `generate_appcast` scans the output directory for release
+  archives, so the `.dmg` is built after it has run.
+
+## Why the app is re-signed rather than signed by Xcode
+
+The packaging scripts used to finish with `codesign --force --deep --sign -`. That single line
+caused most of what needed fixing:
+
+- `--deep` walks a bundle **outside in** and **discards the flags and entitlements** of everything
+  it re-signs. project.yml had asked for `ENABLE_HARDENED_RUNTIME` for a long time, and Xcode
+  honoured it — then this call replaced that hardened signature with a plain ad-hoc one. Apparency
+  reported `Hardening: Not enabled` on a project whose settings said otherwise, and no check
+  looked at the finished artifact.
+- Apple's own guidance is to sign nested code individually, deepest first, so a container is
+  sealed only once its contents are final. `scripts/sign_artifact.sh` does exactly that, using the
+  one shared walk in `oc_nested_code_items` so the signer and the verifier can never disagree
+  about what counts as nested code.
+
+Handing the identity straight to `xcodebuild` instead is not sufficient either. A Release build
+with `CODE_SIGN_IDENTITY` set to a Developer ID certificate produces:
+
+- the app, `Core.framework`, and `Sparkle.framework` correctly signed, but
+- **Sparkle's `Updater.app`, `Downloader.xpc`, `Installer.xpc`, and the `Autoupdate` helper still
+  ad-hoc signed**, exactly as Sparkle ships them. Signing a framework seals its helper binaries as
+  resources without re-signing them. One ad-hoc binary anywhere inside the bundle is enough for
+  the notary service to reject the whole submission.
+- **`com.apple.security.get-task-allow` injected into the entitlements.** Xcode adds this
+  debugging entitlement to any non-archive build. It lets other processes attach a debugger to the
+  app, and the notary service rejects submissions that request it.
+
+Re-signing the finished bundle from a known state fixes both, and the verifier fails the build if
+either ever comes back.
+
+## Entitlements
+
+`Sources/OpenClip/OpenClip.entitlements` grants exactly one thing:
+
+```
+com.apple.security.automation.apple-events
+```
+
+AppleScript actions drive other applications. `AppleScriptRunner` shells out to `/usr/bin/osascript`
+rather than using `NSAppleScript`, and TCC attributes those Apple events to OpenClip as the
+responsible process, so the app needs both this entitlement and the `NSAppleEventsUsageDescription`
+string that `project.yml` puts in `Info.plist`.
+
+Deliberately **not** granted:
+
+| Entitlement | Why not |
+|---|---|
+| `com.apple.security.cs.allow-jit` | JavaScriptCore extensions run correctly under the hardened runtime without it. Measured: a hot three-million-iteration loop evaluates in the same time signed with `--options runtime` as unsigned. The W^X exception buys nothing here. |
+| `com.apple.security.cs.disable-library-validation` | Nothing is `dlopen`'d. Extensions are JavaScript, shell, AppleScript, or URL templates — never native code. |
+| `com.apple.security.cs.allow-dyld-environment-variables` | Script actions get their environment from `ShellProcessRunner`; nothing injects `DYLD_*` into OpenClip itself. |
+| App Sandbox | Incompatible with Accessibility-based text capture, `CGEvent` key synthesis, `~/.openclip`, and arbitrary script actions. Notarization does not require it. |
+
+Two rules when editing that file:
+
+1. **No XML comments.** `codesign`'s entitlement parser (AMFI) rejects them outright with
+   `AMFIUnserializeXML: syntax error`, and the build fails at the signing step. Rationale goes in
+   this document, not in the plist.
+2. `scripts/verify_signing.sh` compares the **signed** entitlements against this file and fails on
+   any difference in either direction. Adding an entitlement is therefore a visible, reviewable
+   diff rather than something that appears only in shipped binaries.
+
+## What signing changes for users
+
+- **Gatekeeper stops refusing the app.** This is the whole point.
+- **The Accessibility grant survives updates.** An ad-hoc signature's designated requirement is a
+  bare `cdhash`, which changes with every build, so TCC treated each update as a different
+  application and quietly dropped the Accessibility permission. That is the bug
+  `PermissionManager.resetTCCAndRelaunch()` and the proactive `tccutil reset` work around. A
+  Developer ID signature's requirement pins the bundle identifier and the Team ID instead:
+
+  ```
+  identifier "com.openclip.OpenClip" and anchor apple generic
+    and certificate leaf[subject.OU] = <TEAMID>
+  ```
+
+  After one final re-grant on the first signed release, updates stop breaking Accessibility.
+- **The Team ID becomes a commitment.** Sparkle checks that an update is signed by the same team
+  as the installed app. Changing teams later means installed copies reject every future update and
+  every user has to reinstall by hand. The first notarized release is the moment to be sure the
+  certificate belongs to the account that will own OpenClip long-term.
+- **The first signed release still updates cleanly.** The installed copies are ad-hoc, so Sparkle
+  has no team to compare against and validates the Ed25519 appcast signature only. Release notes
+  for that version should tell users to re-grant Accessibility once.
+
+## Checking a build by hand
+
+`scripts/verify_signing.sh` runs all of this and fails the build. To reproduce it directly:
+
+```bash
+APP=build/DerivedData/Build/Products/Release/OpenClip.app
+
+codesign --verify --deep --strict --verbose=2 "$APP"   # structurally valid
+codesign -dvv "$APP"                                   # flags contain "runtime"; Authority=Developer ID
+                                                       # Application; Timestamp present; TeamIdentifier set
+codesign -d --entitlements - --xml "$APP"              # only the apple-events entitlement
+codesign -d -r- "$APP"                                 # designated requirement pins identifier + team
+xcrun stapler validate "$APP"                          # "The validate action worked!"
+spctl -a -vv -t exec "$APP"                            # accepted, source=Notarized Developer ID
+spctl -a -vv -t open --context context:primary-signature build/OpenClip.dmg
+```
+
+`spctl` above assesses a file with no quarantine attribute. `verify_signing.sh --require notarized`
+repeats the assessment on a quarantined copy, which is the state a download actually arrives in:
+
+```bash
+xattr -w com.apple.quarantine "0083;$(printf '%x' "$(date +%s)");Safari;$(uuidgen)" /tmp/OpenClip.app
+spctl -a -vv -t exec /tmp/OpenClip.app
+```
+
+## Verifying a published download
+
+Independent of signing, release artifacts carry a Sigstore build-provenance attestation binding
+them to the tag and workflow run that produced them:
+
+```bash
+gh attestation verify OpenClip-v1.4.0.dmg --repo ganeshmshetty/openclip \
+    --signer-workflow ganeshmshetty/openclip/.github/workflows/release.yml
+```
+
+## Troubleshooting
+
+| Symptom | Cause |
+|---|---|
+| `AMFIUnserializeXML: syntax error near line N` | An XML comment in the entitlements file. Remove it. |
+| `... is still ad-hoc signed while the app is not` | Something was signed outside `sign_artifact.sh`, or a new embedded helper is not covered by `oc_nested_code_items`. |
+| `not declared in OpenClip.entitlements: com.apple.security.get-task-allow` | The artifact came straight from `xcodebuild` without the re-sign step. |
+| `no secure timestamp` | Signed while offline. The timestamp needs Apple's timestamp server. |
+| Notary status `Invalid` | The script prints Apple's log; it names the offending binary and reason. |
+| `rejected ... source=Unnotarized Developer ID` | Signed correctly but not notarized yet. |
+| `The staple and validate action failed! Error 65` | No ticket for that exact build. Re-notarize; a ticket is tied to the cdhash. |
+
+## Continuous integration
+
+CI is **not** wired up for signing yet — that is deliberately a separate change. `.github/workflows/ci.yml`
+builds ad-hoc, which is correct: pull requests from forks get no secrets. `.github/workflows/release.yml`
+still needs the certificate and notary credentials as repository secrets, a temporary keychain to
+import them into, and a cleanup step; until then it passes `OPENCLIP_ALLOW_UNSIGNED_RELEASE=1`,
+which downgrades the run to ad-hoc and skips notarization so the pipeline keeps working. Artifacts
+built that way must not be published as a real release.

--- a/docs/dmg.md
+++ b/docs/dmg.md
@@ -133,9 +133,17 @@ inside a 660 × 400 window — so they scroll vertically for anyone with the tab
   that trick and keeping those plates aligned with `ICON_Y` by hand.
 - The volume icon is generated from `assets/app-icon.png` via `sips` + `iconutil`, so the
   mounted volume shows the app's icon in the Finder sidebar and on the desktop.
-- The window is intentionally free of a toolbar, status bar, path bar and sidebar, and the
-  app's `.app` extension is hidden, so the window reads as a single instruction rather than
-  a folder.
+- The window is intentionally free of a toolbar, status bar, path bar and sidebar, so it reads
+  as a single instruction rather than a folder.
+- The app's `.app` extension is **not** hidden, even though dmgbuild offers `hide_extensions`
+  for it. That setting works by writing Finder's hidden-extension bit into a
+  `com.apple.FinderInfo` extended attribute on the app bundle inside the image, and `codesign`
+  treats that attribute as "resource fork, Finder information, or similar detritus not allowed":
+  `codesign --verify --strict` then fails on the copy a user drags out of the DMG, while the same
+  bundle verifies cleanly from the `.zip`. `scripts/release_update.sh` verifies the app inside the
+  mounted image for exactly this reason. Finder hides `.app` extensions by default anyway, so the
+  only people affected are those who turned "Show all filename extensions" on — who asked to see
+  it.
 
 ## Verifying a change
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -57,6 +57,7 @@ Welcome to the **OpenClip** technical documentation hub. OpenClip is a lightweig
 - [Extending OpenClip Overview](developer-guide/overview.md) — Extension architecture and custom action integration.
 - [Extension Package Format](developer-guide/package-format.md) — `.openclipext` bundle structure, `manifest.json` schema, and options definitions.
 - [Standalone Snippet Parsing](developer-guide/snippets.md) — Pure header parsing via `OpenClipSnippetParser`.
+- [Code Signing, Hardened Runtime & Notarization](developer-guide/signing-and-notarization.md) — Ad-hoc vs Developer ID builds, the entitlements OpenClip grants and refuses, the sign → notarize → staple pipeline, and the checks that gate a release.
 
 ### Action Execution Runtimes
 - [AppleScript Runtime](runtimes/applescript.md) — `AppleScriptAction` execution, variable injection, and output handling.

--- a/docs/user-guide/installation.md
+++ b/docs/user-guide/installation.md
@@ -20,6 +20,22 @@ The interface follows the macOS system language. English and Simplified Chinese 
 2. **Move to Applications**: Drag `OpenClip.app` into your `/Applications` folder.
 3. **Launch OpenClip**: Open `OpenClip.app` from Finder or Spotlight.
 
+Releases are signed with an Apple Developer ID certificate and notarized by Apple, so OpenClip
+opens normally. There is no need to right-click to open it, and no need to strip a quarantine
+attribute with `xattr`. If macOS says the app "cannot be opened because the developer cannot be
+verified", the download is not a release build — check where it came from.
+
+To confirm what you have before launching it:
+
+```bash
+spctl -a -vv -t exec /Applications/OpenClip.app
+# accepted
+# source=Notarized Developer ID
+
+xcrun stapler validate /Applications/OpenClip.app
+# The validate action worked!
+```
+
 ---
 
 ## Granting Accessibility Permissions

--- a/project.yml
+++ b/project.yml
@@ -30,6 +30,8 @@ targets:
             CFBundleURLSchemes:
               - openclip
         LSUIElement: true
+        NSHumanReadableCopyright: "Copyright © 2026 Ganesh M and OpenClip Contributors. MIT licensed."
+        NSAppleEventsUsageDescription: "OpenClip needs to control other apps to run your AppleScript actions and to paste results back into the app you were using."
         SUFeedURL: https://github.com/ganeshmshetty/openclip/releases/latest/download/appcast.xml
         SUPublicEDKey: JbyKx5LUkYkM+ovsJ1NPDR2W+1ptfdsu6b51KBsKhWo=
         SUScheduledCheckInterval: 86400
@@ -49,6 +51,9 @@ targets:
         INFOPLIST_KEY_CFBundleShortVersionString: $(MARKETING_VERSION)
         INFOPLIST_KEY_CFBundleVersion: $(CURRENT_PROJECT_VERSION)
         ASSETCATALOG_COMPILER_APPICON_NAME: AppIcon
+        CODE_SIGN_ENTITLEMENTS: Sources/OpenClip/OpenClip.entitlements
+        # Ad-hoc is the default so a clone builds and runs with no Apple Developer account.
+        # scripts/sign_artifact.sh overrides the identity for signed/notarized builds.
         CODE_SIGN_IDENTITY: "-"
         CODE_SIGN_STYLE: Automatic
         DEVELOPMENT_TEAM: ""

--- a/scripts/make_dmg.sh
+++ b/scripts/make_dmg.sh
@@ -39,6 +39,14 @@ ICON_Y=210
 APP_X=170
 DROP_X=490
 
+# dmgbuild's hide_extensions is deliberately not used. It sets Finder's "hidden extension" bit,
+# which is stored in a com.apple.FinderInfo extended attribute written onto the app bundle inside
+# the image — and codesign counts that attribute as "resource fork, Finder information, or similar
+# detritus not allowed", so `codesign --verify --strict` fails on the copy a user drags out of the
+# DMG even though the same bundle verifies cleanly everywhere else. Finder hides .app extensions
+# by default regardless, so the only people who saw a difference were those who had turned
+# "Show all filename extensions" on, i.e. who asked to see it.
+#
 # dmgbuild writes the .DS_Store directly through the ds_store/mac_alias modules rather than
 # driving Finder over AppleScript, so it needs no GUI session and only the items listed in
 # icon_locations get a saved position. Leaving the hidden files (.background.tiff,
@@ -102,7 +110,6 @@ icon_locations = {
     "$APP_NAME": ($APP_X, $ICON_Y),
     "Applications": ($DROP_X, $ICON_Y),
 }
-hide_extensions = ["$APP_NAME"]
 PYTHON
 
 echo "==> Packaging $(basename "$OUTPUT_DMG")..."

--- a/scripts/notarize_artifact.sh
+++ b/scripts/notarize_artifact.sh
@@ -1,0 +1,151 @@
+#!/bin/bash
+# notarize_artifact.sh
+#
+# Submits an artifact to Apple's notary service, waits for the verdict, and staples the resulting
+# ticket to it.
+#
+# Stapling is the part that matters for a download: it writes the ticket into the artifact so
+# Gatekeeper can accept it without asking Apple at launch time, which is what makes the app open
+# on a machine that is offline or behind a filtered network.
+#
+# Usage:
+#   ./scripts/notarize_artifact.sh <path-to-OpenClip.app|path-to.dmg>
+#
+# An .app cannot be submitted as-is — the notary service takes an archive — so the bundle is
+# zipped to a scratch directory for the submission and the ticket is stapled back onto the
+# original bundle. A .dmg is submitted and stapled directly.
+#
+# Credentials, highest precedence first (see also keys/signing.env in scripts/signing_config.sh):
+#   NOTARY_PROFILE                                  a profile stored by
+#                                                   `xcrun notarytool store-credentials`
+#   NOTARY_KEY + NOTARY_KEY_ID + NOTARY_ISSUER      App Store Connect API key. NOTARY_KEY is
+#                                                   either a path to the .p8 or the key text
+#                                                   itself, so a CI secret can be passed inline.
+#   NOTARY_APPLE_ID + NOTARY_PASSWORD + NOTARY_TEAM_ID
+#                                                   Apple ID with an app-specific password.
+#
+# Set NOTARY_TIMEOUT to override the 30m ceiling on how long to wait for a verdict.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+OC_PROJECT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+# shellcheck source=scripts/signing_config.sh
+. "$SCRIPT_DIR/signing_config.sh"
+
+TARGET="${1:-}"
+if [ -z "$TARGET" ]; then
+    echo "usage: $0 <path-to-OpenClip.app|path-to.dmg>" >&2
+    exit 2
+fi
+if [ ! -e "$TARGET" ]; then
+    echo "error: nothing to notarize at $TARGET" >&2
+    exit 1
+fi
+TARGET="${TARGET%/}"
+LABEL="$(basename "$TARGET")"
+
+oc_load_signing_env
+
+WORK_DIR="$(mktemp -d)"
+# The scratch directory can hold a private key written out of an environment variable, so it is
+# removed on every exit path, not just the happy one.
+cleanup() { rm -rf "$WORK_DIR"; }
+trap cleanup EXIT
+
+CREDENTIALS=()
+if [ -n "${NOTARY_PROFILE:-}" ]; then
+    CREDENTIALS=(--keychain-profile "$NOTARY_PROFILE")
+    echo "==> Notarizing with keychain profile \"$NOTARY_PROFILE\""
+elif [ -n "${NOTARY_KEY:-}" ] && [ -n "${NOTARY_KEY_ID:-}" ] && [ -n "${NOTARY_ISSUER:-}" ]; then
+    KEY_PATH="$NOTARY_KEY"
+    if [ ! -f "$KEY_PATH" ]; then
+        # Treat the value as the key material itself. Written with a private mode before the
+        # content lands in it, so it is never briefly world-readable.
+        KEY_PATH="$WORK_DIR/AuthKey.p8"
+        (umask 077; printf '%s\n' "$NOTARY_KEY" > "$KEY_PATH")
+        if ! grep -q "BEGIN PRIVATE KEY" "$KEY_PATH"; then
+            echo "error: NOTARY_KEY is neither a readable file path nor a PEM private key." >&2
+            exit 1
+        fi
+    fi
+    CREDENTIALS=(--key "$KEY_PATH" --key-id "$NOTARY_KEY_ID" --issuer "$NOTARY_ISSUER")
+    echo "==> Notarizing with App Store Connect API key $NOTARY_KEY_ID"
+elif [ -n "${NOTARY_APPLE_ID:-}" ] && [ -n "${NOTARY_PASSWORD:-}" ] && [ -n "${NOTARY_TEAM_ID:-}" ]; then
+    CREDENTIALS=(--apple-id "$NOTARY_APPLE_ID" --password "$NOTARY_PASSWORD" --team-id "$NOTARY_TEAM_ID")
+    echo "==> Notarizing with Apple ID $NOTARY_APPLE_ID"
+else
+    cat >&2 <<'MSG'
+error: no notarization credentials configured.
+
+  Set one of these groups in the environment, or in the gitignored keys/signing.env:
+
+    NOTARY_PROFILE                                   (from `xcrun notarytool store-credentials`)
+    NOTARY_KEY, NOTARY_KEY_ID, NOTARY_ISSUER         (App Store Connect API key)
+    NOTARY_APPLE_ID, NOTARY_PASSWORD, NOTARY_TEAM_ID (app-specific password)
+
+  The Key ID is the XXXXXXXXXX in the AuthKey_XXXXXXXXXX.p8 filename. The Issuer ID is the UUID
+  shown above the key list in App Store Connect under Users and Access > Integrations.
+MSG
+    exit 1
+fi
+
+# What actually gets uploaded: the disk image itself, or a zip of the bundle.
+if [ -d "$TARGET" ]; then
+    SUBMISSION="$WORK_DIR/${LABEL%.app}-notarize.zip"
+    echo "==> Archiving $LABEL for submission..."
+    # --sequesterRsrc --keepParent matches how the release zip is built, so the notary service
+    # sees the same bundle layout that users will unpack.
+    ditto -c -k --sequesterRsrc --keepParent "$TARGET" "$SUBMISSION"
+else
+    SUBMISSION="$TARGET"
+fi
+
+echo "==> Submitting $(basename "$SUBMISSION") to the notary service (this usually takes a few minutes)..."
+SUBMIT_JSON="$WORK_DIR/submit.json"
+SUBMIT_STATUS=0
+xcrun notarytool submit "$SUBMISSION" \
+    "${CREDENTIALS[@]}" \
+    --wait \
+    --timeout "${NOTARY_TIMEOUT:-30m}" \
+    --output-format json \
+    > "$SUBMIT_JSON" 2>"$WORK_DIR/submit.err" || SUBMIT_STATUS=$?
+
+# notarytool writes progress to stderr; surface it only when something went wrong, so a normal
+# run stays readable.
+read_json() {
+    python3 -c "
+import json, sys
+try:
+    with open(sys.argv[1]) as fh:
+        print(json.load(fh).get(sys.argv[2], '') or '')
+except Exception:
+    print('')
+" "$SUBMIT_JSON" "$1"
+}
+
+SUBMISSION_ID="$(read_json id)"
+VERDICT="$(read_json status)"
+
+if [ "$VERDICT" != "Accepted" ]; then
+    echo "error: notarization did not succeed for $LABEL (status: ${VERDICT:-unknown})." >&2
+    [ -s "$WORK_DIR/submit.err" ] && sed 's/^/      /' "$WORK_DIR/submit.err" >&2
+    [ -s "$SUBMIT_JSON" ] && sed 's/^/      /' "$SUBMIT_JSON" >&2
+    if [ -n "$SUBMISSION_ID" ]; then
+        # The log is the only place Apple explains *why*; without it the failure is unactionable.
+        echo "--- notarytool log for $SUBMISSION_ID ---" >&2
+        xcrun notarytool log "$SUBMISSION_ID" "${CREDENTIALS[@]}" 2>&1 | sed 's/^/      /' >&2 || true
+    fi
+    exit 1
+fi
+
+echo "==> Accepted (submission $SUBMISSION_ID)"
+
+echo "==> Stapling the ticket to $LABEL..."
+if ! xcrun stapler staple "$TARGET"; then
+    echo "error: notarization succeeded but stapling $LABEL failed." >&2
+    exit 1
+fi
+
+xcrun stapler validate "$TARGET" >/dev/null
+echo "==> $LABEL is notarized and stapled."

--- a/scripts/package_app.sh
+++ b/scripts/package_app.sh
@@ -1,15 +1,48 @@
 #!/bin/bash
-# Builds OpenClip in Release mode and packages it into build/OpenClip.zip
+# package_app.sh
+#
+# Builds OpenClip in Release mode and packages it into build/OpenClip.zip and build/OpenClip.dmg.
+#
+# Signing is opt-in. With nothing configured the app is signed ad-hoc — with the hardened runtime
+# and the real entitlements still applied — so a fresh clone and a fork's CI run both work without
+# an Apple Developer account. Point OPENCLIP_SIGN_IDENTITY at a Developer ID certificate to
+# produce a distributable build, and add OPENCLIP_NOTARIZE=1 to take it all the way through
+# Apple's notary service:
+#
+#   ./scripts/package_app.sh                                    # ad-hoc, offline, no account
+#   OPENCLIP_SIGN_IDENTITY=auto ./scripts/package_app.sh        # Developer ID signed
+#   OPENCLIP_SIGN_IDENTITY=auto OPENCLIP_NOTARIZE=1 \
+#       ./scripts/package_app.sh                                # signed, notarized, stapled
+#
+# See scripts/signing_config.sh for the full configuration precedence, including the gitignored
+# keys/signing.env used for local release builds.
 
 set -e
 
 PROJECT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
 cd "$PROJECT_DIR"
 
+OC_PROJECT_DIR="$PROJECT_DIR"
+# shellcheck source=scripts/signing_config.sh
+. "$PROJECT_DIR/scripts/signing_config.sh"
+
+oc_load_signing_env
+IDENTITY="$(oc_resolve_identity "")"
+NOTARIZE="${OPENCLIP_NOTARIZE:-0}"
+
+if [ "$NOTARIZE" = "1" ] && oc_is_adhoc "$IDENTITY"; then
+    echo "error: OPENCLIP_NOTARIZE=1 needs a Developer ID identity; Apple will not notarize an ad-hoc build." >&2
+    echo "       Set OPENCLIP_SIGN_IDENTITY (see scripts/signing_config.sh)." >&2
+    exit 1
+fi
+
 echo "Generating Xcode project..."
 xcodegen generate
 
 echo "Building OpenClip (Release)..."
+# The build is left ad-hoc signed whatever the final identity is, and scripts/sign_artifact.sh
+# re-signs the finished bundle. That keeps one signing path for contributors and releases alike,
+# and it is the only way to get Sparkle's nested helpers off the ad-hoc signature they ship with.
 xcodebuild -project OpenClip.xcodeproj -scheme OpenClip -configuration Release -destination 'generic/platform=macOS' ARCHS='arm64 x86_64' ONLY_ACTIVE_ARCH=NO build > /dev/null
 
 BUILT_APP="$(find ~/Library/Developer/Xcode/DerivedData/OpenClip-*/Build/Products/Release -name "OpenClip.app" | head -n 1)"
@@ -19,24 +52,50 @@ if [ -z "$BUILT_APP" ]; then
     exit 1
 fi
 
-echo "Signing app bundle and embedded frameworks ad-hoc..."
-codesign --force --deep --sign - "$BUILT_APP"
+"$PROJECT_DIR/scripts/sign_artifact.sh" "$BUILT_APP"
 
 # CI runs this script on every push, so this is where an arm64-only regression gets caught
 # before it can reach a tag.
 "$PROJECT_DIR/scripts/verify_universal.sh" "$BUILT_APP" "OpenClip.app"
 
+# How far the signature has to go depends on what was configured. An ad-hoc build still has to
+# be hardened and carry exactly the declared entitlements; a Developer ID build additionally
+# needs a real certificate, a secure timestamp, and one team across every nested binary.
+REQUIRE="any"
+oc_is_adhoc "$IDENTITY" || REQUIRE="developer-id"
+
+if [ "$NOTARIZE" = "1" ]; then
+    "$PROJECT_DIR/scripts/verify_signing.sh" "$BUILT_APP" --require "$REQUIRE"
+    "$PROJECT_DIR/scripts/notarize_artifact.sh" "$BUILT_APP"
+    REQUIRE="notarized"
+fi
+
+"$PROJECT_DIR/scripts/verify_signing.sh" "$BUILT_APP" --require "$REQUIRE"
+
 mkdir -p "$PROJECT_DIR/build"
 OUTPUT_ZIP="$PROJECT_DIR/build/OpenClip.zip"
 OUTPUT_DMG="$PROJECT_DIR/build/OpenClip.dmg"
 
+# Both archives are cut after the app is signed and stapled, so the ticket travels with them.
 echo "Packaging $BUILT_APP into $OUTPUT_ZIP..."
 ditto -c -k --sequesterRsrc --keepParent "$BUILT_APP" "$OUTPUT_ZIP"
 
 echo "Packaging $BUILT_APP into $OUTPUT_DMG..."
 "$PROJECT_DIR/scripts/make_dmg.sh" "$BUILT_APP" "$OUTPUT_DMG"
 
+# The disk image is assessed by Gatekeeper in its own right, so it gets its own signature and,
+# when notarizing, its own ticket.
+"$PROJECT_DIR/scripts/sign_artifact.sh" "$OUTPUT_DMG"
+if [ "$NOTARIZE" = "1" ]; then
+    "$PROJECT_DIR/scripts/notarize_artifact.sh" "$OUTPUT_DMG"
+fi
+"$PROJECT_DIR/scripts/verify_signing.sh" "$OUTPUT_DMG" --require "$REQUIRE"
+
 echo "Release packages created:"
 echo "  ZIP: $OUTPUT_ZIP"
 echo "  DMG: $OUTPUT_DMG"
-
+if oc_is_adhoc "$IDENTITY"; then
+    echo ""
+    echo "note: this build is ad-hoc signed. Gatekeeper will refuse it on any other Mac."
+    echo "      Set OPENCLIP_SIGN_IDENTITY to build something distributable."
+fi

--- a/scripts/release_update.sh
+++ b/scripts/release_update.sh
@@ -1,9 +1,14 @@
 #!/bin/bash
 # release_update.sh
 #
-# Builds a Release archive, ad-hoc signs it, zips it, generates a Sparkle
-# appcast.xml signed with an Ed25519 private key, and packages a .dmg.
-# The resulting .zip, .dmg, and appcast.xml are ready to upload to a GitHub Release.
+# Builds a Release archive, signs it with a Developer ID certificate, notarizes and staples it,
+# zips it, generates a Sparkle appcast.xml signed with an Ed25519 private key, and packages a
+# .dmg that is signed, notarized, and stapled in its own right. The resulting .zip, .dmg, and
+# appcast.xml are ready to upload to a GitHub Release.
+#
+# A release is required to be signed and notarized. Anything less does not open on a machine
+# other than the one that built it, so the script refuses to produce one rather than emitting an
+# artifact that looks fine locally and fails for every user.
 #
 # Prerequisites:
 #   1. Generate Ed25519 keys once:
@@ -14,20 +19,45 @@
 #   2. For CI (GitHub Actions), export the private key as a secret:
 #        SPARKLE_ED_PRIVATE_KEY=<base64 private key>
 #
+#   3. A "Developer ID Application" certificate in the keychain, named by
+#        OPENCLIP_SIGN_IDENTITY (or "auto" to pick the only one), and notary credentials in
+#        NOTARY_PROFILE or NOTARY_KEY/NOTARY_KEY_ID/NOTARY_ISSUER. Locally these can all live in
+#        the gitignored keys/signing.env. See scripts/signing_config.sh.
+#
 # Usage:
 #   ./scripts/release_update.sh [version]
 #
 # Example:
 #   ./scripts/release_update.sh 1.2.0
-#   → build/release/OpenClip-v1.2.0.zip
-#   → build/release/OpenClip-v1.2.0.dmg
+#   → build/release/OpenClip-v1.2.0.zip   (signed, notarized, stapled)
+#   → build/release/OpenClip-v1.2.0.dmg   (signed, notarized, stapled)
 #   → build/release/appcast.xml
+#
+# OPENCLIP_ALLOW_UNSIGNED_RELEASE=1 downgrades the whole run to an ad-hoc build with the
+# notarization steps skipped. It exists so the release pipeline can still be exercised end to end
+# without certificates; artifacts it produces must not be published.
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 PROJECT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
 BUILD_DIR="$PROJECT_DIR/build/release"
 DERIVED_DATA="$PROJECT_DIR/build/DerivedData"
+
+OC_PROJECT_DIR="$PROJECT_DIR"
+# shellcheck source=scripts/signing_config.sh
+. "$SCRIPT_DIR/signing_config.sh"
+
+# Checked before the build rather than after it: a missing certificate is a five-second failure
+# here and a five-minute one at the end.
+oc_load_signing_env
+IDENTITY="$(oc_resolve_identity "")"
+ALLOW_UNSIGNED="${OPENCLIP_ALLOW_UNSIGNED_RELEASE:-0}"
+if [ "$ALLOW_UNSIGNED" = "1" ]; then
+    echo "warning: OPENCLIP_ALLOW_UNSIGNED_RELEASE=1 — building an ad-hoc, un-notarized release." >&2
+    echo "warning: these artifacts will not open on other Macs. Do not publish them." >&2
+else
+    oc_require_distribution_identity "$IDENTITY"
+fi
 
 VERSION="${1:-}"
 if [ -z "$VERSION" ]; then
@@ -69,10 +99,28 @@ if [ ! -d "$APP_PATH" ]; then
     exit 1
 fi
 
-echo "==> Ad-hoc signing (required for Apple Silicon)..."
-codesign --force --deep -s - "$APP_PATH"
+# The build above is deliberately left ad-hoc; this is where the real signature goes on. The old
+# `codesign --force --deep -s -` that used to live here is what kept every release ad-hoc and
+# stripped the hardened runtime that project.yml asks for, because --deep re-signs outside-in and
+# discards the flags and entitlements of everything it touches.
+"$SCRIPT_DIR/sign_artifact.sh" "$APP_PATH"
 
 "$SCRIPT_DIR/verify_universal.sh" "$APP_PATH" "build product"
+
+REQUIRE="developer-id"
+[ "$ALLOW_UNSIGNED" = "1" ] && REQUIRE="any"
+"$SCRIPT_DIR/verify_signing.sh" "$APP_PATH" --require "$REQUIRE"
+
+# Notarize and staple before the archive is cut. Stapling writes the ticket into the bundle, so a
+# zip made beforehand would carry an unstapled app and Gatekeeper would have to reach Apple at
+# first launch — which fails for anyone offline or behind a filtered network. The Sparkle
+# signature and the Homebrew sha256 are both taken from the archive produced further down, so
+# they have to describe the stapled bundle.
+if [ "$ALLOW_UNSIGNED" != "1" ]; then
+    "$SCRIPT_DIR/notarize_artifact.sh" "$APP_PATH"
+    REQUIRE="notarized"
+    "$SCRIPT_DIR/verify_signing.sh" "$APP_PATH" --require "$REQUIRE"
+fi
 
 echo "==> Packaging OpenClip-v$VERSION.zip..."
 ZIP_NAME="OpenClip-v$VERSION.zip"
@@ -183,6 +231,15 @@ echo "==> Packaging OpenClip-v$VERSION.dmg..."
 DMG_NAME="OpenClip-v$VERSION.dmg"
 "$SCRIPT_DIR/make_dmg.sh" "$APP_PATH" "$BUILD_DIR/$DMG_NAME"
 
+# Gatekeeper assesses the disk image itself before the user ever reaches the app inside it, and
+# the image is what the website links to, so it needs its own signature and its own ticket. The
+# app within is already stapled; this covers the container.
+"$SCRIPT_DIR/sign_artifact.sh" "$BUILD_DIR/$DMG_NAME"
+if [ "$ALLOW_UNSIGNED" != "1" ]; then
+    "$SCRIPT_DIR/notarize_artifact.sh" "$BUILD_DIR/$DMG_NAME"
+fi
+"$SCRIPT_DIR/verify_signing.sh" "$BUILD_DIR/$DMG_NAME" --require "$REQUIRE"
+
 # The .dmg is the download the website points at, so it gets the same check as the .zip.
 MOUNT_POINT="$(mktemp -d)"
 hdiutil attach "$BUILD_DIR/$DMG_NAME" -mountpoint "$MOUNT_POINT" -nobrowse -readonly -quiet
@@ -199,3 +256,10 @@ echo "==> Done! Release artifacts created:"
 echo "    $BUILD_DIR/$ZIP_NAME"
 echo "    $BUILD_DIR/$DMG_NAME"
 echo "    $BUILD_DIR/appcast.xml"
+if [ "$ALLOW_UNSIGNED" = "1" ]; then
+    echo ""
+    echo "warning: ad-hoc, un-notarized artifacts — for pipeline testing only, do not publish." >&2
+else
+    echo "    signed by: $IDENTITY"
+    echo "    notarized and stapled: OpenClip.app and $DMG_NAME"
+fi

--- a/scripts/release_update.sh
+++ b/scripts/release_update.sh
@@ -138,6 +138,10 @@ rm -rf "$VERIFY_DIR"
 mkdir -p "$VERIFY_DIR"
 ditto -x -k "$BUILD_DIR/$ZIP_NAME" "$VERIFY_DIR"
 "$SCRIPT_DIR/verify_universal.sh" "$VERIFY_DIR/OpenClip.app" "$ZIP_NAME"
+# The strongest check available: the app as it comes out of the archive people download, rather
+# than the bundle the archive was cut from. It proves the notarization ticket survived the
+# round trip through ditto, so Gatekeeper accepts the unpacked app with no network access.
+"$SCRIPT_DIR/verify_signing.sh" "$VERIFY_DIR/OpenClip.app" --require "$REQUIRE"
 rm -rf "$VERIFY_DIR"
 
 echo "==> Generating appcast.xml with Ed25519 signature..."
@@ -243,13 +247,17 @@ fi
 # The .dmg is the download the website points at, so it gets the same check as the .zip.
 MOUNT_POINT="$(mktemp -d)"
 hdiutil attach "$BUILD_DIR/$DMG_NAME" -mountpoint "$MOUNT_POINT" -nobrowse -readonly -quiet
-if ! "$SCRIPT_DIR/verify_universal.sh" "$MOUNT_POINT/OpenClip.app" "$DMG_NAME"; then
-    hdiutil detach "$MOUNT_POINT" -quiet || true
-    rmdir "$MOUNT_POINT" 2>/dev/null || true
+DMG_CHECKS_OK=1
+# Both checks run against the app as it sits inside the image, because that is what someone who
+# downloads from the website drags to /Applications. dmgbuild copies the bundle rather than
+# ditto'ing it, so this is where a lost symlink or a dropped notarization ticket would surface.
+"$SCRIPT_DIR/verify_universal.sh" "$MOUNT_POINT/OpenClip.app" "$DMG_NAME" || DMG_CHECKS_OK=0
+"$SCRIPT_DIR/verify_signing.sh" "$MOUNT_POINT/OpenClip.app" --require "$REQUIRE" || DMG_CHECKS_OK=0
+hdiutil detach "$MOUNT_POINT" -quiet || true
+rmdir "$MOUNT_POINT" 2>/dev/null || true
+if [ "$DMG_CHECKS_OK" -ne 1 ]; then
     exit 1
 fi
-hdiutil detach "$MOUNT_POINT" -quiet
-rmdir "$MOUNT_POINT" 2>/dev/null || true
 
 echo ""
 echo "==> Done! Release artifacts created:"

--- a/scripts/sign_artifact.sh
+++ b/scripts/sign_artifact.sh
@@ -1,0 +1,144 @@
+#!/bin/bash
+# sign_artifact.sh
+#
+# Signs a packaged OpenClip artifact — either OpenClip.app or a .dmg — for distribution.
+#
+# This replaces the `codesign --force --deep --sign -` call the packaging scripts used to make.
+# `--deep` is the wrong tool for a shipping bundle twice over: it walks the bundle outside-in, and
+# it drops the flags and entitlements of everything it re-signs. That is how release builds ended
+# up ad-hoc *and* without the hardened runtime that project.yml asks for. Here every nested piece
+# of code is signed individually, deepest first, so a container is only sealed once its contents
+# are final.
+#
+# Usage:
+#   ./scripts/sign_artifact.sh <path-to-OpenClip.app|path-to.dmg> [--identity <name>]
+#
+# With no identity configured the artifact is signed ad-hoc, with the hardened runtime and the
+# entitlements still applied, so unsigned local builds match release builds everywhere except the
+# certificate. See scripts/signing_config.sh for the configuration precedence.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+OC_PROJECT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+# shellcheck source=scripts/signing_config.sh
+. "$SCRIPT_DIR/signing_config.sh"
+
+TARGET=""
+IDENTITY_ARG=""
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --identity)
+            IDENTITY_ARG="${2:-}"
+            [ -n "$IDENTITY_ARG" ] || { echo "error: --identity needs a value" >&2; exit 2; }
+            shift 2
+            ;;
+        -h|--help)
+            sed -n '2,20p' "$0" | sed 's/^# \{0,1\}//'
+            exit 0
+            ;;
+        -*)
+            echo "error: unknown option $1" >&2
+            exit 2
+            ;;
+        *)
+            [ -z "$TARGET" ] || { echo "error: unexpected extra argument $1" >&2; exit 2; }
+            TARGET="$1"
+            shift
+            ;;
+    esac
+done
+
+if [ -z "$TARGET" ]; then
+    echo "usage: $0 <path-to-OpenClip.app|path-to.dmg> [--identity <name>]" >&2
+    exit 2
+fi
+if [ ! -e "$TARGET" ]; then
+    echo "error: nothing to sign at $TARGET" >&2
+    exit 1
+fi
+
+oc_load_signing_env
+IDENTITY="$(oc_resolve_identity "$IDENTITY_ARG")"
+TEAM_ID="$(oc_team_from_identity "$IDENTITY")"
+
+# A secure timestamp is what lets a signature keep verifying after the certificate expires, and
+# the notary service rejects submissions without one. The ad-hoc pseudo-identity has no
+# certificate to timestamp against, so asking for one there just fails the build.
+TIMESTAMP_FLAG="--timestamp"
+if oc_is_adhoc "$IDENTITY"; then
+    TIMESTAMP_FLAG="--timestamp=none"
+    echo "==> Signing ad-hoc (no Developer ID configured; not distributable)"
+else
+    echo "==> Signing with: $IDENTITY"
+fi
+
+sign_one() {
+    # $1 = path, remaining args = extra codesign flags
+    local path="$1"
+    shift
+    codesign \
+        --force \
+        --sign "$IDENTITY" \
+        --options runtime \
+        "$TIMESTAMP_FLAG" \
+        "$@" \
+        "$path"
+}
+
+if [ -d "$TARGET" ]; then
+    APP_PATH="${TARGET%/}"
+    ENTITLEMENTS="$(oc_entitlements_path)"
+    if [ ! -f "$ENTITLEMENTS" ]; then
+        echo "error: entitlements file missing at $ENTITLEMENTS" >&2
+        exit 1
+    fi
+
+    # Nested code, deepest first (see oc_nested_code_items). Signing the framework does not
+    # re-sign the helper binaries inside it, so each one is signed here in its own right;
+    # otherwise Sparkle's helpers keep the ad-hoc signature they ship with and the notary
+    # service rejects the whole app for containing code that is not Developer ID signed.
+    NESTED=()
+    while IFS= read -r item; do
+        NESTED+=("$item")
+    done < <(oc_nested_code_items "$APP_PATH")
+
+    # Guarded because `"${NESTED[@]}"` on an empty array is an unbound-variable error under
+    # `set -u` in the bash 3.2 that ships with macOS, and an empty list means the walk found
+    # nothing — a wrong path, not a bundle with no nested code.
+    if [ "${#NESTED[@]}" -eq 0 ]; then
+        echo "error: found no nested code under $APP_PATH — wrong path?" >&2
+        exit 1
+    fi
+
+    for item in "${NESTED[@]}"; do
+        echo "    signing ${item#"$APP_PATH"/}"
+        # Nested helpers get the hardened runtime but no entitlements of their own. Sparkle's
+        # XPC services and Updater.app ship with an empty entitlement dictionary, and its
+        # Autoupdate helper carries only a placeholder application-identifier that belongs to
+        # Sparkle's own ad-hoc identity — carrying that into a real Developer ID signature would
+        # claim an identifier this team does not own.
+        sign_one "$item"
+    done
+
+    echo "    signing $(basename "$APP_PATH") (with entitlements)"
+    sign_one "$APP_PATH" --entitlements "$ENTITLEMENTS"
+
+elif [ -f "$TARGET" ]; then
+    case "$TARGET" in
+        *.dmg)
+            # The disk image gets its own signature and, later, its own notarization ticket: it is
+            # what the website links to, so Gatekeeper assesses the image itself before the user
+            # ever reaches the app inside. `--options runtime` is meaningless for a disk image, so
+            # this is a plain signature.
+            echo "    signing $(basename "$TARGET")"
+            codesign --force --sign "$IDENTITY" "$TIMESTAMP_FLAG" "$TARGET"
+            ;;
+        *)
+            echo "error: don't know how to sign $TARGET (expected OpenClip.app or a .dmg)" >&2
+            exit 2
+            ;;
+    esac
+fi
+
+echo "==> Signed $(basename "$TARGET")${TEAM_ID:+ (team $TEAM_ID)}"

--- a/scripts/signing_config.sh
+++ b/scripts/signing_config.sh
@@ -1,0 +1,180 @@
+#!/bin/bash
+# signing_config.sh
+#
+# Sourced by sign_artifact.sh, notarize_artifact.sh, and verify_signing.sh. Not executable on
+# its own.
+#
+# Signing is opt-in: with nothing configured every script falls back to an ad-hoc signature, so
+# a fresh clone builds and packages with no Apple Developer account, no certificate, and no
+# network. Distribution builds turn it on by naming a "Developer ID Application" identity.
+#
+# Configuration, highest precedence first:
+#   1. --identity <name> on the command line (sign_artifact.sh / verify_signing.sh)
+#   2. OPENCLIP_SIGN_IDENTITY in the environment
+#   3. keys/signing.env, if it exists — a gitignored shell fragment for local release builds:
+#        OPENCLIP_SIGN_IDENTITY="Developer ID Application: Your Name (TEAMID)"
+#        NOTARY_KEY="$PROJECT_DIR/keys/AuthKey_XXXXXXXXXX.p8"
+#        NOTARY_KEY_ID="XXXXXXXXXX"
+#        NOTARY_ISSUER="xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
+#   4. "-" (ad-hoc)
+#
+# OPENCLIP_SIGN_IDENTITY may also be the literal "auto", which picks the one Developer ID
+# Application identity in the keychain and fails if there is none or more than one.
+
+# shellcheck shell=bash
+
+OC_ADHOC_IDENTITY="-"
+
+# Absolute path to the entitlements the app bundle is signed with. Kept here so the signer and
+# the verifier can never disagree about which file is authoritative.
+oc_entitlements_path() {
+    printf '%s\n' "$OC_PROJECT_DIR/Sources/OpenClip/OpenClip.entitlements"
+}
+
+# Sources keys/signing.env if present. Called before the identity is resolved.
+#
+# Anything already set in the environment survives the file, so a one-off override still works on
+# a machine that has signing.env configured — e.g. OPENCLIP_SIGN_IDENTITY=- to force an ad-hoc
+# build, or a different NOTARY_PROFILE for one run. Without this, plain assignments in the file
+# would clobber the caller's intent and the documented precedence would be a lie.
+oc_load_signing_env() {
+    local env_file="$OC_PROJECT_DIR/keys/signing.env"
+    [ -f "$env_file" ] || return 0
+
+    local env_identity="${OPENCLIP_SIGN_IDENTITY:-}"
+    local env_profile="${NOTARY_PROFILE:-}"
+    local env_key="${NOTARY_KEY:-}"
+    local env_key_id="${NOTARY_KEY_ID:-}"
+    local env_issuer="${NOTARY_ISSUER:-}"
+    local env_apple_id="${NOTARY_APPLE_ID:-}"
+    local env_password="${NOTARY_PASSWORD:-}"
+    local env_team="${NOTARY_TEAM_ID:-}"
+
+    # PROJECT_DIR is set for the duration of the source so signing.env can reference key files
+    # relative to the repo root.
+    # shellcheck disable=SC1090
+    PROJECT_DIR="$OC_PROJECT_DIR" . "$env_file"
+
+    [ -n "$env_identity" ] && OPENCLIP_SIGN_IDENTITY="$env_identity"
+    [ -n "$env_profile" ] && NOTARY_PROFILE="$env_profile"
+    [ -n "$env_key" ] && NOTARY_KEY="$env_key"
+    [ -n "$env_key_id" ] && NOTARY_KEY_ID="$env_key_id"
+    [ -n "$env_issuer" ] && NOTARY_ISSUER="$env_issuer"
+    [ -n "$env_apple_id" ] && NOTARY_APPLE_ID="$env_apple_id"
+    [ -n "$env_password" ] && NOTARY_PASSWORD="$env_password"
+    [ -n "$env_team" ] && NOTARY_TEAM_ID="$env_team"
+
+    echo "==> Loaded signing configuration from keys/signing.env"
+    return 0
+}
+
+# Echoes the identity to sign with. Resolves "auto" against the keychain.
+oc_resolve_identity() {
+    local requested="${1:-}"
+    [ -n "$requested" ] || requested="${OPENCLIP_SIGN_IDENTITY:-$OC_ADHOC_IDENTITY}"
+
+    if [ "$requested" != "auto" ]; then
+        printf '%s\n' "$requested"
+        return 0
+    fi
+
+    local matches
+    matches="$(security find-identity -v -p codesigning 2>/dev/null \
+        | sed -n 's/.*"\(Developer ID Application: [^"]*\)".*/\1/p')"
+    local count
+    count="$(printf '%s' "$matches" | grep -c . || true)"
+
+    if [ "$count" -eq 0 ]; then
+        echo "error: OPENCLIP_SIGN_IDENTITY=auto but no \"Developer ID Application\" identity is in the keychain." >&2
+        echo "       Import one, or unset OPENCLIP_SIGN_IDENTITY to build ad-hoc." >&2
+        return 1
+    fi
+    if [ "$count" -gt 1 ]; then
+        echo "error: OPENCLIP_SIGN_IDENTITY=auto is ambiguous — $count Developer ID identities found:" >&2
+        printf '       %s\n' "$matches" >&2
+        echo "       Name the one to use explicitly instead of \"auto\"." >&2
+        return 1
+    fi
+    printf '%s\n' "$matches"
+}
+
+# True when the resolved identity is the ad-hoc pseudo-identity.
+oc_is_adhoc() {
+    [ "${1:-}" = "$OC_ADHOC_IDENTITY" ]
+}
+
+# Echoes the Team ID out of a "Developer ID Application: Name (TEAMID)" identity string, or
+# nothing when the identity is ad-hoc or carries no parenthesised team.
+oc_team_from_identity() {
+    printf '%s\n' "${1:-}" | sed -n 's/.*(\([A-Z0-9]\{10\}\))[[:space:]]*$/\1/p'
+}
+
+# Echoes every item inside an app bundle that carries a signature of its own, ordered deepest
+# first so that a container always follows its own contents. The bundle itself is not included.
+#
+# Two kinds of item qualify: nested bundles (.framework, .app, .xpc, .bundle) and loose Mach-O
+# executables. Sparkle contributes both — an Updater.app, two XPC services, and an `Autoupdate`
+# helper binary sitting directly inside the framework. Symlinks are skipped, because
+# Sparkle.framework/Updater.app and .../Versions/Current only point at the real items under
+# Versions/B and signing through a link corrupts the seal.
+oc_nested_code_items() {
+    local app="${1%/}"
+    {
+        find "$app" \
+            \( -name "*.framework" -o -name "*.app" -o -name "*.xpc" -o -name "*.bundle" \) \
+            -type d -print
+        find "$app" -type f -print | while IFS= read -r f; do
+            file -b "$f" | grep -q "Mach-O" && printf '%s\n' "$f"
+        done
+    } | awk -F'/' '{ print NF "\t" $0 }' | sort -k1,1rn -s | cut -f2- | awk -v self="$app" '$0 != self'
+}
+
+# True when a path is a Mach-O binary or a bundle containing one. Resource-only bundles (the
+# .bundle directories SwiftPM emits for a package's assets) are still signed, but the hardened
+# runtime is a property of executable code, so requiring the flag on them would be meaningless.
+oc_item_has_code() {
+    local path="$1"
+    if [ -f "$path" ]; then
+        file -b "$path" | grep -q "Mach-O"
+        return $?
+    fi
+    local found
+    found="$(
+        find "$path" -type f -print | while IFS= read -r f; do
+            if file -b "$f" | grep -q "Mach-O"; then
+                echo yes
+                break
+            fi
+        done
+    )"
+    [ "$found" = "yes" ]
+}
+
+# Fails when the identity is not usable for distribution. Used by release paths that must never
+# ship an ad-hoc build.
+oc_require_distribution_identity() {
+    local identity="${1:-}"
+    if oc_is_adhoc "$identity"; then
+        cat >&2 <<'MSG'
+error: this is a distribution build, but no Developer ID identity is configured.
+
+  A release must be signed with a "Developer ID Application" certificate and notarized,
+  otherwise Gatekeeper refuses to launch it on any machine but the one that built it.
+
+  Configure one of:
+    export OPENCLIP_SIGN_IDENTITY="Developer ID Application: Your Name (TEAMID)"
+    export OPENCLIP_SIGN_IDENTITY=auto        # pick the only one in the keychain
+    keys/signing.env                          # gitignored, see scripts/signing_config.sh
+
+  To package an unsigned build on purpose (local testing, CI without secrets), use
+  scripts/package_app.sh, which is ad-hoc by default.
+MSG
+        return 1
+    fi
+    if [ -z "$(oc_team_from_identity "$identity")" ]; then
+        echo "error: cannot read a Team ID out of the signing identity \"$identity\"." >&2
+        echo "       Expected a name ending in \"(TEAMID)\"; Sparkle and TCC both key on that team." >&2
+        return 1
+    fi
+    return 0
+}

--- a/scripts/verify_signing.sh
+++ b/scripts/verify_signing.sh
@@ -295,8 +295,12 @@ if [ "$FAILURES" -ne 0 ]; then
     exit 1
 fi
 
-if [ "$IS_ADHOC" -eq 1 ]; then
-    echo "==> $LABEL is a valid ad-hoc build (hardened, correct entitlements) — not distributable."
+# The hardened runtime and entitlements are properties of the app; a disk image only carries a
+# signature, so its summary must not claim more than was checked.
+if [ "$IS_ADHOC" -eq 1 ] && [ "$IS_APP" -eq 1 ]; then
+    echo "==> $LABEL is a valid ad-hoc build (hardened, entitlements as declared) — not distributable."
+elif [ "$IS_ADHOC" -eq 1 ]; then
+    echo "==> $LABEL is ad-hoc signed — not distributable."
 else
     echo "==> $LABEL passed all --require $REQUIRE checks."
 fi

--- a/scripts/verify_signing.sh
+++ b/scripts/verify_signing.sh
@@ -1,0 +1,302 @@
+#!/bin/bash
+# verify_signing.sh
+#
+# Fails if a packaged artifact is not signed the way OpenClip is supposed to ship.
+#
+# Inspecting build settings is not enough here. project.yml has asked for ENABLE_HARDENED_RUNTIME
+# since long before any release actually carried it: the old `codesign --deep --sign -` step in the
+# packaging scripts quietly replaced Xcode's hardened signature with a plain ad-hoc one, and
+# nothing checked the finished bundle. So this reads the artifact, the way Gatekeeper and
+# Apparency do, and it walks the nested code too — Xcode leaves Sparkle's Updater.app, XPC
+# services, and Autoupdate helper ad-hoc signed even when the app itself gets a Developer ID,
+# which is enough on its own to fail notarization.
+#
+# Usage:
+#   ./scripts/verify_signing.sh <path-to-OpenClip.app|path-to.dmg> [--require <level>]
+#
+# Levels:
+#   any           (default) structural signature, hardened runtime, entitlements match the
+#                 checked-in entitlements file. Passes for ad-hoc builds.
+#   developer-id  the above, plus a Developer ID Application certificate, a secure timestamp,
+#                 and one consistent Team ID across every nested binary.
+#   notarized     the above, plus a stapled notarization ticket and a Gatekeeper assessment that
+#                 accepts the artifact as "Notarized Developer ID", checked again through a
+#                 quarantined copy so the result matches what a downloader gets.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+OC_PROJECT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+# shellcheck source=scripts/signing_config.sh
+. "$SCRIPT_DIR/signing_config.sh"
+
+TARGET=""
+REQUIRE="any"
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --require)
+            REQUIRE="${2:-}"
+            shift 2
+            ;;
+        -h|--help)
+            sed -n '2,26p' "$0" | sed 's/^# \{0,1\}//'
+            exit 0
+            ;;
+        -*)
+            echo "error: unknown option $1" >&2
+            exit 2
+            ;;
+        *)
+            TARGET="$1"
+            shift
+            ;;
+    esac
+done
+
+case "$REQUIRE" in
+    any|developer-id|notarized) ;;
+    *) echo "error: --require must be any, developer-id, or notarized (got \"$REQUIRE\")" >&2; exit 2 ;;
+esac
+
+if [ -z "$TARGET" ] || [ ! -e "$TARGET" ]; then
+    echo "usage: $0 <path-to-OpenClip.app|path-to.dmg> [--require any|developer-id|notarized]" >&2
+    exit 2
+fi
+TARGET="${TARGET%/}"
+LABEL="$(basename "$TARGET")"
+
+FAILURES=0
+fail() {
+    echo "  ✗ $1" >&2
+    FAILURES=$((FAILURES + 1))
+}
+pass() {
+    echo "  ✓ $1"
+}
+
+# `codesign -dvv` writes its report to stderr; capture it once and query it repeatedly.
+signature_report() {
+    codesign -dvv "$1" 2>&1 || true
+}
+
+echo "==> Verifying $LABEL (--require $REQUIRE)"
+
+REPORT="$(signature_report "$TARGET")"
+
+if ! grep -q "^Signature=" <<<"$REPORT" && ! grep -q "^CodeDirectory" <<<"$REPORT"; then
+    fail "$LABEL is not signed at all"
+    echo "error: $LABEL failed signing verification ($FAILURES problem(s))." >&2
+    exit 1
+fi
+
+IS_ADHOC=0
+grep -qE "^CodeDirectory .*flags=.*adhoc" <<<"$REPORT" && IS_ADHOC=1
+TEAM_ID="$(sed -n 's/^TeamIdentifier=\(.*\)$/\1/p' <<<"$REPORT" | head -1)"
+[ "$TEAM_ID" = "not set" ] && TEAM_ID=""
+
+# ---------------------------------------------------------------------------
+# 1. Structural integrity. --deep so nested bundles are checked too, --strict so
+#    Gatekeeper's own resource rules apply rather than the lenient defaults.
+# ---------------------------------------------------------------------------
+if codesign --verify --deep --strict --verbose=2 "$TARGET" >/dev/null 2>&1; then
+    pass "signature is structurally valid (--deep --strict)"
+else
+    fail "codesign --verify --deep --strict failed:"
+    codesign --verify --deep --strict --verbose=2 "$TARGET" 2>&1 | sed 's/^/      /' >&2 || true
+fi
+
+IS_APP=0
+[ -d "$TARGET" ] && IS_APP=1
+
+if [ "$IS_APP" -eq 1 ]; then
+    # -----------------------------------------------------------------------
+    # 2. Hardened runtime on the app itself. This is the "Hardening: Not enabled"
+    #    row in Apparency, and the reason notarization used to be impossible.
+    # -----------------------------------------------------------------------
+    if grep -qE "^CodeDirectory .*flags=.*runtime" <<<"$REPORT"; then
+        pass "hardened runtime enabled"
+    else
+        fail "hardened runtime flag missing — notarization will be refused"
+    fi
+
+    # -----------------------------------------------------------------------
+    # 3. Entitlements must be exactly what the repo declares. Comparing against the
+    #    checked-in file (rather than a list hard-coded here) keeps one source of
+    #    truth, and it catches the entitlement Xcode injects on its own:
+    #    com.apple.security.get-task-allow, a debugging hole that the notary service
+    #    rejects and that a plain `xcodebuild build` adds to every Release build.
+    # -----------------------------------------------------------------------
+    ENTITLEMENTS_FILE="$(oc_entitlements_path)"
+    # The signed entitlements go to a file rather than a pipe: the comparison program arrives on
+    # python's stdin via heredoc, so a pipe into it would be swallowed and every artifact would
+    # look like it had no entitlements at all.
+    SIGNED_ENTITLEMENTS="$(mktemp)"
+    codesign -d --entitlements - --xml "$TARGET" >"$SIGNED_ENTITLEMENTS" 2>/dev/null || true
+    if ENT_DIFF="$(
+        python3 - "$ENTITLEMENTS_FILE" "$SIGNED_ENTITLEMENTS" <<'PY'
+import plistlib, sys
+
+expected_path, actual_path = sys.argv[1], sys.argv[2]
+with open(expected_path, "rb") as fh:
+    expected = plistlib.load(fh)
+
+with open(actual_path, "rb") as fh:
+    raw = fh.read()
+start = raw.find(b"<?xml")
+actual = plistlib.loads(raw[start:]) if start >= 0 else {}
+
+missing = sorted(k for k in expected if k not in actual)
+extra = sorted(k for k in actual if k not in expected)
+changed = sorted(k for k in expected if k in actual and expected[k] != actual[k])
+
+problems = []
+if missing:
+    problems.append("missing: " + ", ".join(missing))
+if extra:
+    problems.append("not declared in OpenClip.entitlements: " + ", ".join(extra))
+if changed:
+    problems.append("value differs from OpenClip.entitlements: " + ", ".join(changed))
+
+if problems:
+    print("; ".join(problems))
+    sys.exit(1)
+sys.exit(0)
+PY
+    )"; then
+        pass "entitlements match Sources/OpenClip/OpenClip.entitlements"
+    else
+        fail "entitlements do not match Sources/OpenClip/OpenClip.entitlements — $ENT_DIFF"
+    fi
+    rm -f "$SIGNED_ENTITLEMENTS"
+
+    # -----------------------------------------------------------------------
+    # 4. Every nested binary, not just the app. One ad-hoc helper is enough for the
+    #    notary service to reject the submission, and mixed teams break Sparkle's
+    #    check that its updater belongs to the app that launched it.
+    # -----------------------------------------------------------------------
+    NESTED_TOTAL=0
+    NESTED_BAD=0
+    while IFS= read -r item; do
+        NESTED_TOTAL=$((NESTED_TOTAL + 1))
+        NESTED_REPORT="$(signature_report "$item")"
+        REL="${item#"$TARGET"/}"
+
+        if oc_item_has_code "$item" && ! grep -qE "^CodeDirectory .*flags=.*runtime" <<<"$NESTED_REPORT"; then
+            fail "$REL is not signed with the hardened runtime"
+            NESTED_BAD=$((NESTED_BAD + 1))
+        fi
+
+        NESTED_ADHOC=0
+        grep -qE "^CodeDirectory .*flags=.*adhoc" <<<"$NESTED_REPORT" && NESTED_ADHOC=1
+
+        if [ "$IS_ADHOC" -eq 0 ] && [ "$NESTED_ADHOC" -eq 1 ]; then
+            fail "$REL is still ad-hoc signed while the app is not — notarization will reject this"
+            NESTED_BAD=$((NESTED_BAD + 1))
+        fi
+
+        if [ -n "$TEAM_ID" ]; then
+            NESTED_TEAM="$(sed -n 's/^TeamIdentifier=\(.*\)$/\1/p' <<<"$NESTED_REPORT" | head -1)"
+            if [ "$NESTED_TEAM" != "$TEAM_ID" ]; then
+                fail "$REL is signed by team \"${NESTED_TEAM:-none}\", expected \"$TEAM_ID\""
+                NESTED_BAD=$((NESTED_BAD + 1))
+            fi
+        fi
+    done < <(oc_nested_code_items "$TARGET")
+
+    if [ "$NESTED_TOTAL" -eq 0 ]; then
+        fail "found no nested code under $LABEL — wrong path?"
+    elif [ "$NESTED_BAD" -eq 0 ]; then
+        pass "all $NESTED_TOTAL nested binaries hardened and consistently signed"
+    fi
+fi
+
+# ---------------------------------------------------------------------------
+# 5. Distribution requirements.
+# ---------------------------------------------------------------------------
+if [ "$REQUIRE" = "developer-id" ] || [ "$REQUIRE" = "notarized" ]; then
+    if [ "$IS_ADHOC" -eq 1 ]; then
+        fail "$LABEL is ad-hoc signed; --require $REQUIRE needs a Developer ID Application certificate"
+    else
+        if grep -q "^Authority=Developer ID Application:" <<<"$REPORT"; then
+            pass "signed by $(sed -n 's/^Authority=\(Developer ID Application:.*\)$/\1/p' <<<"$REPORT" | head -1)"
+        else
+            fail "not signed by a \"Developer ID Application\" certificate (found: $(sed -n 's/^Authority=\(.*\)$/\1/p' <<<"$REPORT" | head -1 | sed 's/^$/none/'))"
+        fi
+
+        # Without a secure timestamp the signature stops verifying the day the certificate
+        # expires, and the notary service refuses the submission outright.
+        if grep -q "^Timestamp=" <<<"$REPORT"; then
+            pass "secure timestamp present"
+        else
+            fail "no secure timestamp — sign with --timestamp"
+        fi
+
+        if [ -n "$TEAM_ID" ]; then
+            pass "Team ID $TEAM_ID"
+        else
+            fail "no Team ID in the signature"
+        fi
+    fi
+fi
+
+if [ "$REQUIRE" = "notarized" ]; then
+    if xcrun stapler validate "$TARGET" >/dev/null 2>&1; then
+        pass "notarization ticket is stapled (works offline)"
+    else
+        fail "no stapled notarization ticket:"
+        xcrun stapler validate "$TARGET" 2>&1 | sed 's/^/      /' >&2 || true
+    fi
+
+    # Gatekeeper's own verdict. A disk image is assessed as something the user opens, and
+    # --context context:primary-signature makes spctl judge the image's signature instead of
+    # looking for a document handler for it.
+    if [ "$IS_APP" -eq 1 ]; then
+        ASSESS="$(spctl -a -vv -t exec "$TARGET" 2>&1 || true)"
+    else
+        ASSESS="$(spctl -a -vv -t open --context context:primary-signature "$TARGET" 2>&1 || true)"
+    fi
+    if grep -q "accepted" <<<"$ASSESS" && grep -q "source=Notarized Developer ID" <<<"$ASSESS"; then
+        pass "Gatekeeper accepts it as Notarized Developer ID"
+    else
+        fail "Gatekeeper did not accept it:"
+        sed 's/^/      /' <<<"$ASSESS" >&2
+    fi
+
+    # The assessment above ran on a file with no quarantine attribute. Repeat it on a
+    # quarantined copy, which is the state a .dmg or .zip arrives in from a browser, so the
+    # result is the one a person downloading OpenClip actually gets.
+    QUARANTINE_DIR="$(mktemp -d)"
+    trap 'rm -rf "$QUARANTINE_DIR"' EXIT
+    ditto "$TARGET" "$QUARANTINE_DIR/$LABEL"
+    xattr -w com.apple.quarantine "0083;$(printf '%x' "$(date +%s)");Safari;$(uuidgen)" "$QUARANTINE_DIR/$LABEL"
+    if [ "$IS_APP" -eq 1 ]; then
+        QASSESS="$(spctl -a -vv -t exec "$QUARANTINE_DIR/$LABEL" 2>&1 || true)"
+    else
+        QASSESS="$(spctl -a -vv -t open --context context:primary-signature "$QUARANTINE_DIR/$LABEL" 2>&1 || true)"
+    fi
+    if grep -q "accepted" <<<"$QASSESS"; then
+        pass "still accepted after download quarantine is applied"
+    else
+        fail "rejected once quarantined — users would see Gatekeeper's warning:"
+        sed 's/^/      /' <<<"$QASSESS" >&2
+    fi
+fi
+
+# The designated requirement is what TCC records when the user grants Accessibility. An ad-hoc
+# build's requirement is a bare cdhash, which changes on every build and is why the Accessibility
+# grant kept being forgotten across updates; a Developer ID build pins bundle id plus team, so
+# the grant survives.
+# codesign prefixes the requirement with "# " for an ad-hoc signature but not for a real one,
+# so both spellings are stripped here.
+echo "  · designated requirement: $(codesign -d -r- "$TARGET" 2>&1 | sed -n 's/^#\{0,1\}[[:space:]]*designated => //p' | head -1)"
+
+if [ "$FAILURES" -ne 0 ]; then
+    echo "error: $LABEL failed signing verification ($FAILURES problem(s))." >&2
+    exit 1
+fi
+
+if [ "$IS_ADHOC" -eq 1 ]; then
+    echo "==> $LABEL is a valid ad-hoc build (hardened, correct entitlements) — not distributable."
+else
+    echo "==> $LABEL passed all --require $REQUIRE checks."
+fi


### PR DESCRIPTION
Every OpenClip release so far has been ad-hoc signed and unhardened, and the second part was not intentional. `project.yml` has set `ENABLE_HARDENED_RUNTIME` for a long time and Xcode honoured it, but both packaging scripts finished with `codesign --force --deep --sign -`, and `--deep` re-signs a bundle outside-in while discarding the flags and entitlements of everything it touches. The hardened signature was replaced by a plain ad-hoc one on the way out, nothing inspected the finished artifact, and `SECURITY.md` documented a protection that shipped builds did not have.

This gets the app to a Developer ID signature, a genuine hardened runtime, and a stapled notarization ticket, and adds the checks that stop any of it regressing quietly.

## Two traps that a signing identity alone does not solve

Handing a Developer ID to `xcodebuild` is not sufficient. A Release build with `CODE_SIGN_IDENTITY` set produces:

- the app, `Core.framework` and `Sparkle.framework` correctly signed, but **Sparkle's `Updater.app`, `Downloader.xpc`, `Installer.xpc` and the `Autoupdate` helper still ad-hoc**, exactly as Sparkle ships them. Signing a framework seals its helper binaries as resources without re-signing them, and one ad-hoc binary anywhere inside the bundle is enough for the notary service to reject the whole submission.
- **`com.apple.security.get-task-allow` injected into the entitlements.** Xcode adds this debugging entitlement to any non-archive build. It lets other processes attach a debugger, and the notary service refuses submissions that request it.

So the finished bundle is re-signed from a known state, inside out, deepest first.

## What's here

| Script | Role |
|---|---|
| `scripts/signing_config.sh` | Identity and credential resolution, plus the one shared nested-code walk so the signer and the verifier cannot disagree |
| `scripts/sign_artifact.sh` | Signs an `.app` deepest-first, or a `.dmg` |
| `scripts/notarize_artifact.sh` | Submits to the notary service and staples the ticket |
| `scripts/verify_signing.sh` | Fails the build on anything not distributable |

`verify_signing.sh` has three levels. `any` requires a structurally valid signature, the hardened runtime, and entitlements matching the checked-in file. `developer-id` adds a real certificate, a secure timestamp, and one consistent Team ID across every nested binary. `notarized` adds a stapled ticket and a Gatekeeper verdict, re-checked through a quarantined copy so the result is the one a downloader gets.

Entitlements grant exactly one exception, `com.apple.security.automation.apple-events`, for the Apple events that AppleScript actions send. `allow-jit` is deliberately withheld: JavaScriptCore evaluates a hot three-million-iteration loop in the same time under `--options runtime` as unsigned, so the W^X hole buys nothing. The file carries no XML comments because `codesign`'s AMFI parser rejects them outright.

## Signing is opt-in and defaults to ad-hoc

A clone builds and packages with no Apple Developer account, certificate, or network access. Ad-hoc builds carry the same hardened runtime and entitlements as a release; the only thing they cannot do is leave the machine that produced them.

```bash
./scripts/package_app.sh                                # ad-hoc
OPENCLIP_SIGN_IDENTITY=auto OPENCLIP_NOTARIZE=1 \
    ./scripts/package_app.sh                            # signed, notarized, stapled
```

## CI

`release.yml` signs, notarizes and staples when the secrets are present, and otherwise still builds and publishes an ad-hoc release with a `::warning::` naming exactly which secrets were missing. All are required together, because a certificate without notary credentials would sign successfully and fail minutes later. The certificate is imported with plain `security` commands into a keychain under `RUNNER_TEMP` that is never made the default and is deleted by a step marked `if: always()`. The `.p8` is passed as inline PEM through the environment and never written into the workspace. There is no secret for the Team ID: the temporary keychain holds one identity, so the run uses `OPENCLIP_SIGN_IDENTITY=auto`, which fails loudly on none or several.

`ci.yml` stays ad-hoc on purpose. Fork pull requests get no secrets, so a certificate there would only work for collaborator branches, and a check that silently does nothing for outside contributors is worse than one that behaves the same for everyone. A new step verifies the app unpacked from the archive, so the hardening regression cannot come back.

## Also fixed

Dropped dmgbuild's `hide_extensions`. It writes Finder's hidden-extension bit into a `com.apple.FinderInfo` attribute on the app inside the image, and `codesign` counts that as "resource fork, Finder information, or similar detritus not allowed" — so `codesign --verify --strict` failed on the copy a user drags out of the DMG while the identical bundle from the `.zip` verified cleanly. The new in-image check is what caught it. Finder hides `.app` extensions by default anyway.

## What signing changes for users

Gatekeeper stops refusing the app, and the Accessibility grant survives updates. An ad-hoc signature's designated requirement is a bare `cdhash` that changes with every build, so TCC treated each update as a different application — the bug `PermissionManager` works around with `tccutil reset`. A Developer ID requirement pins the bundle identifier and Team ID instead.

The Team ID becomes a commitment: Sparkle checks that an update is signed by the same team as the installed app, so changing teams later means installed copies reject every future update.

## Verification

Ran end to end locally, twice: ad-hoc with no credentials, and Developer ID with notarization. Both the app and the disk image were accepted by Apple and stapled. Verified at `--require notarized` in three places — the build product, the app unpacked from the release zip, and the app inside the mounted disk image — and confirmed each is still accepted once a download quarantine attribute is applied. The keychain import sequence was rehearsed locally, including that the login keychain survives and `delete-keychain` restores the search list exactly.

Test suite shows no regression. Failing test methods on this branch are a subset of those failing on `main`: `main` at 737e35e gives 12 assertion failures across five tests, this branch gives 6 across four of them, all environment-dependent (screen geometry and number locale).

## Before merging

The five signing secrets need to be added, and the Homebrew cask still strips quarantine in a postflight — that has to be removed in the same change that bumps the cask to the first notarized release, not before.

Full reference: `docs/developer-guide/signing-and-notarization.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Release builds are now signed with an Apple Developer ID, notarized, and stapled for smoother macOS installation.
  * Hardened runtime protections and required Apple Events permissions are applied consistently.
  * Release packages now include both ZIP and DMG formats.

* **Bug Fixes**
  * Accessibility permissions can persist across updates more reliably.
  * DMG packaging no longer adds metadata that can invalidate code signatures.

* **Documentation**
  * Added guidance for installation, signing, notarization, verification, and distinguishing release builds from local ad-hoc builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->