### PR TITLE
Rebuild the preferences window on stock AppKit controls

### DIFF
--- a/OpenClip.xcodeproj/project.pbxproj
+++ b/OpenClip.xcodeproj/project.pbxproj
@@ -50,6 +50,7 @@
 		2140964D90DA799B312DED49 /* GoldenExtensionPlatformTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0A5C800BE48C74A05B33DDA /* GoldenExtensionPlatformTests.swift */; };
 		220A6F48497F91FA31273426 /* CalendarActionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D1221805EFDD065CA543A00 /* CalendarActionTests.swift */; };
 		22D5F64A56A4688BE5272FE2 /* ActionRowControlsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DF89ACBE81E50696C1CCF2F3 /* ActionRowControlsTests.swift */; };
+		23079CE2CEE3E41027A6413A /* PreferencesToolbar.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7F26242B60606C743CBBA169 /* PreferencesToolbar.swift */; };
 		2320A4B4D04528CD6D99F9BF /* NativeSearchField.swift in Sources */ = {isa = PBXBuildFile; fileRef = 38966F7112271EC9D176FA15 /* NativeSearchField.swift */; };
 		24ABC449CE3810541D898C48 /* PermissionManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4BB115DCDCB4749A1DDB8222 /* PermissionManager.swift */; };
 		2625F61BBDA95D300AA8BBC4 /* LocalizedStringValue.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7F0E732D2DCAF53EDEB6653D /* LocalizedStringValue.swift */; };
@@ -244,6 +245,7 @@
 		AE8C8312A2C5B67FCF938E4E /* SettingKey.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1830B25888AE1D0532D00813 /* SettingKey.swift */; };
 		AEB67702CE089BAFFFB8DCB7 /* ActionResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = E54AEEA54ADE3106E777F448 /* ActionResult.swift */; };
 		AF9B768B692236362C2F52AC /* CustomIconManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80E2BC8A01E00E844CE34144 /* CustomIconManager.swift */; };
+		AFAFB8389632B97E97F34D58 /* WindowConfigurator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 472E7385DBCBD7C2443AC1B9 /* WindowConfigurator.swift */; };
 		B3E4DEAEC23EBE3A801E2964 /* CalculateActionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D719D2B6B3F32C056AED329D /* CalculateActionTests.swift */; };
 		B441B121753496237B98A8CB /* MenuActionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E843649F2E5528CE1F44259F /* MenuActionTests.swift */; };
 		B493AA1195F09951711EA1AE /* DebugLogStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 643250CF0FF406A8F5AC587E /* DebugLogStore.swift */; };
@@ -504,6 +506,7 @@
 		459B709840D3A9F1DFD49761 /* ToastPanel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ToastPanel.swift; sourceTree = "<group>"; };
 		45EDC48BB789417097D3B8A4 /* ExtensionUpdatePlanner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExtensionUpdatePlanner.swift; sourceTree = "<group>"; };
 		46F35FE3A8EA5549603E53B4 /* PermissionRecoveryView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PermissionRecoveryView.swift; sourceTree = "<group>"; };
+		472E7385DBCBD7C2443AC1B9 /* WindowConfigurator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WindowConfigurator.swift; sourceTree = "<group>"; };
 		47E51843D196C894F4B98910 /* SettingsStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsStoreTests.swift; sourceTree = "<group>"; };
 		493FF0699565029ED4F5E07A /* ActionSearchKeywords.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActionSearchKeywords.swift; sourceTree = "<group>"; };
 		4953987A3DEEA1E3E220311D /* PaletteRowShortcuts.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaletteRowShortcuts.swift; sourceTree = "<group>"; };
@@ -564,6 +567,7 @@
 		7B1CAECD556B1DF6245E0DED /* PasteAvailability.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PasteAvailability.swift; sourceTree = "<group>"; };
 		7BBCBD7E4F5F0D1015061E8D /* ActionCoordinatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActionCoordinatorTests.swift; sourceTree = "<group>"; };
 		7F0E732D2DCAF53EDEB6653D /* LocalizedStringValue.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocalizedStringValue.swift; sourceTree = "<group>"; };
+		7F26242B60606C743CBBA169 /* PreferencesToolbar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PreferencesToolbar.swift; sourceTree = "<group>"; };
 		7F86844851929D68343D9230 /* PopupPreview.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PopupPreview.swift; sourceTree = "<group>"; };
 		7FF20DB76BDB47222A26CBAC /* AIProviderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AIProviderTests.swift; sourceTree = "<group>"; };
 		8018BA605653ACD93A6A6BF6 /* SelectionGatePolicy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SelectionGatePolicy.swift; sourceTree = "<group>"; };
@@ -1015,6 +1019,7 @@
 			children = (
 				14D700402A242D8DEE0F3686 /* LiquidGlass.swift */,
 				38966F7112271EC9D176FA15 /* NativeSearchField.swift */,
+				472E7385DBCBD7C2443AC1B9 /* WindowConfigurator.swift */,
 			);
 			path = Design;
 			sourceTree = "<group>";
@@ -1207,6 +1212,7 @@
 				171CC0405F553E737A32C250 /* ExtensionsStoreView.swift */,
 				E7F63399A1C7D78E9E1667DF /* GeneralTabView.swift */,
 				0AC7C388035A937859369C48 /* IconPickerView.swift */,
+				7F26242B60606C743CBBA169 /* PreferencesToolbar.swift */,
 				F660BE562891C148ECA1E083 /* PreferencesView.swift */,
 				CE94C5DF6F55C48818CE55EC /* SettingsRowLabel.swift */,
 			);
@@ -1881,6 +1887,7 @@
 				52BEF3963FD28FB56E10A235 /* PopupThemeSelector.swift in Sources */,
 				0ABD4746A74B3657C3550DCE /* PopupView.swift in Sources */,
 				7E44D09AC94810898D6E5D1D /* PopupWindowController.swift in Sources */,
+				23079CE2CEE3E41027A6413A /* PreferencesToolbar.swift in Sources */,
 				FAE8B480FE55D8C3ACC20A29 /* PreferencesView.swift in Sources */,
 				EF3BE1F10E35A392B5F686F8 /* RecommendedExtensionsView.swift in Sources */,
 				7AC316FB783A7E96C716DE2F /* RemoteExtensionInstaller.swift in Sources */,
@@ -1909,6 +1916,7 @@
 				C4745A31020CAE1A7DDD424F /* TooltipPlacement.swift in Sources */,
 				07AD3DB565E57EDADBBC73EA /* TooltipPresenter.swift in Sources */,
 				94B3C1F1B49D3696A9059021 /* UnifiedIconProvider.swift in Sources */,
+				AFAFB8389632B97E97F34D58 /* WindowConfigurator.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/OpenClip.xcodeproj/project.pbxproj
+++ b/OpenClip.xcodeproj/project.pbxproj
@@ -50,6 +50,7 @@
 		2140964D90DA799B312DED49 /* GoldenExtensionPlatformTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0A5C800BE48C74A05B33DDA /* GoldenExtensionPlatformTests.swift */; };
 		220A6F48497F91FA31273426 /* CalendarActionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D1221805EFDD065CA543A00 /* CalendarActionTests.swift */; };
 		22D5F64A56A4688BE5272FE2 /* ActionRowControlsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DF89ACBE81E50696C1CCF2F3 /* ActionRowControlsTests.swift */; };
+		2320A4B4D04528CD6D99F9BF /* NativeSearchField.swift in Sources */ = {isa = PBXBuildFile; fileRef = 38966F7112271EC9D176FA15 /* NativeSearchField.swift */; };
 		24ABC449CE3810541D898C48 /* PermissionManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4BB115DCDCB4749A1DDB8222 /* PermissionManager.swift */; };
 		2625F61BBDA95D300AA8BBC4 /* LocalizedStringValue.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7F0E732D2DCAF53EDEB6653D /* LocalizedStringValue.swift */; };
 		264760E3D025E183E831C7C0 /* ActionVisibility.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5CA2E8ED39FAF909162A8023 /* ActionVisibility.swift */; };
@@ -328,6 +329,7 @@
 		E6EB3B0A91D5B10B60A5734C /* SemanticVersion.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88A1B37766CE7914EED1A827 /* SemanticVersion.swift */; };
 		E6F19F69F4A7600DE3C664AA /* CustomIconManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5039B99D3EACB1E2BF272D2 /* CustomIconManagerTests.swift */; };
 		E7C069E73B09FDA02830A7CA /* PopupInlineUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2EB6113A88986EE1C7FF3FB7 /* PopupInlineUITests.swift */; };
+		E75472EBB90E82A98D3C787E /* SettingsRowLabel.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE94C5DF6F55C48818CE55EC /* SettingsRowLabel.swift */; };
 		E86C2D7468C5053D116BE999 /* ActionCustomizationManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7683646692AA6067DA5AA86D /* ActionCustomizationManager.swift */; };
 		E86F203A8AF88E30A78C7709 /* SettingKey+ResultCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 79D64C96408A09CB4C053E1E /* SettingKey+ResultCard.swift */; };
 		E94E8E1A91416CA1E54B9BFD /* MultiActionExtensionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8898F579917FE375DDEE7778 /* MultiActionExtensionTests.swift */; };
@@ -482,6 +484,7 @@
 		3675FDD7BC06CF3B3CBDA003 /* DynamicActionConfigView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DynamicActionConfigView.swift; sourceTree = "<group>"; };
 		37C5B4BFF2D115C64916D6E9 /* CustomActionManifestWriter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomActionManifestWriter.swift; sourceTree = "<group>"; };
 		382F45A3CA8BFDC01E3132BD /* LogCoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LogCoreTests.swift; sourceTree = "<group>"; };
+		38966F7112271EC9D176FA15 /* NativeSearchField.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NativeSearchField.swift; sourceTree = "<group>"; };
 		38D9A91D8E78B77B35D10754 /* Core.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Core.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		38E0B09A0FCBBCF4C67A0FFF /* AppleIntelligenceProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppleIntelligenceProvider.swift; sourceTree = "<group>"; };
 		3A55EA02DDDA4E6CD7B599D1 /* AIActionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AIActionTests.swift; sourceTree = "<group>"; };
@@ -683,6 +686,7 @@
 		CC5159546A774B9BA999BA54 /* DebugLogBuffer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DebugLogBuffer.swift; sourceTree = "<group>"; };
 		CD6C339B374DBE3884DA21E9 /* UnifiedIconProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UnifiedIconProvider.swift; sourceTree = "<group>"; };
 		CE52A2746613B843A8CD5AB5 /* ActionUsageStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActionUsageStoreTests.swift; sourceTree = "<group>"; };
+		CE94C5DF6F55C48818CE55EC /* SettingsRowLabel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsRowLabel.swift; sourceTree = "<group>"; };
 		CEE41531ACE74639DE1C5CB4 /* RemoteExtensionInstaller.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteExtensionInstaller.swift; sourceTree = "<group>"; };
 		CFBBB348DDDFA3F5AB048540 /* ActionIconResolveTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActionIconResolveTests.swift; sourceTree = "<group>"; };
 		D0F292704F06603C30BB2C77 /* DebugLogCommandTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DebugLogCommandTests.swift; sourceTree = "<group>"; };
@@ -1010,6 +1014,7 @@
 			isa = PBXGroup;
 			children = (
 				14D700402A242D8DEE0F3686 /* LiquidGlass.swift */,
+				38966F7112271EC9D176FA15 /* NativeSearchField.swift */,
 			);
 			path = Design;
 			sourceTree = "<group>";
@@ -1203,6 +1208,7 @@
 				E7F63399A1C7D78E9E1667DF /* GeneralTabView.swift */,
 				0AC7C388035A937859369C48 /* IconPickerView.swift */,
 				F660BE562891C148ECA1E083 /* PreferencesView.swift */,
+				CE94C5DF6F55C48818CE55EC /* SettingsRowLabel.swift */,
 			);
 			path = Preferences;
 			sourceTree = "<group>";
@@ -1841,6 +1847,7 @@
 				FAE6A04356B9A3C6C10F7274 /* LogExporter.swift in Sources */,
 				09A58930CFE1B6C771AAF8D4 /* MacSelectionMonitor.swift in Sources */,
 				468FD2B168D9A77D579DFBF1 /* NamedServiceAction.swift in Sources */,
+				2320A4B4D04528CD6D99F9BF /* NativeSearchField.swift in Sources */,
 				785CC3424C3E3086FBD4CDF3 /* Notification.Name+OpenClip.swift in Sources */,
 				F9BF36325EE43D2E470B7019 /* OllamaProvider.swift in Sources */,
 				3CFA6606D2D7ADE239AC70D8 /* OnboardingView.swift in Sources */,
@@ -1888,6 +1895,7 @@
 				F3605465C595AC6C4AD817D6 /* SettingKey+MenuBar.swift in Sources */,
 				E86F203A8AF88E30A78C7709 /* SettingKey+ResultCard.swift in Sources */,
 				66D0BC9F0103DA6CC8BC7EF6 /* SettingKey+SearchPalette.swift in Sources */,
+				E75472EBB90E82A98D3C787E /* SettingsRowLabel.swift in Sources */,
 				E6C58D0747EA41DECA6FFFA2 /* ShortcutAction.swift in Sources */,
 				4C5773E0C53E2A28F2664CD5 /* StatusBarController.swift in Sources */,
 				1A9BDA5FEA591677DF2852AC /* SubBarPanel.swift in Sources */,

--- a/OpenClip.xcodeproj/project.pbxproj
+++ b/OpenClip.xcodeproj/project.pbxproj
@@ -330,8 +330,8 @@
 		E6C58D0747EA41DECA6FFFA2 /* ShortcutAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = C612A5C65039CA80623072E4 /* ShortcutAction.swift */; };
 		E6EB3B0A91D5B10B60A5734C /* SemanticVersion.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88A1B37766CE7914EED1A827 /* SemanticVersion.swift */; };
 		E6F19F69F4A7600DE3C664AA /* CustomIconManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5039B99D3EACB1E2BF272D2 /* CustomIconManagerTests.swift */; };
-		E7C069E73B09FDA02830A7CA /* PopupInlineUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2EB6113A88986EE1C7FF3FB7 /* PopupInlineUITests.swift */; };
 		E75472EBB90E82A98D3C787E /* SettingsRowLabel.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE94C5DF6F55C48818CE55EC /* SettingsRowLabel.swift */; };
+		E7C069E73B09FDA02830A7CA /* PopupInlineUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2EB6113A88986EE1C7FF3FB7 /* PopupInlineUITests.swift */; };
 		E86C2D7468C5053D116BE999 /* ActionCustomizationManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7683646692AA6067DA5AA86D /* ActionCustomizationManager.swift */; };
 		E86F203A8AF88E30A78C7709 /* SettingKey+ResultCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 79D64C96408A09CB4C053E1E /* SettingKey+ResultCard.swift */; };
 		E94E8E1A91416CA1E54B9BFD /* MultiActionExtensionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8898F579917FE375DDEE7778 /* MultiActionExtensionTests.swift */; };

--- a/Sources/OpenClip/OpenClipApp.swift
+++ b/Sources/OpenClip/OpenClipApp.swift
@@ -15,8 +15,10 @@ struct OpenClipApp: App {
         // correctly. The Dock icon is suppressed by calling
         // NSApp.setActivationPolicy(.accessory) in AppDelegate.applicationDidFinishLaunching,
         // which is the Apple-documented approach for agent apps that need a settings window.
-        // hiddenTitleBar makes the glass sidebar extend to the top of the window so the
-        // traffic lights sit directly on the Liquid Glass surface instead of an opaque strip.
+        // hiddenTitleBar is the SwiftUI spelling of fullSizeContentView plus a
+        // transparent title bar, which is what lets the sidebar run full height with
+        // the traffic lights sitting on it (see StatusBarController.showPreferences,
+        // which configures the same thing on the window it opens).
         Settings {
             PreferencesView()
         }

--- a/Sources/OpenClip/Resources/Localizable.xcstrings
+++ b/Sources/OpenClip/Resources/Localizable.xcstrings
@@ -1,6 +1,62 @@
 {
   "sourceLanguage": "en",
   "strings": {
+    "%@ download": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ 次下载"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ 次下載"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ téléchargement"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ ダウンロード"
+          }
+        }
+      }
+    },
+    "%@ downloads": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ 次下载"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ 次下載"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ téléchargements"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ ダウンロード"
+          }
+        }
+      }
+    },
     "%lld actions will be grouped.": {
       "localizations": {
         "zh-Hans": {

--- a/Sources/OpenClip/StatusBarController.swift
+++ b/Sources/OpenClip/StatusBarController.swift
@@ -630,6 +630,7 @@ class StatusBarController: NSObject, NSMenuDelegate {
         // Empty on purpose: the pane's name is a toolbar item, and a window title
         // would be drawn beside it (see PreferencesToolbar).
         window.title = ""
+        window.setAccessibilityTitle(tab.windowTitle)
         window.setContentSize(NSSize(width: 820, height: 640))
         // Both, not just contentMinSize: the hosting view publishes no minimum of
         // its own (sizingOptions is empty), and a window dragged narrower than the

--- a/Sources/OpenClip/StatusBarController.swift
+++ b/Sources/OpenClip/StatusBarController.swift
@@ -627,8 +627,9 @@ class StatusBarController: NSObject, NSMenuDelegate {
         // to resize the window around whichever pane had just appeared.
         controller.sizingOptions = [.minSize]
         let window = NSWindow(contentViewController: controller)
-        // Title tracks the selected pane; the toolbar controller keeps it current.
-        window.title = tab.windowTitle
+        // Empty on purpose: the pane's name is a toolbar item, and a window title
+        // would be drawn beside it (see PreferencesToolbar).
+        window.title = ""
         window.setContentSize(NSSize(width: 820, height: 640))
         // Both, not just contentMinSize: the hosting view publishes no minimum of
         // its own (sizingOptions is empty), and a window dragged narrower than the
@@ -640,15 +641,20 @@ class StatusBarController: NSObject, NSMenuDelegate {
         ).size
         // Full-height sidebar, the way every stock sidebar app (System Settings,
         // Mail, Finder) is put together: `fullSizeContentView` hands the content
-        // view the whole window, and a transparent title bar lets the sidebar's
-        // material run up behind the traffic lights instead of the sidebar
-        // starting below an opaque strip. AppKit gives the sidebar split item
-        // full-height layout on its own once the style mask asks for it
+        // view the whole window. AppKit gives the sidebar split item full-height
+        // layout on its own once the style mask asks for it
         // (NSSplitViewItem.allowsFullHeightLayout defaults to true), and it insets
         // the sidebar's own content below the traffic lights — nothing here has to
         // reserve that space by hand.
+        //
+        // `titlebarAppearsTransparent` is deliberately left alone: it drops the
+        // title bar's backdrop across the whole window, and then anything the
+        // detail pane scrolls runs straight through the toolbar. The Store hid
+        // that behind the glass of its own toolbar items; App Rules, with only a
+        // pane name and one button up there, showed its rows sliding through the
+        // gaps. Off, the sidebar still runs full height — the split view item,
+        // not the flag, is what keeps that half of the title bar clear.
         window.styleMask = [.titled, .closable, .miniaturizable, .resizable, .fullSizeContentView]
-        window.titlebarAppearsTransparent = true
         // The toolbar is built once, in AppKit, and lives for the window's whole
         // life (see PreferencesToolbar.swift). A toolbar that comes and goes makes
         // the title bar re-measure, and that is what kept dropping the traffic
@@ -656,6 +662,7 @@ class StatusBarController: NSObject, NSMenuDelegate {
         window.toolbar = toolbarController.makeToolbar()
         toolbarController.window = window
         window.toolbarStyle = .unified
+        window.titleVisibility = .hidden
         // Left at .automatic on purpose: it defers to NSSplitViewItem, which draws
         // the title bar separator over the detail pane only, so the sidebar keeps
         // one unbroken surface from the traffic lights down.

--- a/Sources/OpenClip/StatusBarController.swift
+++ b/Sources/OpenClip/StatusBarController.swift
@@ -16,6 +16,7 @@ class StatusBarController: NSObject, NSMenuDelegate {
     private let notificationCenter: NotificationCenter
     private var statusItem: NSStatusItem?
     private var preferencesWindow: NSWindow?
+    private var preferencesToolbarController: PreferencesToolbarController?
     private var rootMenu: NSMenu?
     internal var resumeItem: NSMenuItem?
     internal var toggleEnabledItem: NSMenuItem?
@@ -606,18 +607,37 @@ class StatusBarController: NSObject, NSMenuDelegate {
             NSApp.activate(ignoringOtherApps: true)
             return
         }
-        let controller = NSHostingController(rootView: PreferencesView(initialTab: tab))
+        let toolbarModel = PreferencesToolbarModel()
+        toolbarModel.tab = tab
+        let toolbarController = PreferencesToolbarController(model: toolbarModel)
+        preferencesToolbarController = toolbarController
+        let controller = NSHostingController(
+            rootView: PreferencesView(initialTab: tab, toolbarModel: toolbarModel)
+        )
         // The window owns its size, not the SwiftUI content. With the default
         // sizing options the hosting controller republishes the current pane's
         // fitting size as the window's preferred content size, so every tab
         // switch resized the window around whatever pane had just appeared —
         // panes that fill (Actions, Store, App Rules) held it open while the
         // shorter ones (General, Appearance, About) collapsed it.
-        controller.sizingOptions = []
+        // .minSize only: SwiftUI publishes the content's minimum as the window's
+        // contentMinSize, which is the one number the window can't work out on
+        // its own once NavigationSplitView starts collapsing the sidebar. It
+        // deliberately does not include .preferredContentSize — that is what used
+        // to resize the window around whichever pane had just appeared.
+        controller.sizingOptions = [.minSize]
         let window = NSWindow(contentViewController: controller)
-        window.title = String(localized: "OpenClip Preferences")
+        // Title tracks the selected pane; the toolbar controller keeps it current.
+        window.title = tab.windowTitle
         window.setContentSize(NSSize(width: 820, height: 640))
-        window.contentMinSize = NSSize(width: 780, height: 520)
+        // Both, not just contentMinSize: the hosting view publishes no minimum of
+        // its own (sizingOptions is empty), and a window dragged narrower than the
+        // sidebar plus the detail column leaves the split view with no solution.
+        let minimumContent = NSSize(width: 760, height: 480)
+        window.contentMinSize = minimumContent
+        window.minSize = window.frameRect(
+            forContentRect: NSRect(origin: .zero, size: minimumContent)
+        ).size
         // Full-height sidebar, the way every stock sidebar app (System Settings,
         // Mail, Finder) is put together: `fullSizeContentView` hands the content
         // view the whole window, and a transparent title bar lets the sidebar's
@@ -629,15 +649,12 @@ class StatusBarController: NSObject, NSMenuDelegate {
         // reserve that space by hand.
         window.styleMask = [.titled, .closable, .miniaturizable, .resizable, .fullSizeContentView]
         window.titlebarAppearsTransparent = true
-        // A toolbar has to exist for every pane, not just the ones with buttons in
-        // it. AppKit only gives the sidebar its full-height layout in a window that
-        // has a toolbar, so on the panes that published no toolbar items the
-        // sidebar dropped back to a floating inset panel and left the traffic
-        // lights stranded above it. This empty toolbar is the floor; SwiftUI
-        // replaces it with its own on the panes that do have items.
-        let toolbar = NSToolbar(identifier: "OpenClipPreferencesToolbar")
-        toolbar.showsBaselineSeparator = false
-        window.toolbar = toolbar
+        // The toolbar is built once, in AppKit, and lives for the window's whole
+        // life (see PreferencesToolbar.swift). A toolbar that comes and goes makes
+        // the title bar re-measure, and that is what kept dropping the traffic
+        // lights out of the full-height sidebar when the pane changed.
+        window.toolbar = toolbarController.makeToolbar()
+        toolbarController.window = window
         window.toolbarStyle = .unified
         // Left at .automatic on purpose: it defers to NSSplitViewItem, which draws
         // the title bar separator over the detail pane only, so the sidebar keeps

--- a/Sources/OpenClip/StatusBarController.swift
+++ b/Sources/OpenClip/StatusBarController.swift
@@ -607,12 +607,42 @@ class StatusBarController: NSObject, NSMenuDelegate {
             return
         }
         let controller = NSHostingController(rootView: PreferencesView(initialTab: tab))
+        // The window owns its size, not the SwiftUI content. With the default
+        // sizing options the hosting controller republishes the current pane's
+        // fitting size as the window's preferred content size, so every tab
+        // switch resized the window around whatever pane had just appeared —
+        // panes that fill (Actions, Store, App Rules) held it open while the
+        // shorter ones (General, Appearance, About) collapsed it.
+        controller.sizingOptions = []
         let window = NSWindow(contentViewController: controller)
         window.title = String(localized: "OpenClip Preferences")
-        window.setContentSize(NSSize(width: 760, height: 620))
+        window.setContentSize(NSSize(width: 820, height: 640))
+        window.contentMinSize = NSSize(width: 780, height: 520)
+        // Full-height sidebar, the way every stock sidebar app (System Settings,
+        // Mail, Finder) is put together: `fullSizeContentView` hands the content
+        // view the whole window, and a transparent title bar lets the sidebar's
+        // material run up behind the traffic lights instead of the sidebar
+        // starting below an opaque strip. AppKit gives the sidebar split item
+        // full-height layout on its own once the style mask asks for it
+        // (NSSplitViewItem.allowsFullHeightLayout defaults to true), and it insets
+        // the sidebar's own content below the traffic lights — nothing here has to
+        // reserve that space by hand.
         window.styleMask = [.titled, .closable, .miniaturizable, .resizable, .fullSizeContentView]
         window.titlebarAppearsTransparent = true
-        window.titleVisibility = .hidden
+        // A toolbar has to exist for every pane, not just the ones with buttons in
+        // it. AppKit only gives the sidebar its full-height layout in a window that
+        // has a toolbar, so on the panes that published no toolbar items the
+        // sidebar dropped back to a floating inset panel and left the traffic
+        // lights stranded above it. This empty toolbar is the floor; SwiftUI
+        // replaces it with its own on the panes that do have items.
+        let toolbar = NSToolbar(identifier: "OpenClipPreferencesToolbar")
+        toolbar.showsBaselineSeparator = false
+        window.toolbar = toolbar
+        window.toolbarStyle = .unified
+        // Left at .automatic on purpose: it defers to NSSplitViewItem, which draws
+        // the title bar separator over the detail pane only, so the sidebar keeps
+        // one unbroken surface from the traffic lights down.
+        window.titlebarSeparatorStyle = .automatic
         // Closing the window must not deallocate it while `preferencesWindow`
         // still points at it — the reuse check above reads the window back
         // after a close, and the default (release on close) makes that a read

--- a/Sources/OpenClip/UI/Design/NativeSearchField.swift
+++ b/Sources/OpenClip/UI/Design/NativeSearchField.swift
@@ -1,0 +1,62 @@
+// NativeSearchField.swift
+// OpenClip
+//
+// A real `NSSearchField` for the places that need a search box inline in the
+// content rather than in the toolbar (the toolbar ones use `.searchable`).
+// Wrapping AppKit's control keeps the magnifier, the recents menu, the cancel
+// button, the focus ring and the vibrancy behaviour the system already ships.
+import AppKit
+import SwiftUI
+
+struct NativeSearchField: NSViewRepresentable {
+    @Binding var text: String
+    var placeholder: String
+    var controlSize: NSControl.ControlSize = .regular
+    /// Called when the user presses Return; searches that are too expensive to
+    /// run per keystroke (the Iconify catalog) hang off this instead of `text`.
+    var onSubmit: ((String) -> Void)?
+
+    func makeNSView(context: Context) -> NSSearchField {
+        let field = NSSearchField()
+        field.placeholderString = placeholder
+        field.controlSize = controlSize
+        field.font = .systemFont(ofSize: NSFont.systemFontSize(for: controlSize))
+        field.delegate = context.coordinator
+        field.target = context.coordinator
+        field.action = #selector(Coordinator.searchFieldDidSubmit(_:))
+        field.sendsWholeSearchString = onSubmit != nil
+        field.sendsSearchStringImmediately = onSubmit == nil
+        return field
+    }
+
+    func updateNSView(_ field: NSSearchField, context: Context) {
+        context.coordinator.parent = self
+        field.placeholderString = placeholder
+        if field.stringValue != text {
+            field.stringValue = text
+        }
+    }
+
+    func makeCoordinator() -> Coordinator {
+        Coordinator(parent: self)
+    }
+
+    @MainActor
+    final class Coordinator: NSObject, NSSearchFieldDelegate {
+        var parent: NativeSearchField
+
+        init(parent: NativeSearchField) {
+            self.parent = parent
+        }
+
+        func controlTextDidChange(_ notification: Notification) {
+            guard let field = notification.object as? NSSearchField else { return }
+            parent.text = field.stringValue
+        }
+
+        @objc func searchFieldDidSubmit(_ sender: NSSearchField) {
+            parent.text = sender.stringValue
+            parent.onSubmit?(sender.stringValue)
+        }
+    }
+}

--- a/Sources/OpenClip/UI/Design/WindowConfigurator.swift
+++ b/Sources/OpenClip/UI/Design/WindowConfigurator.swift
@@ -1,0 +1,62 @@
+// WindowConfigurator.swift
+// OpenClip
+//
+// Reaches the NSWindow hosting a SwiftUI view. Some window properties have no
+// SwiftUI spelling — a hard minimum size among them — and a view can be hosted
+// by more than one window (the Settings scene and the window StatusBarController
+// opens both show the preferences), so the settings belong with the view rather
+// than with one of the call sites.
+import AppKit
+import SwiftUI
+
+struct WindowConfigurator: NSViewRepresentable {
+    let configure: (NSWindow) -> Void
+
+    func makeNSView(context: Context) -> NSView {
+        let view = NSView(frame: .zero)
+        apply(from: view)
+        return view
+    }
+
+    func updateNSView(_ nsView: NSView, context: Context) {
+        // Re-applied on update: the window can be attached after the first
+        // layout, and SwiftUI resets some of these when the scene rebuilds.
+        apply(from: nsView)
+    }
+
+    private func apply(from view: NSView) {
+        DispatchQueue.main.async {
+            guard let window = view.window else { return }
+            configure(window)
+        }
+    }
+}
+
+extension View {
+    /// Clamps the hosting window to a minimum content size.
+    func minimumWindowContentSize(width: CGFloat, height: CGFloat) -> some View {
+        background(
+            WindowConfigurator { window in
+                let content = NSSize(width: width, height: height)
+                // Re-asserted every time rather than skipped when it already
+                // matches: SwiftUI rewrites these as the split view's layout
+                // changes, and it does not always rewrite both of them.
+                window.contentMinSize = content
+                window.minSize = window.frameRect(
+                    forContentRect: NSRect(origin: .zero, size: content)
+                ).size
+                // A window already smaller than the new floor keeps its size
+                // until something nudges it, so bring it up now.
+                let frame = window.frame
+                if frame.width < window.minSize.width || frame.height < window.minSize.height {
+                    window.setContentSize(
+                        NSSize(
+                            width: max(window.contentLayoutRect.width, width),
+                            height: max(window.contentLayoutRect.height, height)
+                        )
+                    )
+                }
+            }
+        )
+    }
+}

--- a/Sources/OpenClip/UI/Popup/PopupThemeSelector.swift
+++ b/Sources/OpenClip/UI/Popup/PopupThemeSelector.swift
@@ -112,49 +112,41 @@ struct PopupThemeSelector: View {
     var body: some View {
         Form {
             Section {
-                Picker(selection: themeSelection) {
-                    ForEach(themeOptions) { option in
-                        Text(LocalizedStringKey(option.label)).tag(option.value)
-                    }
-                } label: {
-                    SettingsRowLabel(title: "Popup Theme", systemImage: "paintbrush.fill")
+                SettingsRow(title: "Popup Theme", systemImage: "paintbrush.fill") {
+                    segmentedPicker(
+                        selection: themeSelection,
+                        options: themeOptions,
+                        label: "Popup Theme",
+                        width: 150
+                    )
                 }
-                .pickerStyle(.segmented)
 
-                Picker(selection: $themeColor) {
-                    ForEach(appearanceOptions) { option in
-                        Image(systemName: option.icon)
-                            .help(LocalizedStringKey(option.label))
-                            .accessibilityLabel(LocalizedStringKey(option.label))
-                            .tag(option.value)
-                    }
-                } label: {
-                    SettingsRowLabel(title: "Color Mode", systemImage: "circle.lefthalf.filled")
+                SettingsRow(title: "Color Mode", systemImage: "circle.lefthalf.filled") {
+                    iconPicker(
+                        selection: $themeColor,
+                        options: appearanceOptions,
+                        label: "Color Mode"
+                    )
                 }
-                .pickerStyle(.segmented)
 
-                Picker(selection: $popupAlignment) {
-                    ForEach(alignmentOptions) { option in
-                        Image(systemName: option.icon)
-                            .help(LocalizedStringKey(option.label))
-                            .accessibilityLabel(LocalizedStringKey(option.label))
-                            .tag(option.value)
-                    }
-                } label: {
-                    SettingsRowLabel(title: "Horizontal Position", systemImage: "text.alignleft")
+                SettingsRow(title: "Horizontal Position", systemImage: "text.alignleft") {
+                    iconPicker(
+                        selection: $popupAlignment,
+                        options: alignmentOptions,
+                        label: "Horizontal Position"
+                    )
                 }
-                .pickerStyle(.segmented)
 
-                Picker(selection: $popupVerticalPosition) {
-                    ForEach(verticalPositionOptions) { option in
-                        Text(LocalizedStringKey(option.label)).tag(option.value)
-                    }
-                } label: {
-                    SettingsRowLabel(title: "Vertical Position", systemImage: "arrow.up.and.down")
+                SettingsRow(title: "Vertical Position", systemImage: "arrow.up.and.down") {
+                    segmentedPicker(
+                        selection: $popupVerticalPosition,
+                        options: verticalPositionOptions,
+                        label: "Vertical Position",
+                        width: 200
+                    )
                 }
-                .pickerStyle(.segmented)
 
-                LabeledContent {
+                SettingsRow(title: "Popup Scale", systemImage: "arrow.up.left.and.arrow.down.right") {
                     stepSlider(
                         value: Binding(
                             get: { popupScale },
@@ -162,14 +154,9 @@ struct PopupThemeSelector: View {
                         ),
                         accessibilityLabel: "Popup Scale"
                     )
-                } label: {
-                    SettingsRowLabel(
-                        title: "Popup Scale",
-                        systemImage: "arrow.up.left.and.arrow.down.right"
-                    )
                 }
 
-                LabeledContent {
+                SettingsRow(title: "Popup Width", systemImage: "arrow.left.and.right") {
                     stepSlider(
                         value: Binding(
                             get: { barWidthLevel },
@@ -177,8 +164,6 @@ struct PopupThemeSelector: View {
                         ),
                         accessibilityLabel: "Popup Width"
                     )
-                } label: {
-                    SettingsRowLabel(title: "Popup Width", systemImage: "arrow.left.and.right")
                 }
             } footer: {
                 HStack {
@@ -192,6 +177,42 @@ struct PopupThemeSelector: View {
             }
         }
         .formStyle(.grouped)
+    }
+
+    private func segmentedPicker(
+        selection: Binding<String>,
+        options: [AppearanceOption],
+        label: LocalizedStringKey,
+        width: CGFloat
+    ) -> some View {
+        Picker("", selection: selection) {
+            ForEach(options) { option in
+                Text(LocalizedStringKey(option.label)).tag(option.value)
+            }
+        }
+        .labelsHidden()
+        .pickerStyle(.segmented)
+        .frame(width: width)
+        .accessibilityLabel(label)
+    }
+
+    private func iconPicker(
+        selection: Binding<String>,
+        options: [AppearanceOption],
+        label: LocalizedStringKey
+    ) -> some View {
+        Picker("", selection: selection) {
+            ForEach(options) { option in
+                Image(systemName: option.icon)
+                    .help(LocalizedStringKey(option.label))
+                    .accessibilityLabel(LocalizedStringKey(option.label))
+                    .tag(option.value)
+            }
+        }
+        .labelsHidden()
+        .pickerStyle(.segmented)
+        .frame(width: 120)
+        .accessibilityLabel(label)
     }
 
     /// Both size rows are the same 1-5 slider with its value parked at the end.

--- a/Sources/OpenClip/UI/Popup/PopupThemeSelector.swift
+++ b/Sources/OpenClip/UI/Popup/PopupThemeSelector.swift
@@ -100,269 +100,122 @@ struct PopupThemeSelector: View {
         popupVerticalPosition = SettingKey.popupVerticalPosition.defaultValue
     }
 
+    /// The stored value carries legacy category names; the picker only ever
+    /// deals in the two current ones.
+    private var themeSelection: Binding<String> {
+        Binding(
+            get: { isGlassOn ? "glass" : "classic" },
+            set: { theme = $0 }
+        )
+    }
+
     var body: some View {
         Form {
             Section {
-                themeRow
-                modeRow
-                alignmentRow
-                verticalPositionRow
-                sizeRow
-                barWidthRow
+                Picker(selection: themeSelection) {
+                    ForEach(themeOptions) { option in
+                        Text(LocalizedStringKey(option.label)).tag(option.value)
+                    }
+                } label: {
+                    SettingsRowLabel(title: "Popup Theme", systemImage: "paintbrush.fill")
+                }
+                .pickerStyle(.segmented)
+
+                Picker(selection: $themeColor) {
+                    ForEach(appearanceOptions) { option in
+                        Image(systemName: option.icon)
+                            .help(LocalizedStringKey(option.label))
+                            .accessibilityLabel(LocalizedStringKey(option.label))
+                            .tag(option.value)
+                    }
+                } label: {
+                    SettingsRowLabel(title: "Color Mode", systemImage: "circle.lefthalf.filled")
+                }
+                .pickerStyle(.segmented)
+
+                Picker(selection: $popupAlignment) {
+                    ForEach(alignmentOptions) { option in
+                        Image(systemName: option.icon)
+                            .help(LocalizedStringKey(option.label))
+                            .accessibilityLabel(LocalizedStringKey(option.label))
+                            .tag(option.value)
+                    }
+                } label: {
+                    SettingsRowLabel(title: "Horizontal Position", systemImage: "text.alignleft")
+                }
+                .pickerStyle(.segmented)
+
+                Picker(selection: $popupVerticalPosition) {
+                    ForEach(verticalPositionOptions) { option in
+                        Text(LocalizedStringKey(option.label)).tag(option.value)
+                    }
+                } label: {
+                    SettingsRowLabel(title: "Vertical Position", systemImage: "arrow.up.and.down")
+                }
+                .pickerStyle(.segmented)
+
+                LabeledContent {
+                    stepSlider(
+                        value: Binding(
+                            get: { popupScale },
+                            set: { popupScale = $0 }
+                        ),
+                        accessibilityLabel: "Popup Scale"
+                    )
+                } label: {
+                    SettingsRowLabel(
+                        title: "Popup Scale",
+                        systemImage: "arrow.up.left.and.arrow.down.right"
+                    )
+                }
+
+                LabeledContent {
+                    stepSlider(
+                        value: Binding(
+                            get: { barWidthLevel },
+                            set: { barWidthLevel = $0 }
+                        ),
+                        accessibilityLabel: "Popup Width"
+                    )
+                } label: {
+                    SettingsRowLabel(title: "Popup Width", systemImage: "arrow.left.and.right")
+                }
             } footer: {
                 HStack {
                     Spacer()
                     Button("Reset to Defaults") {
                         resetToDefaults()
                     }
-                    .buttonStyle(.plain)
-                    .font(.caption)
-                    .foregroundColor(.accentColor)
                     .disabled(isAllDefault)
-                    .opacity(isAllDefault ? 0.4 : 1.0)
                 }
                 .padding(.top, 6)
             }
         }
         .formStyle(.grouped)
-        .scrollContentBackground(.hidden)
     }
 
-    private var themeRow: some View {
-        HStack(spacing: 12) {
-            rowTitle(icon: "paintbrush.fill", title: "Popup Theme")
-            Spacer()
-            labelSegments(
-                options: themeOptions,
-                isSelected: { isGlassOn ? $0.value == "glass" : $0.value == "classic" },
-                select: { theme = $0 }
-            )
-        }
-        .frame(minHeight: 24)
-        .padding(.vertical, 3)
-    }
-
-    private var modeRow: some View {
-        HStack(spacing: 12) {
-            rowTitle(icon: "circle.lefthalf.filled", title: "Color Mode")
-            Spacer()
-            iconTiles(
-                options: appearanceOptions,
-                isSelected: { activeAppearance == $0.value },
-                select: selectAppearance
-            )
-        }
-        .frame(minHeight: 24)
-        .padding(.vertical, 3)
-    }
-
-    private var alignmentRow: some View {
-        HStack(spacing: 12) {
-            rowTitle(icon: "text.alignleft", title: "Horizontal Position")
-            Spacer()
-            iconTiles(
-                options: alignmentOptions,
-                isSelected: { popupAlignment == $0.value },
-                select: { popupAlignment = $0 }
-            )
-        }
-        .frame(minHeight: 24)
-        .padding(.vertical, 3)
-    }
-
-    private var verticalPositionRow: some View {
-        HStack(spacing: 12) {
-            rowTitle(icon: "arrow.up.and.down", title: "Vertical Position")
-            Spacer()
-            labelSegments(
-                options: verticalPositionOptions,
-                segmentWidth: 44,
-                isSelected: { popupVerticalPosition == $0.value },
-                select: { popupVerticalPosition = $0 }
-            )
-        }
-        .frame(minHeight: 24)
-        .padding(.vertical, 3)
-    }
-
-    private var sizeRow: some View {
-        HStack(spacing: 12) {
-            rowTitle(
-                icon: "arrow.up.left.and.arrow.down.right",
-                title: "Popup Scale"
-            )
-            Spacer()
-            HStack(spacing: 8) {
-                Slider(
-                    value: Binding(
-                        get: { Double(popupScale) },
-                        set: { popupScale = max(1, min(5, Int(round($0)))) }
-                    ),
-                    in: 1...5,
-                    step: 1
-                )
-                .accessibilityLabel("Popup Scale")
-                .accessibilityValue("\(popupScale)")
-                .frame(width: 120)
-                Text("\(popupScale)")
-                    .font(.system(size: 12, weight: .medium, design: .monospaced))
-                    .foregroundColor(.secondary)
-                    .frame(width: 32, alignment: .trailing)
-            }
-        }
-        .frame(minHeight: 24)
-        .padding(.vertical, 3)
-    }
-
-    private var barWidthRow: some View {
-        HStack(spacing: 12) {
-            rowTitle(
-                icon: "arrow.left.and.right",
-                title: "Popup Width"
-            )
-            Spacer()
-            HStack(spacing: 8) {
-                Slider(
-                    value: Binding(
-                        get: { Double(barWidthLevel) },
-                        set: { barWidthLevel = max(1, min(5, Int(round($0)))) }
-                    ),
-                    in: 1...5,
-                    step: 1
-                )
-                .accessibilityLabel("Popup Width")
-                .accessibilityValue("\(barWidthLevel)")
-                .frame(width: 120)
-                Text("\(barWidthLevel)")
-                    .font(.system(size: 12, weight: .medium, design: .monospaced))
-                    .foregroundColor(.secondary)
-                    .frame(width: 32, alignment: .trailing)
-            }
-        }
-        .frame(minHeight: 24)
-        .padding(.vertical, 3)
-    }
-
-    private func rowTitle(icon: String, title: LocalizedStringKey) -> some View {
-        HStack(spacing: 12) {
-            Image(systemName: icon)
-                .font(.system(size: 15))
-                .foregroundColor(.accentColor)
-                .frame(width: 20, alignment: .center)
-            Text(title)
-                .font(.body)
-                .fontWeight(.medium)
-        }
-    }
-
-    /// Label-only segments for the Theme row.
-    private func labelSegments(
-        options: [AppearanceOption],
-        segmentWidth: CGFloat = 56,
-        isSelected: @escaping (AppearanceOption) -> Bool,
-        select: @escaping (String) -> Void
+    /// Both size rows are the same 1-5 slider with its value parked at the end.
+    private func stepSlider(
+        value: Binding<Int>,
+        accessibilityLabel: LocalizedStringKey
     ) -> some View {
-        HStack(spacing: 0) {
-            ForEach(options) { option in
-                if option.value != options[0].value {
-                    hairline(height: 12)
-                }
-                segmentButton(
-                    label: LocalizedStringKey(option.label),
-                    width: segmentWidth,
-                    isSelected: isSelected(option),
-                    action: { select(option.value) }
-                )
-            }
+        HStack(spacing: 8) {
+            Slider(
+                value: Binding(
+                    get: { Double(value.wrappedValue) },
+                    set: { value.wrappedValue = max(1, min(5, Int(round($0)))) }
+                ),
+                in: 1...5,
+                step: 1
+            )
+            .accessibilityLabel(accessibilityLabel)
+            .accessibilityValue("\(value.wrappedValue)")
+            .frame(width: 140)
+            Text("\(value.wrappedValue)")
+                .font(.callout)
+                .monospacedDigit()
+                .foregroundStyle(.secondary)
+                .frame(width: 16, alignment: .trailing)
         }
-        .padding(2)
-        .frame(height: trayHeight)
-        .background(segmentContainerBackground)
-        .overlay(segmentContainerBorder)
-    }
-
-    /// Icon-only segments for the Mode row matching the theme row size.
-    private func iconTiles(
-        options: [AppearanceOption],
-        isSelected: @escaping (AppearanceOption) -> Bool,
-        select: @escaping (String) -> Void
-    ) -> some View {
-        HStack(spacing: 0) {
-            ForEach(options) { option in
-                if option.value != options[0].value {
-                    hairline(height: 12)
-                }
-                tileButton(
-                    label: option.label,
-                    icon: option.icon,
-                    isSelected: isSelected(option),
-                    action: { select(option.value) }
-                )
-            }
-        }
-        .padding(2)
-        .frame(height: trayHeight)
-        .background(segmentContainerBackground)
-        .overlay(segmentContainerBorder)
-    }
-
-    private var segmentContainerBackground: some View {
-        RoundedRectangle(cornerRadius: 6, style: .continuous)
-            .fill(Color.primary.opacity(0.055))
-    }
-
-    private var segmentContainerBorder: some View {
-        RoundedRectangle(cornerRadius: 6, style: .continuous)
-            .stroke(Color.primary.opacity(0.08), lineWidth: 1)
-    }
-
-    /// Thin separator between the segments/tiles within a tray.
-    private func hairline(height: CGFloat = 14) -> some View {
-        Rectangle()
-            .fill(Color.primary.opacity(0.1))
-            .frame(width: 1, height: height)
-    }
-
-    private func segmentButton(
-        label: LocalizedStringKey,
-        width: CGFloat = 56,
-        isSelected: Bool,
-        action: @escaping () -> Void
-    ) -> some View {
-        Button(action: action) {
-            Text(label)
-                .font(.system(size: 11, weight: .medium))
-                .foregroundColor(isSelected ? .white : .primary)
-                .frame(width: width, height: trayContentHeight)
-                .padding(.horizontal, 4)
-                .contentShape(Rectangle())
-                .background(
-                    RoundedRectangle(cornerRadius: 4, style: .continuous)
-                        .fill(isSelected ? Color.accentColor : Color.clear)
-                )
-        }
-        .buttonStyle(.plain)
-    }
-
-    private func tileButton(
-        label: String,
-        icon: String,
-        isSelected: Bool,
-        action: @escaping () -> Void
-    ) -> some View {
-        Button(action: action) {
-            Image(systemName: icon)
-                .font(.system(size: 12, weight: .medium))
-                .foregroundColor(isSelected ? .white : .primary)
-                .frame(width: modeSegmentWidth, height: trayContentHeight)
-                .contentShape(Rectangle())
-                .help(LocalizedStringKey(label))
-                .accessibilityLabel(LocalizedStringKey(label))
-                .background(
-                    RoundedRectangle(cornerRadius: 4, style: .continuous)
-                        .fill(isSelected ? Color.accentColor : Color.clear)
-                )
-        }
-        .buttonStyle(.plain)
     }
 }

--- a/Sources/OpenClip/UI/Preferences/AboutTabView.swift
+++ b/Sources/OpenClip/UI/Preferences/AboutTabView.swift
@@ -19,221 +19,99 @@ struct AboutTab: View {
     }
 
     var body: some View {
-        VStack(spacing: 0) {
-            Spacer(minLength: 16)
-
-            // ── App Identity ──
-            VStack(spacing: 6) {
-                Image(nsImage: AppIcon.image)
-                    .resizable()
-                    .frame(width: 76, height: 76)
-                    .shadow(color: .black.opacity(0.15), radius: 6, y: 3)
-                    .padding(.bottom, 2)
-
-                Text("OpenClip")
-                    .font(.system(size: 20, weight: .bold))
-
-                Text("Version \(version)")
-                    .font(.subheadline)
-                    .foregroundStyle(.secondary)
-
-                Text("Instant actions for selected text on macOS")
-                    .font(.system(size: 13))
-                    .multilineTextAlignment(.center)
-                    .foregroundStyle(.secondary)
-                    .frame(maxWidth: 320)
-                    .padding(.top, 2)
-            }
-
-            // ── Updates Card ──
-            VStack(alignment: .leading, spacing: 6) {
+        Form {
+            Section {
                 if let newVersion = updateManager.availableUpdateVersion {
-                    VStack(alignment: .leading, spacing: 6) {
-                        HStack(spacing: 6) {
-                            Image(systemName: "sparkles")
-                                .font(.system(size: 13))
-                                .foregroundStyle(.tint)
-                            Text(updateManager.isUpdateStagedForQuitInstall
-                                 ? String(localized: "Update Ready: v\(newVersion)")
-                                 : String(localized: "Update Available: v\(newVersion)"))
-                                .font(.system(size: 12, weight: .semibold))
-                            Spacer()
-                            Button {
-                                updateManager.installUpdateNow()
-                            } label: {
-                                Text(String(localized: "Update Now"))
-                                    .font(.system(size: 11, weight: .semibold))
-                            }
-                            .buttonStyle(.borderedProminent)
-                            .controlSize(.small)
+                    updateAvailableRow(version: newVersion)
 
-                            Button {
-                                updateManager.installUpdateOnQuit()
-                            } label: {
-                                Text(String(localized: "Update on Quit"))
-                                    .font(.system(size: 11, weight: .medium))
+                    if let notes = updateManager.availableUpdateReleaseNotes, !notes.isEmpty {
+                        DisclosureGroup("Release Notes") {
+                            ScrollView {
+                                Text(LocalizedStringKey(notes))
+                                    .font(.callout)
+                                    .textSelection(.enabled)
+                                    .frame(maxWidth: .infinity, alignment: .leading)
+                                    .padding(.vertical, 4)
                             }
-                            .buttonStyle(.bordered)
-                            .controlSize(.small)
-                        }
-
-                        if let notes = updateManager.availableUpdateReleaseNotes, !notes.isEmpty {
-                            DisclosureGroup(String(localized: "Release Notes")) {
-                                ScrollView {
-                                    Text(LocalizedStringKey(notes))
-                                        .font(.system(size: 11))
-                                        .frame(maxWidth: .infinity, alignment: .leading)
-                                        .textSelection(.enabled)
-                                        .padding(6)
-                                }
-                                .frame(maxHeight: 100)
-                                .background(Color(NSColor.textBackgroundColor).opacity(0.5))
-                                .clipShape(RoundedRectangle(cornerRadius: 6))
-                            }
-                            .font(.system(size: 11, weight: .medium))
-                            .foregroundStyle(.secondary)
+                            .frame(maxHeight: 140)
                         }
                     }
-                    .padding(.horizontal, 10)
-                    .padding(.vertical, 6)
-                    .background(Color.accentColor.opacity(0.12))
-                    .clipShape(RoundedRectangle(cornerRadius: 8))
                 }
 
-                // Row 1: Automatically Download Updates
-                HStack(spacing: 8) {
-                    Image(systemName: "arrow.down.circle")
-                        .font(.system(size: 13))
-                        .foregroundColor(updateManager.automaticallyDownloadsUpdates ? .accentColor : .secondary)
-                        .frame(width: 18, alignment: .center)
+                SettingsToggleRow(
+                    title: "Automatically Download Updates",
+                    systemImage: "arrow.down.circle",
+                    isOn: $updateManager.automaticallyDownloadsUpdates
+                )
 
-                    Text(String(localized: "Automatically Download Updates"))
-                        .font(.system(size: 12))
+                SettingsToggleRow(
+                    title: "Notify on Update",
+                    systemImage: "bell.badge",
+                    isOn: $updateManager.notifyOnUpdate
+                )
 
-                    Spacer()
-
-                    Toggle("", isOn: $updateManager.automaticallyDownloadsUpdates)
-                        .labelsHidden()
-                        .controlSize(.mini)
-                        .accessibilityLabel(String(localized: "Automatically Download Updates"))
-                }
-                .padding(.vertical, 2)
-
-                // Row 2: Notify on Update
-                HStack(spacing: 8) {
-                    Image(systemName: "bell.badge")
-                        .font(.system(size: 13))
-                        .foregroundColor(updateManager.notifyOnUpdate ? .accentColor : .secondary)
-                        .frame(width: 18, alignment: .center)
-
-                    Text(String(localized: "Notify on Update"))
-                        .font(.system(size: 12))
-
-                    Spacer()
-
-                    Toggle("", isOn: $updateManager.notifyOnUpdate)
-                        .labelsHidden()
-                        .controlSize(.mini)
-                        .accessibilityLabel(String(localized: "Notify on Update"))
-                }
-                .padding(.vertical, 2)
-
-                Divider()
-                    .padding(.vertical, 2)
-
-                // Row 3: Check for Updates Status & Button
-                HStack(spacing: 8) {
-                    if let lastCheck = updateManager.lastUpdateCheckDate {
-                        Text(String(localized: "Last checked: \(Self.shortTimeAgo(lastCheck))"))
-                            .font(.system(size: 11))
-                            .foregroundStyle(.tertiary)
-                            .lineLimit(1)
-                    }
-
-                    Spacer()
-
-                    Button {
+                SettingsRow(
+                    title: "Check for Updates",
+                    subtitle: lastCheckedSubtitle,
+                    systemImage: "arrow.triangle.2.circlepath"
+                ) {
+                    Button("Check Now") {
                         updateManager.checkForUpdates()
-                    } label: {
-                        Text(String(localized: "Check for Updates"))
-                            .font(.system(size: 11, weight: .medium))
                     }
-                    .buttonStyle(.bordered)
-                    .controlSize(.small)
                     .disabled(!updateManager.canCheckForUpdates)
                 }
-            }
-            .padding(.horizontal, 12)
-            .padding(.vertical, 8)
-            .background(Color(NSColor.controlBackgroundColor).opacity(0.7))
-            .clipShape(RoundedRectangle(cornerRadius: 10))
-            .overlay(
-                RoundedRectangle(cornerRadius: 10)
-                    .strokeBorder(Color.primary.opacity(0.08), lineWidth: 1)
-            )
-            .padding(.top, 20)
-
-            // ── Links & Diagnostics ──
-            VStack(spacing: 8) {
-                HStack(spacing: 8) {
-                    actionButton("Website", icon: "globe") {
-                        openURL("https://www.getopenclip.app")
-                    }
-                    actionButton("GitHub", icon: "chevron.left.forwardslash.chevron.right") {
-                        openURL("https://github.com/ganeshmshetty/openclip")
-                    }
-                    actionButton("Issues", icon: "ant") {
-                        openURL("https://github.com/ganeshmshetty/openclip/issues")
-                    }
-                }
-
-                HStack(spacing: 8) {
-                    Button {
-                        exportLogs()
-                    } label: {
-                        HStack(spacing: 5) {
-                            if isExporting {
-                                ProgressView()
-                                    .controlSize(.mini)
-                            } else {
-                                Image(systemName: "square.and.arrow.up")
-                                    .font(.system(size: 11))
-                            }
-                            Text(isExporting ? String(localized: "Exporting…") : String(localized: "Export Logs"))
-                                .font(.system(size: 12))
-                        }
-                    }
-                    .buttonStyle(.bordered)
-                    .controlSize(.small)
-                    .disabled(isExporting)
-
-                    Button {
-                        LogExporter.showLogsInFinder()
-                    } label: {
-                        HStack(spacing: 5) {
-                            Image(systemName: "folder")
-                                .font(.system(size: 11))
-                            Text("Reveal Log File")
-                                .font(.system(size: 12))
-                        }
-                    }
-                    .buttonStyle(.bordered)
-                    .controlSize(.small)
+            } header: {
+                // The identity block rides the first section's header: a header
+                // scrolls with the form and draws no card, where a pinned top
+                // inset let the rows slide underneath it.
+                VStack(spacing: 0) {
+                    identityBlock
+                    Text("Software Updates")
+                        .frame(maxWidth: .infinity, alignment: .leading)
                 }
             }
-            .padding(.top, 14)
 
-            // ── Footer ──
-            Text("Open source under MIT License")
-                .font(.system(size: 11))
-                .foregroundStyle(.tertiary)
-                .padding(.top, 16)
+            Section("Links") {
+                linkRow("Website", systemImage: "globe", url: "https://www.getopenclip.app")
+                linkRow(
+                    "GitHub",
+                    systemImage: "chevron.left.forwardslash.chevron.right",
+                    url: "https://github.com/ganeshmshetty/openclip"
+                )
+                linkRow(
+                    "Report an Issue",
+                    systemImage: "ant",
+                    url: "https://github.com/ganeshmshetty/openclip/issues"
+                )
+            }
 
-            Spacer(minLength: 24)
+            Section("Diagnostics") {
+                SettingsRow(
+                    title: "Logs",
+                    subtitle: "Attach these when reporting a problem.",
+                    systemImage: "doc.text"
+                ) {
+                    HStack(spacing: 10) {
+                        Button(isExporting ? "Exporting…" : "Export…") {
+                            exportLogs()
+                        }
+                        .disabled(isExporting)
+
+                        Button("Reveal") {
+                            LogExporter.showLogsInFinder()
+                        }
+                    }
+                }
+            }
+
+            Section {
+                Text("Open source under MIT License")
+                    .font(.footnote)
+                    .foregroundStyle(.tertiary)
+                    .frame(maxWidth: .infinity, alignment: .center)
+            }
         }
-        .frame(maxWidth: 380)
-        .frame(maxWidth: .infinity, maxHeight: .infinity)
-        .padding(.horizontal, 24)
+        .formStyle(.grouped)
         .alert("Export Logs Failed", isPresented: Binding(
             get: { exportError != nil },
             set: { if !$0 { exportError = nil } }
@@ -246,20 +124,75 @@ struct AboutTab: View {
         }
     }
 
-    // MARK: - Helpers
+    // MARK: - Pieces
 
-    private func actionButton(_ title: LocalizedStringKey, icon: String, action: @escaping () -> Void) -> some View {
-        Button(action: action) {
-            HStack(spacing: 5) {
-                Image(systemName: icon)
-                    .font(.system(size: 11))
-                Text(title)
-                    .font(.system(size: 12))
+    private var identityBlock: some View {
+        VStack(spacing: 6) {
+            Image(nsImage: AppIcon.image)
+                .resizable()
+                .frame(width: 72, height: 72)
+
+            Text("OpenClip")
+                .font(.title2.weight(.semibold))
+
+            Text("Version \(version)")
+                .font(.callout)
+                .foregroundStyle(.secondary)
+
+            Text("Instant actions for selected text on macOS")
+                .font(.callout)
+                .foregroundStyle(.secondary)
+                .multilineTextAlignment(.center)
+        }
+        .frame(maxWidth: .infinity)
+        .padding(.top, 12)
+        .padding(.bottom, 20)
+    }
+
+    private func updateAvailableRow(version newVersion: String) -> some View {
+        SettingsRow(
+            title: updateManager.isUpdateStagedForQuitInstall
+                ? "Update Ready"
+                : "Update Available",
+            subtitle: LocalizedStringKey("Version \(newVersion)"),
+            systemImage: "sparkles"
+        ) {
+            HStack(spacing: 10) {
+                Button("Update Now") {
+                    updateManager.installUpdateNow()
+                }
+                .buttonStyle(.borderedProminent)
+
+                Button("On Quit") {
+                    updateManager.installUpdateOnQuit()
+                }
             }
         }
-        .buttonStyle(.bordered)
-        .controlSize(.small)
     }
+
+    private var lastCheckedSubtitle: LocalizedStringKey? {
+        guard let lastCheck = updateManager.lastUpdateCheckDate else { return nil }
+        return LocalizedStringKey("Last checked \(Self.shortTimeAgo(lastCheck))")
+    }
+
+    /// Secondary navigation, so the whole row is the target and the only
+    /// decoration is the outward arrow — a bordered button per link read as
+    /// three competing primary actions.
+    private func linkRow(_ title: LocalizedStringKey, systemImage: String, url: String) -> some View {
+        Button {
+            openURL(url)
+        } label: {
+            SettingsRow(title: title, systemImage: systemImage) {
+                Image(systemName: "arrow.up.right")
+                    .font(.footnote.weight(.semibold))
+                    .foregroundStyle(.tertiary)
+            }
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+    }
+
+    // MARK: - Helpers
 
     private func openURL(_ string: String) {
         if let url = URL(string: string) {

--- a/Sources/OpenClip/UI/Preferences/ActionsOutlineView.swift
+++ b/Sources/OpenClip/UI/Preferences/ActionsOutlineView.swift
@@ -254,6 +254,24 @@ final class ActionsOutlineTableView: NSOutlineView {
     }
 }
 
+// MARK: - Scroll View
+
+/// Keeps the list's rows clear of the title bar while the scroll view itself runs
+/// underneath it. The pane hands this view the whole detail column, title bar
+/// included, so scrolled rows fade out beneath the toolbar the way every Form-based
+/// pane's do; AppKit only insets scroll views the window owns directly, so the
+/// overlap is measured and applied here.
+@MainActor
+final class ActionsScrollView: NSScrollView {
+    override func layout() {
+        super.layout()
+        guard let window else { return }
+        let overlap = max(0, convert(bounds, to: nil).maxY - window.contentLayoutRect.maxY)
+        guard abs(contentInsets.top - overlap) > 0.5 else { return }
+        contentInsets = NSEdgeInsets(top: overlap, left: 0, bottom: 0, right: 0)
+    }
+}
+
 // MARK: - SwiftUI Representable
 
 @MainActor
@@ -271,11 +289,14 @@ struct ActionsOutlineView: NSViewRepresentable {
     }
 
     func makeNSView(context: Context) -> NSScrollView {
-        let scrollView = NSScrollView()
+        let scrollView = ActionsScrollView()
         scrollView.hasVerticalScroller = true
         scrollView.hasHorizontalScroller = false
         scrollView.autohidesScrollers = true
         scrollView.drawsBackground = false
+        // The inset is measured against the title bar in `layout()`; the automatic
+        // one only fires for a scroll view the window itself owns.
+        scrollView.automaticallyAdjustsContentInsets = false
 
         let outlineView = ActionsOutlineTableView()
         let column = NSTableColumn(identifier: NSUserInterfaceItemIdentifier("ActionColumn"))

--- a/Sources/OpenClip/UI/Preferences/ActionsTabView.swift
+++ b/Sources/OpenClip/UI/Preferences/ActionsTabView.swift
@@ -49,6 +49,10 @@ struct ActionsTab: View {
                 showingCreateGroupSheet = true
             }
         )
+        // Runs the list up into the title bar so its rows fade out under the
+        // toolbar like the Form-based panes do. `ActionsScrollView` puts the rows
+        // themselves back below it.
+        .ignoresSafeArea(.container, edges: .top)
         .sheet(isPresented: $showingAddActionSheet) {
             AddCustomActionSheet()
         }

--- a/Sources/OpenClip/UI/Preferences/AppPickerSheet.swift
+++ b/Sources/OpenClip/UI/Preferences/AppPickerSheet.swift
@@ -109,11 +109,11 @@ public struct AppPickerSheet: View {
                 .padding(16)
                 .frame(height: 320)
             } else {
-                HStack {
-                    Image(systemName: "magnifyingglass").foregroundColor(.secondary)
-                    TextField("Search applications...", text: $searchText)
-                        .textFieldStyle(.plain)
-                }
+                NativeSearchField(
+                    text: $searchText,
+                    placeholder: String(localized: "Search applications...")
+                )
+                .frame(height: 24)
                 .padding(10)
                 
                 Divider()

--- a/Sources/OpenClip/UI/Preferences/AppRulesTab.swift
+++ b/Sources/OpenClip/UI/Preferences/AppRulesTab.swift
@@ -9,9 +9,15 @@ import Core
 @MainActor
 public struct AppRulesTab: View {
     @ObservedObject private var ruleEngine = RuleEngine.shared
-    @State private var showingAppPicker = false
-    
-    public init() {}
+    /// Owned by PreferencesView: the Add button lives in the window toolbar
+    /// alongside every other tab's, so this pane doesn't declare a toolbar of
+    /// its own — a second toolbar group renders as its own floating glass
+    /// capsule next to the first one.
+    @Binding private var showingAppPicker: Bool
+
+    public init(showingAppPicker: Binding<Bool>) {
+        _showingAppPicker = showingAppPicker
+    }
     
     public var body: some View {
         Form {
@@ -42,22 +48,6 @@ public struct AppRulesTab: View {
             }
         }
         .formStyle(.grouped)
-        .toolbar {
-            ToolbarItem {
-                Button {
-                    showingAppPicker = true
-                } label: {
-                    Label("Add Application", systemImage: "plus")
-                }
-                .help("Add Application")
-            }
-        }
-        .sheet(isPresented: $showingAppPicker) {
-            AppPickerSheet { bundleID in
-                let newRule = AppRule(bundleIdentifiers: [bundleID])
-                RuleEngine.shared.addOrUpdateRule(newRule)
-            }
-        }
     }
 }
 
@@ -84,7 +74,7 @@ private struct AppRuleRowView: View {
     }
     
     var body: some View {
-        HStack(alignment: .center, spacing: 10) {
+        HStack(alignment: .center, spacing: 12) {
             // App Icon
             if let appURL = NSWorkspace.shared.urlForApplication(withBundleIdentifier: bundleID) {
                 Image(nsImage: NSWorkspace.shared.icon(forFile: appURL.path))
@@ -99,20 +89,18 @@ private struct AppRuleRowView: View {
             }
             
             // App Title & Bundle ID
-            VStack(alignment: .leading, spacing: 1) {
+            VStack(alignment: .leading, spacing: 2) {
                 if let appURL = NSWorkspace.shared.urlForApplication(withBundleIdentifier: bundleID),
                    let bundle = Bundle(url: appURL),
                    let appName = bundle.object(forInfoDictionaryKey: "CFBundleName") as? String ?? bundle.object(forInfoDictionaryKey: "CFBundleDisplayName") as? String {
                     Text(appName)
-                        .font(.system(size: 13, weight: .semibold))
-                        .foregroundColor(isDisabled ? .secondary : .primary)
+                        .foregroundStyle(isDisabled ? .secondary : .primary)
                     Text(bundleID)
-                        .font(.system(size: 10))
-                        .foregroundColor(.secondary)
+                        .font(.callout)
+                        .foregroundStyle(.secondary)
                 } else {
                     Text(bundleID)
-                        .font(.system(size: 13, weight: .semibold))
-                        .foregroundColor(isDisabled ? .secondary : .primary)
+                        .foregroundStyle(isDisabled ? .secondary : .primary)
                 }
             }
             
@@ -136,7 +124,6 @@ private struct AppRuleRowView: View {
             ))
             .labelsHidden()
             .toggleStyle(.switch)
-            .controlSize(.mini)
             .accessibilityLabel(isDisabled ? String(localized: "Enable in this app") : String(localized: "Disable in this app"))
             
             // Three-Dots (...) Actions Menu
@@ -186,8 +173,7 @@ private struct AppRuleRowView: View {
                 }
             } label: {
                 Image(systemName: "ellipsis.circle")
-                    .font(.system(size: 15))
-                    .foregroundColor(.secondary)
+                    .foregroundStyle(.secondary)
             }
             .menuStyle(.borderlessButton)
             .menuIndicator(.hidden)
@@ -195,6 +181,6 @@ private struct AppRuleRowView: View {
             .help("More Actions")
             .accessibilityLabel("More Actions")
         }
-        .padding(.vertical, 6)
+        .padding(.vertical, 4)
     }
 }

--- a/Sources/OpenClip/UI/Preferences/AppRulesTab.swift
+++ b/Sources/OpenClip/UI/Preferences/AppRulesTab.swift
@@ -14,57 +14,44 @@ public struct AppRulesTab: View {
     public init() {}
     
     public var body: some View {
-        VStack(alignment: .leading, spacing: 12) {
-            HStack {
-                VStack(alignment: .leading, spacing: 2) {
-                    Text("Application Rules")
-                        .font(.headline)
-                    Text("Configure per-app trigger and paste behavior.")
-                        .font(.caption)
-                        .foregroundColor(.secondary)
-                }
-                Spacer()
-                
-                Button(action: {
-                    showingAppPicker = true
-                }) {
-                    Label("Add Application", systemImage: "plus")
-                }
-                .buttonStyle(.borderedProminent)
-                .controlSize(.small)
-            }
-            
-            Form {
-                Section {
-                    if ruleEngine.userRules.isEmpty {
-                        VStack(spacing: 8) {
-                            Image(systemName: "app.badge.checkmark")
-                                .font(.system(size: 32))
-                                .foregroundColor(.secondary)
-                            Text("No App Rules Configured")
-                                .font(.headline)
-                            Text("OpenClip works in all applications by default. Click 'Add Application' to configure per-app rules or exclusions.")
-                                .font(.caption)
-                                .foregroundColor(.secondary)
-                                .multilineTextAlignment(.center)
-                        }
-                        .frame(maxWidth: .infinity)
-                        .padding(.vertical, 30)
-                    } else {
-                        ForEach(ruleEngine.userRules) { rule in
-                            AppRuleRowView(rule: rule) { updatedRule in
-                                RuleEngine.shared.addOrUpdateRule(updatedRule)
-                            } onDelete: {
-                                RuleEngine.shared.removeRule(id: rule.id)
-                            }
+        Form {
+            Section {
+                if ruleEngine.userRules.isEmpty {
+                    ContentUnavailableView {
+                        Label("No App Rules Configured", systemImage: "app.badge.checkmark")
+                    } description: {
+                        Text("OpenClip works in all applications by default. Add an application to configure per-app rules or exclusions.")
+                    } actions: {
+                        Button("Add Application") { showingAppPicker = true }
+                    }
+                    .padding(.vertical, 12)
+                } else {
+                    ForEach(ruleEngine.userRules) { rule in
+                        AppRuleRowView(rule: rule) { updatedRule in
+                            RuleEngine.shared.addOrUpdateRule(updatedRule)
+                        } onDelete: {
+                            RuleEngine.shared.removeRule(id: rule.id)
                         }
                     }
                 }
+            } header: {
+                Text("Application Rules")
+            } footer: {
+                Text("Configure per-app trigger and paste behavior.")
+                    .foregroundStyle(.secondary)
             }
-            .formStyle(.grouped)
-            .scrollContentBackground(.hidden)
         }
-        .padding(12)
+        .formStyle(.grouped)
+        .toolbar {
+            ToolbarItem {
+                Button {
+                    showingAppPicker = true
+                } label: {
+                    Label("Add Application", systemImage: "plus")
+                }
+                .help("Add Application")
+            }
+        }
         .sheet(isPresented: $showingAppPicker) {
             AppPickerSheet { bundleID in
                 let newRule = AppRule(bundleIdentifiers: [bundleID])

--- a/Sources/OpenClip/UI/Preferences/AppearanceTabView.swift
+++ b/Sources/OpenClip/UI/Preferences/AppearanceTabView.swift
@@ -9,10 +9,18 @@ import Core
 @MainActor
 struct AppearanceTab: View {
     var body: some View {
-        VStack(spacing: 12) {
+        VStack(spacing: 0) {
+            // The preview is a fixed-size stage, so it sits above the form
+            // rather than inside it — a grouped row would stretch it.
             PopupPreview()
+                .padding(.horizontal, 20)
+                .padding(.top, 20)
 
             PopupThemeSelector()
         }
+        // Fill the detail pane rather than settling at the content's own height:
+        // a pane that only claims what it needs leaves the window sizing itself
+        // differently per tab.
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
     }
 }

--- a/Sources/OpenClip/UI/Preferences/ExtensionCardView.swift
+++ b/Sources/OpenClip/UI/Preferences/ExtensionCardView.swift
@@ -74,7 +74,9 @@ struct ExtensionCardView: View {
         if !item.author.isEmpty {
             parts.append(item.author)
         }
-        if item.downloadCount > 0 {
+        if item.downloadCount == 1 {
+            parts.append(String(localized: "\(formattedDownloadCount(item.downloadCount)) download"))
+        } else if item.downloadCount > 1 {
             parts.append(String(localized: "\(formattedDownloadCount(item.downloadCount)) downloads"))
         }
         return parts.joined(separator: " · ")

--- a/Sources/OpenClip/UI/Preferences/ExtensionCardView.swift
+++ b/Sources/OpenClip/UI/Preferences/ExtensionCardView.swift
@@ -68,6 +68,18 @@ struct ExtensionCardView: View {
         ExtensionsStoreViewModel.isNew(item) && (item.version == nil || item.version == "1.0.0")
     }
 
+    /// Byline and download count on one quiet line under the description.
+    private var metadataLine: String {
+        var parts: [String] = []
+        if !item.author.isEmpty {
+            parts.append(item.author)
+        }
+        if item.downloadCount > 0 {
+            parts.append(String(localized: "\(formattedDownloadCount(item.downloadCount)) downloads"))
+        }
+        return parts.joined(separator: " · ")
+    }
+
     private func formattedDownloadCount(_ count: Int) -> String {
         if count >= 1_000_000 {
             let millions = Double(count) / 1_000_000.0
@@ -101,49 +113,44 @@ struct ExtensionCardView: View {
             .background(Color.primary.opacity(0.06))
             .cornerRadius(7)
 
-            // Center Title & Description (clean 2-line layout without metadata clutter)
+            // Three levels, three weights: the name is what you scan, the
+            // description is what you read, and the byline and download count
+            // are only there once something has caught your eye. They used to be
+            // the same grey as the description, and the byline sat on the name's
+            // line, so all three competed at once.
             VStack(alignment: .leading, spacing: 3) {
                 HStack(spacing: 6) {
                     Text(item.name)
-                        .font(.system(size: 13, weight: .semibold))
-                        .foregroundColor(.primary)
+                        .font(.body.weight(.semibold))
                         .lineLimit(1)
-
-                    if isFeatured {
-                        Image(systemName: "rosette")
-                            .font(.system(size: 11, weight: .semibold))
-                            .foregroundColor(.accentColor)
-                            .help(String(localized: "Featured"))
-                            .accessibilityLabel(String(localized: "Featured"))
-                    }
 
                     if isBrandNew {
                         Text(String(localized: "New"))
-                            .font(.system(size: 9, weight: .semibold))
-                            .foregroundColor(.accentColor)
+                            .font(.caption2.weight(.semibold))
+                            .foregroundStyle(.tint)
                             .padding(.horizontal, 5)
                             .padding(.vertical, 1)
                             .background(Color.accentColor.opacity(0.12))
                             .clipShape(Capsule())
                     }
-
-                    if !item.author.isEmpty {
-                        Text("by @\(item.author)")
-                            .font(.system(size: 11))
-                            .foregroundColor(.secondary)
-                            .lineLimit(1)
-                    }
                 }
 
                 if let err = installError {
                     Text("⚠︎ \(err)")
-                        .font(.caption2)
-                        .foregroundColor(.red)
+                        .font(.callout)
+                        .foregroundStyle(.red)
                         .lineLimit(1)
                 } else {
                     Text(item.description)
-                        .font(.system(size: 11))
-                        .foregroundColor(.secondary)
+                        .font(.callout)
+                        .foregroundStyle(.secondary)
+                        .lineLimit(1)
+                }
+
+                if !metadataLine.isEmpty {
+                    Text(metadataLine)
+                        .font(.caption)
+                        .foregroundStyle(.tertiary)
                         .lineLimit(1)
                 }
             }
@@ -152,17 +159,6 @@ struct ExtensionCardView: View {
 
             // Right Action Buttons
             HStack(spacing: 8) {
-                if item.downloadCount > 0 {
-                    HStack(spacing: 2) {
-                        Image(systemName: "arrow.down")
-                            .font(.system(size: 8.5, weight: .medium))
-                        Text(formattedDownloadCount(item.downloadCount))
-                            .font(.system(size: 10.5, weight: .medium, design: .rounded))
-                    }
-                    .foregroundColor(.secondary.opacity(0.8))
-                    .padding(.trailing, 2)
-                }
-
                 if isInstalled {
                     if updateManager.updatablePackageIDs.contains(item.id) {
                         Button(action: {

--- a/Sources/OpenClip/UI/Preferences/ExtensionsStoreView.swift
+++ b/Sources/OpenClip/UI/Preferences/ExtensionsStoreView.swift
@@ -329,11 +329,11 @@ public struct ExtensionStoreView: View {
 
     public var body: some View {
         VStack(spacing: 0) {
-            filterPillsRow
+            filterBar
             storeContent
         }
         .padding(.horizontal, 12)
-        .padding(.top, 4)
+        .padding(.top, 10)
         .padding(.bottom, 0)
         .task {
             if viewModel.extensions.isEmpty {
@@ -342,45 +342,46 @@ public struct ExtensionStoreView: View {
         }
     }
 
-    private var filterPillsRow: some View {
-        HStack(spacing: 8) {
-            ForEach(StoreFilter.allCases) { filter in
-                let isSelected = viewModel.selectedFilter == filter && !isSearching
-                Button {
-                    withAnimation(.easeInOut(duration: 0.15)) {
-                        if isSearching {
-                            viewModel.searchQuery = ""
-                        }
-                        viewModel.selectedFilter = filter
-                    }
-                } label: {
-                    HStack(spacing: 4.5) {
-                        if filter == .popular {
-                            Image(systemName: "flame.fill")
-                                .font(.system(size: 9.5, weight: .semibold))
-                        } else if filter == .new {
-                            Image(systemName: "clock.arrow.circlepath")
-                                .font(.system(size: 9.5, weight: .semibold))
-                        }
-                        Text(filter.title)
-                            .font(.system(size: 11.5, weight: isSelected ? .semibold : .medium))
-                    }
-                    .padding(.horizontal, 11)
-                    .padding(.vertical, 4.5)
-                    .background(
-                        RoundedRectangle(cornerRadius: 12, style: .continuous)
-                            .fill(isSelected ? Color.accentColor : Color.primary.opacity(0.06))
-                    )
-                    .foregroundColor(isSelected ? .white : .secondary)
-                    .contentShape(Rectangle())
+    /// A stock segmented control: the catalog filter is a plain three-way choice,
+    /// and the system control already handles focus, keyboard and appearance.
+    private var filterPicker: some View {
+        Picker("Filter", selection: Binding(
+            get: { viewModel.selectedFilter },
+            set: { newValue in
+                if isSearching {
+                    viewModel.searchQuery = ""
                 }
-                .buttonStyle(.plain)
+                viewModel.selectedFilter = newValue
             }
-            Spacer()
+        )) {
+            ForEach(StoreFilter.allCases) { filter in
+                Text(filter.title).tag(filter)
+            }
+        }
+        .pickerStyle(.segmented)
+        .labelsHidden()
+        .frame(maxWidth: 300, alignment: .leading)
+        .disabled(isSearching)
+    }
+
+    /// The search field lives in the content, not the toolbar: a `.searchable`
+    /// that only exists on this tab makes the window's toolbar appear and
+    /// disappear as tabs change, and the title bar re-measures every time.
+    private var filterBar: some View {
+        HStack(spacing: 12) {
+            filterPicker
+            Spacer(minLength: 12)
+            NativeSearchField(
+                text: $viewModel.searchQuery,
+                placeholder: String(localized: "Search extensions")
+            )
+            .frame(width: 200, height: 24)
+            .onChange(of: viewModel.searchQuery) { _, _ in
+                viewModel.queryDidChange()
+            }
         }
         .padding(.horizontal, 14)
-        .padding(.bottom, 8)
-        .opacity(isSearching ? 0.4 : 1.0)
+        .padding(.bottom, 10)
     }
 
     private var storeContent: some View {

--- a/Sources/OpenClip/UI/Preferences/ExtensionsStoreView.swift
+++ b/Sources/OpenClip/UI/Preferences/ExtensionsStoreView.swift
@@ -337,10 +337,11 @@ public struct ExtensionStoreView: View {
     public var body: some View {
         // The filter and the search field live in the window toolbar (see
         // PreferencesView.toolbarContent), so the pane is just the list.
+        // No padding around `storeContent`: the list has to reach the pane's top
+        // edge for the system to fade it out under the toolbar the way the
+        // Form-based panes are. The 12pt gutter lives on the scrolling content
+        // inside instead.
         storeContent
-        .padding(.horizontal, 12)
-        .padding(.top, 4)
-        .padding(.bottom, 0)
         .task {
             if viewModel.extensions.isEmpty {
                 await viewModel.resetAndFetch(limit: 100)
@@ -414,6 +415,7 @@ public struct ExtensionStoreView: View {
                     }
                 }
             }
+            .padding(.horizontal, 12)
         }
         .opacity(viewModel.isLoading && !viewModel.extensions.isEmpty ? 0.65 : 1.0)
         .animation(.easeInOut(duration: 0.15), value: viewModel.isLoading)
@@ -451,6 +453,7 @@ public struct ExtensionStoreView: View {
                         }
                 }
             }
+            .padding(.horizontal, 12)
         }
         .opacity(viewModel.isLoading && !viewModel.extensions.isEmpty ? 0.65 : 1.0)
         .animation(.easeInOut(duration: 0.15), value: viewModel.isLoading)
@@ -468,6 +471,7 @@ public struct ExtensionStoreView: View {
                     ExtensionCardSkeletonRow()
                 }
             }
+            .padding(.horizontal, 12)
         }
     }
 }

--- a/Sources/OpenClip/UI/Preferences/ExtensionsStoreView.swift
+++ b/Sources/OpenClip/UI/Preferences/ExtensionsStoreView.swift
@@ -160,11 +160,18 @@ public final class ExtensionsStoreViewModel: ObservableObject {
         return extensions.filter { !showcased.contains($0.id.lowercased()) }
     }
 
+    /// The storefront below the featured showcase: everything else, in catalog
+    /// order. New and updated items used to get a showcase of their own, which
+    /// meant three stacked lists competing for the first look; they are part of
+    /// the catalog now.
+    public var catalogSectionItems: [ExtensionItem] {
+        let featured = Set(featuredSectionItems.map { $0.id.lowercased() })
+        return extensions.filter { !featured.contains($0.id.lowercased()) }
+    }
+
     /// ID of the last item rendered across the sectioned storefront, used to trigger pagination.
     public var lastRenderedSectionedItemID: String? {
-        remainingAllSectionItems.last?.id
-            ?? newSectionItems.last?.id
-            ?? featuredSectionItems.last?.id
+        catalogSectionItems.last?.id ?? featuredSectionItems.last?.id
     }
 
     /// True when the given item is the final rendered item in the sectioned storefront.
@@ -328,60 +335,17 @@ public struct ExtensionStoreView: View {
     }
 
     public var body: some View {
-        VStack(spacing: 0) {
-            filterBar
-            storeContent
-        }
+        // The filter and the search field live in the window toolbar (see
+        // PreferencesView.toolbarContent), so the pane is just the list.
+        storeContent
         .padding(.horizontal, 12)
-        .padding(.top, 10)
+        .padding(.top, 4)
         .padding(.bottom, 0)
         .task {
             if viewModel.extensions.isEmpty {
                 await viewModel.resetAndFetch(limit: 100)
             }
         }
-    }
-
-    /// A stock segmented control: the catalog filter is a plain three-way choice,
-    /// and the system control already handles focus, keyboard and appearance.
-    private var filterPicker: some View {
-        Picker("Filter", selection: Binding(
-            get: { viewModel.selectedFilter },
-            set: { newValue in
-                if isSearching {
-                    viewModel.searchQuery = ""
-                }
-                viewModel.selectedFilter = newValue
-            }
-        )) {
-            ForEach(StoreFilter.allCases) { filter in
-                Text(filter.title).tag(filter)
-            }
-        }
-        .pickerStyle(.segmented)
-        .labelsHidden()
-        .frame(maxWidth: 300, alignment: .leading)
-        .disabled(isSearching)
-    }
-
-    /// The search field lives in the content, not the toolbar: a `.searchable`
-    /// that only exists on this tab makes the window's toolbar appear and
-    /// disappear as tabs change, and the title bar re-measures every time.
-    private var filterBar: some View {
-        HStack(spacing: 12) {
-            filterPicker
-            Spacer(minLength: 12)
-            NativeSearchField(
-                text: $viewModel.searchQuery,
-                placeholder: String(localized: "Search extensions")
-            )
-            .frame(width: 200, height: 24)
-            .onChange(of: viewModel.searchQuery) { _, _ in
-                viewModel.queryDidChange()
-            }
-        }
-        .padding(.horizontal, 14)
-        .padding(.bottom, 10)
     }
 
     private var storeContent: some View {
@@ -408,87 +372,66 @@ public struct ExtensionStoreView: View {
         }
     }
 
-    private func sectionHeader(title: String, icon: String, count: Int? = nil) -> some View {
+    private func sectionHeader(_ title: String, count: Int? = nil) -> some View {
         HStack(spacing: 6) {
-            Image(systemName: icon)
-                .font(.system(size: 11, weight: .semibold))
-                .foregroundColor(.accentColor)
             Text(title)
-                .font(.system(size: 11, weight: .semibold))
-                .foregroundColor(.secondary)
-                .textCase(.uppercase)
+                .font(.headline)
             if let count {
-                Text("(\(count))")
-                    .font(.system(size: 11))
-                    .foregroundColor(.secondary.opacity(0.7))
+                Text("\(count)")
+                    .font(.subheadline)
+                    .foregroundStyle(.secondary)
             }
             Spacer()
         }
         .padding(.horizontal, 14)
-        .padding(.top, 14)
-        .padding(.bottom, 4)
+        .padding(.top, 16)
+        .padding(.bottom, 6)
     }
 
     private var sectionedAllStoreContent: some View {
         ScrollView {
             LazyVStack(spacing: 0) {
-                // Section 1: Featured
                 if !viewModel.featuredSectionItems.isEmpty {
-                    sectionHeader(title: String(localized: "Featured"), icon: "rosette")
+                    sectionHeader(String(localized: "Featured"))
                     ForEach(Array(viewModel.featuredSectionItems.enumerated()), id: \.element.id) { index, ext in
                         if index > 0 {
-                            Divider()
-                                .padding(.leading, 60)
-                                .padding(.trailing, 14)
+                            rowDivider
                         }
-                        ExtensionCardView(item: ext)
-                            .onAppear {
-                                if viewModel.shouldTriggerSectionedPagination(for: ext.id) {
-                                    Task { await viewModel.fetchNextPage() }
-                                }
-                            }
+                        storeRow(ext)
                     }
                 }
 
-                // Section 2: New & Updated
-                if !viewModel.newSectionItems.isEmpty {
-                    sectionHeader(title: String(localized: "New & Updated"), icon: "clock.arrow.circlepath")
-                    ForEach(Array(viewModel.newSectionItems.enumerated()), id: \.element.id) { index, ext in
+                if !viewModel.catalogSectionItems.isEmpty {
+                    sectionHeader(
+                        String(localized: "All Extensions"),
+                        count: viewModel.catalogSectionItems.count
+                    )
+                    ForEach(Array(viewModel.catalogSectionItems.enumerated()), id: \.element.id) { index, ext in
                         if index > 0 {
-                            Divider()
-                                .padding(.leading, 60)
-                                .padding(.trailing, 14)
+                            rowDivider
                         }
-                        ExtensionCardView(item: ext)
-                            .onAppear {
-                                if viewModel.shouldTriggerSectionedPagination(for: ext.id) {
-                                    Task { await viewModel.fetchNextPage() }
-                                }
-                            }
-                    }
-                }
-
-                // Section 3: All Extensions
-                if !viewModel.remainingAllSectionItems.isEmpty {
-                    sectionHeader(title: String(localized: "All Extensions"), icon: "square.grid.2x2", count: viewModel.remainingAllSectionItems.count)
-                    ForEach(Array(viewModel.remainingAllSectionItems.enumerated()), id: \.element.id) { index, ext in
-                        if index > 0 {
-                            Divider()
-                                .padding(.leading, 60)
-                                .padding(.trailing, 14)
-                        }
-                        ExtensionCardView(item: ext)
-                            .onAppear {
-                                if viewModel.shouldTriggerSectionedPagination(for: ext.id) {
-                                    Task { await viewModel.fetchNextPage() }
-                                }
-                            }
+                        storeRow(ext)
                     }
                 }
             }
         }
         .opacity(viewModel.isLoading && !viewModel.extensions.isEmpty ? 0.65 : 1.0)
         .animation(.easeInOut(duration: 0.15), value: viewModel.isLoading)
+    }
+
+    private var rowDivider: some View {
+        Divider()
+            .padding(.leading, 60)
+            .padding(.trailing, 14)
+    }
+
+    private func storeRow(_ ext: ExtensionItem) -> some View {
+        ExtensionCardView(item: ext)
+            .onAppear {
+                if viewModel.shouldTriggerSectionedPagination(for: ext.id) {
+                    Task { await viewModel.fetchNextPage() }
+                }
+            }
     }
 
     private var flatStoreContent: some View {

--- a/Sources/OpenClip/UI/Preferences/GeneralTabView.swift
+++ b/Sources/OpenClip/UI/Preferences/GeneralTabView.swift
@@ -33,14 +33,16 @@ struct GeneralTab: View {
     
     var body: some View {
         Form {
-            Section {
-                Toggle(isOn: $isAppEnabled) {
-                    SettingsRowLabel(
-                        title: "Appear Automatically",
-                        subtitle: "Show the popup as soon as text is selected.",
-                        systemImage: "cursorarrow"
-                    )
-                }
+            // Everything that decides how the popup is summoned sits together,
+            // shortcut included — it used to be stranded between switches that
+            // had nothing to do with triggering.
+            Section("Triggers") {
+                SettingsToggleRow(
+                    title: "Appear Automatically",
+                    subtitle: "Show the popup as soon as text is selected.",
+                    systemImage: "cursorarrow",
+                    isOn: $isAppEnabled
+                )
                 .onChange(of: isAppEnabled) { _, newValue in
                     DefaultSettingsStore.shared.set(.isAppEnabled, value: newValue)
                     NotificationCenter.default.post(name: Notification.Name("OpenClipEnabledStateChanged"), object: newValue)
@@ -49,26 +51,55 @@ struct GeneralTab: View {
                     isAppEnabled = (notification.object as? Bool) ?? DefaultSettingsStore.shared.get(.isAppEnabled)
                 }
 
-                Toggle(isOn: $isMouseHoldEnabled) {
-                    SettingsRowLabel(
-                        title: "Hold Mouse to Trigger",
-                        subtitle: "Keep the button down after selecting to summon the popup.",
-                        systemImage: "hand.tap"
-                    )
-                }
+                SettingsToggleRow(
+                    title: "Hold Mouse to Trigger",
+                    subtitle: "Keep the button down after selecting to summon the popup.",
+                    systemImage: "hand.tap",
+                    isOn: $isMouseHoldEnabled
+                )
                 .onChange(of: isMouseHoldEnabled) { _, newValue in
                     DefaultSettingsStore.shared.set(.isMouseHoldEnabled, value: newValue)
                 }
 
-                LabeledContent {
+                SettingsRow(
+                    title: "Keyboard Shortcut",
+                    subtitle: "Summon the popup for whatever is selected.",
+                    systemImage: "keyboard"
+                ) {
                     KeyboardShortcuts.Recorder(for: .togglePopup)
-                } label: {
-                    SettingsRowLabel(title: "Trigger Popup Shortcut", systemImage: "keyboard")
+                }
+            }
+
+            Section("Action Results") {
+                SettingsRow(
+                    title: "Primary click",
+                    subtitle: "Left click",
+                    systemImage: "cursorarrow.click"
+                ) {
+                    resultPicker(selection: $primaryBehavior, label: "Primary click")
+                        .onChange(of: primaryBehavior) { _, newValue in
+                            DefaultSettingsStore.shared.set(.primaryClickBehavior, value: newValue)
+                        }
                 }
 
-                Toggle(isOn: $showMenuBarIcon) {
-                    SettingsRowLabel(title: "Show Menu Bar Icon", systemImage: "menubar.rectangle")
+                SettingsRow(
+                    title: "Secondary click",
+                    subtitle: "Right click or ⇧-click",
+                    systemImage: "cursorarrow.click.2"
+                ) {
+                    resultPicker(selection: $secondaryBehavior, label: "Secondary click")
+                        .onChange(of: secondaryBehavior) { _, newValue in
+                            DefaultSettingsStore.shared.set(.secondaryClickBehavior, value: newValue)
+                        }
                 }
+            }
+
+            Section("App") {
+                SettingsToggleRow(
+                    title: "Show Menu Bar Icon",
+                    systemImage: "menubar.rectangle",
+                    isOn: $showMenuBarIcon
+                )
                 .onChange(of: showMenuBarIcon) { _, newValue in
                     DefaultSettingsStore.shared.set(.showMenuBarIcon, value: newValue)
                     NotificationCenter.default.post(
@@ -77,47 +108,19 @@ struct GeneralTab: View {
                     )
                 }
 
-                Toggle(isOn: $launchManager.isEnabled) {
-                    SettingsRowLabel(title: "Start at Login", systemImage: "arrow.clockwise.circle")
-                }
+                SettingsToggleRow(
+                    title: "Start at Login",
+                    systemImage: "arrow.clockwise.circle",
+                    isOn: $launchManager.isEnabled
+                )
             }
 
-            Section("Action Results") {
-                Picker(selection: $primaryBehavior) {
-                    ForEach(ResultDeliveryPreference.allCases, id: \.self) { pref in
-                        Text(LocalizedStringKey(pref.rawValue.capitalized)).tag(pref.rawValue)
-                    }
-                } label: {
-                    SettingsRowLabel(
-                        title: "Primary click",
-                        subtitle: "Left click",
-                        systemImage: "cursorarrow.click"
-                    )
-                }
-                .pickerStyle(.segmented)
-                .onChange(of: primaryBehavior) { _, newValue in
-                    DefaultSettingsStore.shared.set(.primaryClickBehavior, value: newValue)
-                }
-
-                Picker(selection: $secondaryBehavior) {
-                    ForEach(ResultDeliveryPreference.allCases, id: \.self) { pref in
-                        Text(LocalizedStringKey(pref.rawValue.capitalized)).tag(pref.rawValue)
-                    }
-                } label: {
-                    SettingsRowLabel(
-                        title: "Secondary click",
-                        subtitle: "Right click or ⇧-click",
-                        systemImage: "cursorarrow.click.2"
-                    )
-                }
-                .pickerStyle(.segmented)
-                .onChange(of: secondaryBehavior) { _, newValue in
-                    DefaultSettingsStore.shared.set(.secondaryClickBehavior, value: newValue)
-                }
-            }
-
-            Section("System Permissions") {
-                LabeledContent {
+            Section("Permissions") {
+                SettingsRow(
+                    title: "Accessibility Access",
+                    subtitle: "Required to read the selected text.",
+                    systemImage: "lock.shield"
+                ) {
                     HStack(spacing: 10) {
                         Label {
                             Text(permissionManager.isAccessibilityGranted
@@ -138,17 +141,25 @@ struct GeneralTab: View {
                             permissionManager.requestAccessibilityPermission(proactivelyResetStaleTCC: shouldReset)
                         }
                     }
-                } label: {
-                    SettingsRowLabel(
-                        title: "Accessibility Access",
-                        subtitle: "Required to read the selected text.",
-                        systemImage: "lock.shield"
-                    )
                 }
             }
         }
         .formStyle(.grouped)
         .onAppear { permissionManager.startMonitoring() }
         .onDisappear { permissionManager.stopMonitoring() }
+    }
+
+    /// Both click rows offer the same three outcomes, at a width that fits the
+    /// longest of them without stretching across the row.
+    private func resultPicker(selection: Binding<String>, label: LocalizedStringKey) -> some View {
+        Picker("", selection: selection) {
+            ForEach(ResultDeliveryPreference.allCases, id: \.self) { pref in
+                Text(LocalizedStringKey(pref.rawValue.capitalized)).tag(pref.rawValue)
+            }
+        }
+        .labelsHidden()
+        .pickerStyle(.segmented)
+        .frame(width: 230)
+        .accessibilityLabel(label)
     }
 }

--- a/Sources/OpenClip/UI/Preferences/GeneralTabView.swift
+++ b/Sources/OpenClip/UI/Preferences/GeneralTabView.swift
@@ -3,6 +3,10 @@
 //
 // The General preferences tab: app enable and menu bar toggles, trigger hotkey,
 // start-at-login, and system-permission status. Split out of PreferencesView.swift.
+//
+// Rows are stock grouped-`Form` controls: the system draws the card, the row
+// metrics and the label/control split, so the tab tracks System Settings across
+// appearance and accent changes without any local styling.
 import SwiftUI
 import Core
 import KeyboardShortcuts
@@ -29,216 +33,121 @@ struct GeneralTab: View {
     
     var body: some View {
         Form {
-            Section(header: Text("General Controls")) {
-                // Row 1: Appear Automatically
-                HStack {
-                    HStack(spacing: 12) {
-                        Image(systemName: "cursorarrow")
-                            .font(.system(size: 16))
-                            .foregroundColor(isAppEnabled ? .accentColor : .secondary)
-                            .frame(width: 22, alignment: .center)
-                        
-                        Text("Appear Automatically")
-                            .font(.body)
-                            .fontWeight(.medium)
-                    }
-                    Spacer()
-                    Toggle("", isOn: $isAppEnabled)
-                        .labelsHidden()
-                        .accessibilityLabel("Appear Automatically")
-                        .onChange(of: isAppEnabled) { _, newValue in
-                            DefaultSettingsStore.shared.set(.isAppEnabled, value: newValue)
-                            NotificationCenter.default.post(name: Notification.Name("OpenClipEnabledStateChanged"), object: newValue)
-                        }
-                        .onReceive(NotificationCenter.default.publisher(for: Notification.Name("OpenClipEnabledStateChanged"))) { notification in
-                            isAppEnabled = (notification.object as? Bool) ?? DefaultSettingsStore.shared.get(.isAppEnabled)
-                        }
+            Section {
+                Toggle(isOn: $isAppEnabled) {
+                    SettingsRowLabel(
+                        title: "Appear Automatically",
+                        subtitle: "Show the popup as soon as text is selected.",
+                        systemImage: "cursorarrow"
+                    )
                 }
-                .padding(.vertical, 4)
-                
-                // Row 2: Menu Bar Icon
-                HStack {
-                    HStack(spacing: 12) {
-                        Image(systemName: "menubar.rectangle")
-                            .font(.system(size: 16))
-                            .foregroundColor(showMenuBarIcon ? .accentColor : .secondary)
-                            .frame(width: 22, alignment: .center)
-
-                        Text("Show Menu Bar Icon")
-                            .font(.body)
-                            .fontWeight(.medium)
-                    }
-                    Spacer()
-                    Toggle("", isOn: $showMenuBarIcon)
-                        .labelsHidden()
-                        .accessibilityLabel("Show Menu Bar Icon")
-                        .onChange(of: showMenuBarIcon) { _, newValue in
-                            DefaultSettingsStore.shared.set(.showMenuBarIcon, value: newValue)
-                            NotificationCenter.default.post(
-                                name: .openClipMenuBarVisibilityChanged,
-                                object: newValue
-                            )
-                        }
+                .onChange(of: isAppEnabled) { _, newValue in
+                    DefaultSettingsStore.shared.set(.isAppEnabled, value: newValue)
+                    NotificationCenter.default.post(name: Notification.Name("OpenClipEnabledStateChanged"), object: newValue)
                 }
-                .padding(.vertical, 4)
+                .onReceive(NotificationCenter.default.publisher(for: Notification.Name("OpenClipEnabledStateChanged"))) { notification in
+                    isAppEnabled = (notification.object as? Bool) ?? DefaultSettingsStore.shared.get(.isAppEnabled)
+                }
 
-                // Row 3: Trigger Shortcut
-                HStack {
-                    HStack(spacing: 12) {
-                        Image(systemName: "keyboard")
-                            .font(.system(size: 16))
-                            .foregroundColor(.accentColor)
-                            .frame(width: 22, alignment: .center)
-                        
-                        Text("Trigger Popup Shortcut")
-                            .font(.body)
-                            .fontWeight(.medium)
-                    }
-                    Spacer()
+                Toggle(isOn: $isMouseHoldEnabled) {
+                    SettingsRowLabel(
+                        title: "Hold Mouse to Trigger",
+                        subtitle: "Keep the button down after selecting to summon the popup.",
+                        systemImage: "hand.tap"
+                    )
+                }
+                .onChange(of: isMouseHoldEnabled) { _, newValue in
+                    DefaultSettingsStore.shared.set(.isMouseHoldEnabled, value: newValue)
+                }
+
+                LabeledContent {
                     KeyboardShortcuts.Recorder(for: .togglePopup)
+                } label: {
+                    SettingsRowLabel(title: "Trigger Popup Shortcut", systemImage: "keyboard")
                 }
-                .padding(.vertical, 4)
 
-                // Row 4: Hold Mouse to Trigger
-                HStack {
-                    HStack(spacing: 12) {
-                        Image(systemName: "hand.tap")
-                            .font(.system(size: 16))
-                            .foregroundColor(isMouseHoldEnabled ? .accentColor : .secondary)
-                            .frame(width: 22, alignment: .center)
-                        
-                        Text("Hold Mouse to Trigger")
-                            .font(.body)
-                            .fontWeight(.medium)
-                    }
-                    Spacer()
-                    Toggle("", isOn: $isMouseHoldEnabled)
-                        .labelsHidden()
-                        .accessibilityLabel("Hold Mouse to Trigger")
-                        .onChange(of: isMouseHoldEnabled) { _, newValue in
-                            DefaultSettingsStore.shared.set(.isMouseHoldEnabled, value: newValue)
-                        }
+                Toggle(isOn: $showMenuBarIcon) {
+                    SettingsRowLabel(title: "Show Menu Bar Icon", systemImage: "menubar.rectangle")
                 }
-                .padding(.vertical, 4)
-                
-                // Row 5: Start at Login
-                HStack {
-                    HStack(spacing: 12) {
-                        Image(systemName: "arrow.clockwise.circle")
-                            .font(.system(size: 16))
-                            .foregroundColor(.accentColor)
-                            .frame(width: 22, alignment: .center)
-                        
-                        Text("Start at Login")
-                            .font(.body)
-                            .fontWeight(.medium)
-                    }
-                    Spacer()
-                    Toggle("", isOn: $launchManager.isEnabled)
-                        .labelsHidden()
-                        .accessibilityLabel("Start at Login")
+                .onChange(of: showMenuBarIcon) { _, newValue in
+                    DefaultSettingsStore.shared.set(.showMenuBarIcon, value: newValue)
+                    NotificationCenter.default.post(
+                        name: .openClipMenuBarVisibilityChanged,
+                        object: newValue
+                    )
                 }
-                .padding(.vertical, 4)
+
+                Toggle(isOn: $launchManager.isEnabled) {
+                    SettingsRowLabel(title: "Start at Login", systemImage: "arrow.clockwise.circle")
+                }
             }
 
-            Section(header: Text("Action Results")) {
-                HStack {
-                    VStack(alignment: .leading, spacing: 1) {
-                        Text("Primary click")
-                            .font(.body)
-                            .fontWeight(.medium)
-                        Text("Left click")
-                            .font(.caption)
-                            .foregroundColor(.secondary)
+            Section("Action Results") {
+                Picker(selection: $primaryBehavior) {
+                    ForEach(ResultDeliveryPreference.allCases, id: \.self) { pref in
+                        Text(LocalizedStringKey(pref.rawValue.capitalized)).tag(pref.rawValue)
                     }
-                    Spacer()
-                    Picker("Primary click", selection: $primaryBehavior) {
-                        ForEach(ResultDeliveryPreference.allCases, id: \.self) { pref in
-                            Text(LocalizedStringKey(pref.rawValue.capitalized)).tag(pref.rawValue)
-                        }
-                    }
-                    .labelsHidden()
-                    .pickerStyle(.segmented)
-                    .frame(width: 220)
-                    .onChange(of: primaryBehavior) { _, newValue in
-                        DefaultSettingsStore.shared.set(.primaryClickBehavior, value: newValue)
-                    }
+                } label: {
+                    SettingsRowLabel(
+                        title: "Primary click",
+                        subtitle: "Left click",
+                        systemImage: "cursorarrow.click"
+                    )
                 }
-                .padding(.vertical, 4)
+                .pickerStyle(.segmented)
+                .onChange(of: primaryBehavior) { _, newValue in
+                    DefaultSettingsStore.shared.set(.primaryClickBehavior, value: newValue)
+                }
 
-                HStack {
-                    VStack(alignment: .leading, spacing: 1) {
-                        Text("Secondary click")
-                            .font(.body)
-                            .fontWeight(.medium)
-                        Text("Right click or ⇧-click")
-                            .font(.caption)
-                            .foregroundColor(.secondary)
+                Picker(selection: $secondaryBehavior) {
+                    ForEach(ResultDeliveryPreference.allCases, id: \.self) { pref in
+                        Text(LocalizedStringKey(pref.rawValue.capitalized)).tag(pref.rawValue)
                     }
-                    Spacer()
-                    Picker("Secondary click", selection: $secondaryBehavior) {
-                        ForEach(ResultDeliveryPreference.allCases, id: \.self) { pref in
-                            Text(LocalizedStringKey(pref.rawValue.capitalized)).tag(pref.rawValue)
-                        }
-                    }
-                    .labelsHidden()
-                    .pickerStyle(.segmented)
-                    .frame(width: 220)
-                    .onChange(of: secondaryBehavior) { _, newValue in
-                        DefaultSettingsStore.shared.set(.secondaryClickBehavior, value: newValue)
-                    }
+                } label: {
+                    SettingsRowLabel(
+                        title: "Secondary click",
+                        subtitle: "Right click or ⇧-click",
+                        systemImage: "cursorarrow.click.2"
+                    )
                 }
-                .padding(.vertical, 4)
+                .pickerStyle(.segmented)
+                .onChange(of: secondaryBehavior) { _, newValue in
+                    DefaultSettingsStore.shared.set(.secondaryClickBehavior, value: newValue)
+                }
             }
 
-            Section(header: Text("System Permissions")) {
-                // Row 4: Accessibility Access
-                HStack {
-                    HStack(spacing: 12) {
-                        Image(systemName: "lock.shield")
-                            .font(.system(size: 16))
-                            .foregroundColor(permissionManager.isAccessibilityGranted ? .green : .orange)
-                            .frame(width: 22, alignment: .center)
-                        
-                        Text("Accessibility Access")
-                            .font(.body)
-                            .fontWeight(.medium)
-                    }
-                    
-                    Spacer()
-                    
+            Section("System Permissions") {
+                LabeledContent {
                     HStack(spacing: 10) {
-                        HStack(spacing: 5) {
-                            Image(systemName: permissionManager.isAccessibilityGranted ? "checkmark.circle.fill" : "exclamationmark.triangle.fill")
-                                .font(.caption)
-                            Text(permissionManager.isAccessibilityGranted ? String(localized: "Granted") : String(localized: "Access Required"))
-                                .font(.caption)
-                                .fontWeight(.semibold)
+                        Label {
+                            Text(permissionManager.isAccessibilityGranted
+                                 ? String(localized: "Granted")
+                                 : String(localized: "Access Required"))
+                        } icon: {
+                            Image(systemName: permissionManager.isAccessibilityGranted
+                                  ? "checkmark.circle.fill"
+                                  : "exclamationmark.triangle.fill")
                         }
-                        .foregroundColor(permissionManager.isAccessibilityGranted ? .green : .orange)
-                        .padding(.horizontal, 9)
-                        .padding(.vertical, 4)
-                        .background(
-                            Capsule()
-                                .fill((permissionManager.isAccessibilityGranted ? Color.green : Color.orange).opacity(0.15))
-                        )
-                        
+                        .font(.callout)
+                        .foregroundStyle(permissionManager.isAccessibilityGranted ? Color.green : Color.orange)
+
                         Button("Open Settings") {
                             // Only proactively reset stale TCC when permission is missing.
                             // Resetting while already granted would revoke the active entry.
                             let shouldReset = !permissionManager.isAccessibilityGranted
                             permissionManager.requestAccessibilityPermission(proactivelyResetStaleTCC: shouldReset)
                         }
-                        .buttonStyle(.bordered)
-                        .controlSize(.small)
                     }
+                } label: {
+                    SettingsRowLabel(
+                        title: "Accessibility Access",
+                        subtitle: "Required to read the selected text.",
+                        systemImage: "lock.shield"
+                    )
                 }
-                .padding(.vertical, 4)
             }
         }
         .formStyle(.grouped)
-        .scrollContentBackground(.hidden)
-        .padding(.horizontal, 12)
         .onAppear { permissionManager.startMonitoring() }
         .onDisappear { permissionManager.stopMonitoring() }
     }

--- a/Sources/OpenClip/UI/Preferences/IconPickerView.swift
+++ b/Sources/OpenClip/UI/Preferences/IconPickerView.swift
@@ -101,20 +101,12 @@ public struct IconPickerView: View {
             }()
 
             VStack(alignment: .leading, spacing: 6) {
-                HStack {
-                    Image(systemName: "magnifyingglass").foregroundColor(.secondary).font(.caption)
-                    TextField("Search SF Symbols…", text: $searchText)
-                        .textFieldStyle(.plain)
-                        .font(.caption)
-                    if !searchText.isEmpty {
-                        Button { searchText = "" } label: {
-                            Image(systemName: "xmark.circle.fill").foregroundColor(.secondary)
-                        }.buttonStyle(.plain)
-                    }
-                }
-                .padding(5)
-                .background(Color.primary.opacity(0.04))
-                .cornerRadius(5)
+                NativeSearchField(
+                    text: $searchText,
+                    placeholder: String(localized: "Search SF Symbols…"),
+                    controlSize: .small
+                )
+                .frame(height: 20)
 
                 ScrollView {
                     LazyVGrid(columns: Array(repeating: GridItem(.flexible(), spacing: 4), count: 8), spacing: 4) {
@@ -142,26 +134,20 @@ public struct IconPickerView: View {
     private var openSourceTab: some View {
         VStack(alignment: .leading, spacing: 6) {
             // Search field - fires Iconify query only when Enter is pressed
-            HStack {
-                Image(systemName: "magnifyingglass").foregroundColor(.secondary).font(.caption)
-                TextField("Search Iconify (press Enter)…", text: $searchText)
-                    .textFieldStyle(.plain)
-                    .font(.caption)
-                    .onSubmit {
-                        submittedQuery = searchText.trimmingCharacters(in: .whitespacesAndNewlines)
-                        provider.search(query: submittedQuery)
-                    }
+            HStack(spacing: 6) {
+                NativeSearchField(
+                    text: $searchText,
+                    placeholder: String(localized: "Search Iconify (press Enter)…"),
+                    controlSize: .small
+                ) { query in
+                    submittedQuery = query.trimmingCharacters(in: .whitespacesAndNewlines)
+                    provider.search(query: submittedQuery)
+                }
+                .frame(height: 20)
                 if provider.isSearching {
                     ProgressView().controlSize(.mini)
-                } else if !searchText.isEmpty {
-                    Button { searchText = ""; submittedQuery = "" } label: {
-                        Image(systemName: "xmark.circle.fill").foregroundColor(.secondary)
-                    }.buttonStyle(.plain)
                 }
             }
-            .padding(5)
-            .background(Color.primary.opacity(0.04))
-            .cornerRadius(5)
 
             if submittedQuery.isEmpty {
                 VStack(spacing: 6) {

--- a/Sources/OpenClip/UI/Preferences/IconPickerView.swift
+++ b/Sources/OpenClip/UI/Preferences/IconPickerView.swift
@@ -140,8 +140,16 @@ public struct IconPickerView: View {
                     placeholder: String(localized: "Search Iconify (press Enter)…"),
                     controlSize: .small
                 ) { query in
-                    submittedQuery = query.trimmingCharacters(in: .whitespacesAndNewlines)
-                    provider.search(query: submittedQuery)
+                    let trimmed = query.trimmingCharacters(in: .whitespacesAndNewlines)
+                    submittedQuery = trimmed
+                    if !trimmed.isEmpty {
+                        provider.search(query: trimmed)
+                    }
+                }
+                .onChange(of: searchText) { _, newValue in
+                    if newValue.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+                        submittedQuery = ""
+                    }
                 }
                 .frame(height: 20)
                 if provider.isSearching {

--- a/Sources/OpenClip/UI/Preferences/PreferencesToolbar.swift
+++ b/Sources/OpenClip/UI/Preferences/PreferencesToolbar.swift
@@ -9,10 +9,10 @@
 // of the full-height sidebar on the way between tabs. Here the toolbar is
 // created once with a fixed set of items and only their contents change, so the
 // title bar's geometry is the same on every pane. It also gets the store a real
-// NSSearchToolbarItem, which is the system search field a SwiftUI toolbar item
-// could not give it.
+// AppKit search field, which is what a SwiftUI toolbar item could not give it.
 import AppKit
 import Combine
+import Core
 
 public enum PreferencesToolbarAction: Sendable {
     case newGroup
@@ -39,21 +39,34 @@ public final class PreferencesToolbarModel: ObservableObject {
 @MainActor
 public final class PreferencesToolbarController: NSObject, NSToolbarDelegate, NSSearchFieldDelegate {
     private enum ItemID {
-        /// Filter and search share one item. As two, the toolbar was free to
-        /// decide only one of them fit and push the other into the overflow
-        /// menu; as one view they are measured, shown and hidden together.
-        static let storeControls = NSToolbarItem.Identifier("openclip.preferences.storeControls")
+        /// The pane's name as a toolbar item rather than the window's own title:
+        /// a unified toolbar reserves a title area of its own choosing, which
+        /// left a wide gap between "Store" and the first control.
+        static let title = NSToolbarItem.Identifier("openclip.preferences.title")
+        static let filter = NSToolbarItem.Identifier("openclip.preferences.filter")
+        static let search = NSToolbarItem.Identifier("openclip.preferences.search")
         static let action = NSToolbarItem.Identifier("openclip.preferences.action")
     }
 
     private let model: PreferencesToolbarModel
     private var cancellables: Set<AnyCancellable> = []
-    /// Set by whoever opens the window, so the title can follow the pane.
+    /// Set by whoever opens the window. The pane name is drawn by the title item
+    /// below, not by the window: `titleVisibility = .hidden` is ignored by a
+    /// unified toolbar on macOS 26, so a window with a title ended up showing the
+    /// pane's name twice.
     public weak var window: NSWindow? {
-        didSet { window?.title = model.tab.windowTitle }
+        didSet {
+            // Once the content view has a split view the toolbar can be told
+            // where the sidebar ends.
+            installSidebarTrackingSeparator(retriesLeft: 20)
+        }
     }
 
-    private weak var storeControlsItem: NSToolbarItem?
+    private weak var trackingSplitView: NSSplitView?
+
+    private weak var titleLabel: NSTextField?
+    private weak var filterItem: NSToolbarItem?
+    private weak var searchItem: NSToolbarItem?
     private weak var actionItem: NSToolbarItem?
     private weak var filterControl: NSSegmentedControl?
     private weak var searchField: NSSearchField?
@@ -99,8 +112,10 @@ public final class PreferencesToolbarController: NSObject, NSToolbarDelegate, NS
     // MARK: - Item contents per tab
 
     private func sync(tab: PreferenceTab) {
-        window?.title = tab.windowTitle
-        setHidden(storeControlsItem, tab != .store)
+        titleLabel?.stringValue = tab.windowTitle
+        let showsStoreControls = (tab == .store)
+        setHidden(filterItem, !showsStoreControls)
+        setHidden(searchItem, !showsStoreControls)
 
         switch tab {
         case .actions:
@@ -188,11 +203,49 @@ public final class PreferencesToolbarController: NSObject, NSToolbarDelegate, NS
         // space between them. Centring the filter with a leading flexible space
         // spent the width twice and pushed the search field into the overflow
         // menu at the window's minimum size.
-        [ItemID.storeControls, .flexibleSpace, ItemID.action]
+        // Pane name, filter beside it, then everything else pinned right: the
+        // pane's button, with the search field last against the window edge.
+        [ItemID.title, ItemID.filter, .flexibleSpace, ItemID.action, ItemID.search]
     }
 
     public func toolbarAllowedItemIdentifiers(_ toolbar: NSToolbar) -> [NSToolbarItem.Identifier] {
-        toolbarDefaultItemIdentifiers(toolbar)
+        [.sidebarTrackingSeparator] + toolbarDefaultItemIdentifiers(toolbar)
+    }
+
+    /// Without this the toolbar has no idea where the sidebar ends, so it lines
+    /// its items up against the right edge instead of the content area's left
+    /// one. The separator tracks the split view's first divider, which is what
+    /// gives the leading items something to start from.
+    private func installSidebarTrackingSeparator(retriesLeft: Int) {
+        guard let toolbar = window?.toolbar,
+              !toolbar.items.contains(where: { $0.itemIdentifier == .sidebarTrackingSeparator }) else { return }
+        // SwiftUI builds NavigationSplitView's NSSplitView on its first layout
+        // pass, which is later than the window gaining a toolbar. One shot at
+        // this found nothing and left the toolbar with no leading anchor, so
+        // every item ended up packed against the right edge; keep looking for a
+        // few run loop turns instead.
+        guard let contentView = window?.contentView,
+              let splitView = Self.firstSplitView(in: contentView),
+              splitView.arrangedSubviews.count > 1 else {
+            guard retriesLeft > 0 else {
+                Log.chrome.error("Preferences toolbar found no split view to track; items will right-align")
+                return
+            }
+            DispatchQueue.main.async { [weak self] in
+                self?.installSidebarTrackingSeparator(retriesLeft: retriesLeft - 1)
+            }
+            return
+        }
+        trackingSplitView = splitView
+        toolbar.insertItem(withItemIdentifier: .sidebarTrackingSeparator, at: 0)
+    }
+
+    private static func firstSplitView(in view: NSView) -> NSSplitView? {
+        if let splitView = view as? NSSplitView { return splitView }
+        for subview in view.subviews {
+            if let found = firstSplitView(in: subview) { return found }
+        }
+        return nil
     }
 
     public func toolbar(
@@ -201,7 +254,33 @@ public final class PreferencesToolbarController: NSObject, NSToolbarDelegate, NS
         willBeInsertedIntoToolbar flag: Bool
     ) -> NSToolbarItem? {
         switch itemIdentifier {
-        case ItemID.storeControls:
+        case .sidebarTrackingSeparator:
+            guard let splitView = trackingSplitView else { return nil }
+            return NSTrackingSeparatorToolbarItem(
+                identifier: itemIdentifier,
+                splitView: splitView,
+                dividerIndex: 0
+            )
+
+        case ItemID.title:
+            let label = NSTextField(labelWithString: model.tab.windowTitle)
+            label.font = .systemFont(ofSize: 15, weight: .bold)
+            label.textColor = .labelColor
+            label.lineBreakMode = .byTruncatingTail
+
+            let item = NSToolbarItem(itemIdentifier: itemIdentifier)
+            item.view = label
+            item.label = ""
+            item.visibilityPriority = .high
+            // Navigational, like a back button: it is what pins the item to the
+            // leading edge of the content area. Without it the toolbar re-lays
+            // itself out on the first pane change and packs every item against
+            // the window's right edge, flexible space and all.
+            item.isNavigational = true
+            titleLabel = label
+            return item
+
+        case ItemID.filter:
             let control = NSSegmentedControl(
                 labels: StoreFilter.allCases.map(\.title),
                 trackingMode: .selectOne,
@@ -209,31 +288,46 @@ public final class PreferencesToolbarController: NSObject, NSToolbarDelegate, NS
                 action: #selector(filterChanged(_:))
             )
             control.segmentStyle = .automatic
-            control.segmentDistribution = .fillEqually
-            for index in 0..<control.segmentCount {
-                control.setWidth(66, forSegment: index)
-            }
+            // Each segment as wide as its own label, sized into a real frame: an
+            // equal-width control spends more room than the labels need, and the
+            // toolbar answers a set of items too wide for the window by dropping
+            // the trailing ones into the overflow menu. Constraints are no good
+            // here either — a constrained view has no size for the toolbar to
+            // measure.
+            control.segmentDistribution = .fit
+            control.sizeToFit()
             control.selectedSegment = StoreFilter.allCases.firstIndex(of: model.storeFilter) ?? 0
 
-            let field = NSSearchField()
-            field.delegate = self
-            field.placeholderString = String(localized: "Search extensions")
-            field.stringValue = model.searchQuery
-            field.translatesAutoresizingMaskIntoConstraints = false
-            field.widthAnchor.constraint(equalToConstant: 170).isActive = true
+            let item = NSToolbarItem(itemIdentifier: itemIdentifier)
+            item.view = control
+            item.label = String(localized: "Filter")
+            item.visibilityPriority = .high
+            // Leading edge, beside the pane name — see the title item above.
+            item.isNavigational = true
+            filterControl = control
+            filterItem = item
+            setHidden(item, model.tab != .store)
+            return item
 
-            let stack = NSStackView(views: [control, field])
-            stack.orientation = .horizontal
-            stack.alignment = .centerY
-            stack.spacing = 10
+        case ItemID.search:
+            // A plain item around an NSSearchField rather than NSSearchToolbarItem:
+            // the system item collapses to a magnifying glass at this window's
+            // width and, on the click that expands it again, takes enough room to
+            // push the filter into the overflow menu — so the field opened in the
+            // middle of the toolbar with the segments gone. A field that is always
+            // its full width never moves.
+            let field = NSSearchField(frame: NSRect(x: 0, y: 0, width: 160, height: 28))
+            field.delegate = self
+            field.bezelStyle = .roundedBezel
+            field.placeholderString = String(localized: "Search")
+            field.stringValue = model.searchQuery
 
             let item = NSToolbarItem(itemIdentifier: itemIdentifier)
-            item.view = stack
-            item.label = String(localized: "Extensions")
+            item.view = field
+            item.label = String(localized: "Search")
             item.visibilityPriority = .high
-            filterControl = control
             searchField = field
-            storeControlsItem = item
+            searchItem = item
             setHidden(item, model.tab != .store)
             return item
 

--- a/Sources/OpenClip/UI/Preferences/PreferencesToolbar.swift
+++ b/Sources/OpenClip/UI/Preferences/PreferencesToolbar.swift
@@ -1,0 +1,261 @@
+// PreferencesToolbar.swift
+// OpenClip
+//
+// The preferences window's toolbar, owned by AppKit rather than by SwiftUI.
+//
+// SwiftUI builds the window's NSToolbar from whatever `.toolbar` publishes and
+// tears it down again when a pane publishes nothing, and every rebuild makes
+// the title bar re-measure — which is what kept knocking the traffic lights out
+// of the full-height sidebar on the way between tabs. Here the toolbar is
+// created once with a fixed set of items and only their contents change, so the
+// title bar's geometry is the same on every pane. It also gets the store a real
+// NSSearchToolbarItem, which is the system search field a SwiftUI toolbar item
+// could not give it.
+import AppKit
+import Combine
+
+public enum PreferencesToolbarAction: Sendable {
+    case newGroup
+    case addCustomAction
+    case installExtension
+    case addApplication
+    case refresh
+}
+
+/// The bridge between the SwiftUI panes and the AppKit toolbar.
+@MainActor
+public final class PreferencesToolbarModel: ObservableObject {
+    @Published public var tab: PreferenceTab = .general
+    @Published public var storeFilter: StoreFilter = .all
+    @Published public var searchQuery: String = ""
+    @Published public var isRefreshing: Bool = false
+
+    /// Toolbar button presses, forwarded to whichever pane acts on them.
+    public let actions = PassthroughSubject<PreferencesToolbarAction, Never>()
+
+    public init() {}
+}
+
+@MainActor
+public final class PreferencesToolbarController: NSObject, NSToolbarDelegate, NSSearchFieldDelegate {
+    private enum ItemID {
+        /// Filter and search share one item. As two, the toolbar was free to
+        /// decide only one of them fit and push the other into the overflow
+        /// menu; as one view they are measured, shown and hidden together.
+        static let storeControls = NSToolbarItem.Identifier("openclip.preferences.storeControls")
+        static let action = NSToolbarItem.Identifier("openclip.preferences.action")
+    }
+
+    private let model: PreferencesToolbarModel
+    private var cancellables: Set<AnyCancellable> = []
+    /// Set by whoever opens the window, so the title can follow the pane.
+    public weak var window: NSWindow? {
+        didSet { window?.title = model.tab.windowTitle }
+    }
+
+    private weak var storeControlsItem: NSToolbarItem?
+    private weak var actionItem: NSToolbarItem?
+    private weak var filterControl: NSSegmentedControl?
+    private weak var searchField: NSSearchField?
+    private weak var actionButton: NSButton?
+
+    public init(model: PreferencesToolbarModel) {
+        self.model = model
+        super.init()
+
+        model.$tab
+            .sink { [weak self] tab in self?.sync(tab: tab) }
+            .store(in: &cancellables)
+
+        model.$storeFilter
+            .sink { [weak self] filter in
+                self?.filterControl?.selectedSegment = StoreFilter.allCases.firstIndex(of: filter) ?? 0
+            }
+            .store(in: &cancellables)
+
+        model.$searchQuery
+            .sink { [weak self] query in
+                guard let field = self?.searchField, field.stringValue != query else { return }
+                field.stringValue = query
+            }
+            .store(in: &cancellables)
+
+        model.$isRefreshing
+            .sink { [weak self] isRefreshing in
+                self?.actionButton?.isEnabled = !(isRefreshing && self?.model.tab == .store)
+            }
+            .store(in: &cancellables)
+    }
+
+    public func makeToolbar() -> NSToolbar {
+        let toolbar = NSToolbar(identifier: "OpenClipPreferencesToolbar")
+        toolbar.delegate = self
+        toolbar.displayMode = .iconOnly
+        toolbar.allowsUserCustomization = false
+        toolbar.showsBaselineSeparator = false
+        return toolbar
+    }
+
+    // MARK: - Item contents per tab
+
+    private func sync(tab: PreferenceTab) {
+        window?.title = tab.windowTitle
+        setHidden(storeControlsItem, tab != .store)
+
+        switch tab {
+        case .actions:
+            configureActionButton(symbol: "plus", tooltip: String(localized: "Add Action or Group"))
+        case .appRules:
+            configureActionButton(symbol: "plus", tooltip: String(localized: "Add Application"))
+        case .store:
+            configureActionButton(symbol: "arrow.clockwise", tooltip: String(localized: "Refresh Catalog"))
+        default:
+            setHidden(actionItem, true)
+        }
+    }
+
+    /// Hides the whole item, not just its control: an item left in place still
+    /// gets its own glass backing drawn, which showed up as an empty pane of
+    /// material on the tabs with no toolbar controls.
+    private func setHidden(_ item: NSToolbarItem?, _ hidden: Bool) {
+        guard let item else { return }
+        if #available(macOS 15.0, *) {
+            item.isHidden = hidden
+        } else {
+            item.view?.isHidden = hidden
+        }
+    }
+
+    private func configureActionButton(symbol: String, tooltip: String) {
+        guard let button = actionButton else { return }
+        button.image = NSImage(systemSymbolName: symbol, accessibilityDescription: tooltip)
+        button.toolTip = tooltip
+        button.isEnabled = true
+        setHidden(actionItem, false)
+        actionItem?.toolTip = tooltip
+    }
+
+    // MARK: - Actions
+
+    @objc private func actionButtonPressed(_ sender: NSButton) {
+        switch model.tab {
+        case .actions:
+            // The Actions tab's button offers three ways to add, so it drops a
+            // menu rather than firing one action.
+            let menu = NSMenu()
+            menu.addItem(menuItem(String(localized: "New Group"), symbol: "folder.badge.plus", action: #selector(menuNewGroup)))
+            menu.addItem(menuItem(String(localized: "Add Custom Action"), symbol: "plus.circle", action: #selector(menuAddCustomAction)))
+            menu.addItem(menuItem(String(localized: "Install Extension…"), symbol: "square.and.arrow.down", action: #selector(menuInstallExtension)))
+            menu.popUp(positioning: nil, at: NSPoint(x: 0, y: sender.bounds.height + 4), in: sender)
+        case .appRules:
+            model.actions.send(.addApplication)
+        case .store:
+            model.actions.send(.refresh)
+        default:
+            break
+        }
+    }
+
+    private func menuItem(_ title: String, symbol: String, action: Selector) -> NSMenuItem {
+        let item = NSMenuItem(title: title, action: action, keyEquivalent: "")
+        item.target = self
+        item.image = NSImage(systemSymbolName: symbol, accessibilityDescription: nil)
+        return item
+    }
+
+    @objc private func menuNewGroup() { model.actions.send(.newGroup) }
+    @objc private func menuAddCustomAction() { model.actions.send(.addCustomAction) }
+    @objc private func menuInstallExtension() { model.actions.send(.installExtension) }
+
+    @objc private func filterChanged(_ sender: NSSegmentedControl) {
+        let filters = StoreFilter.allCases
+        guard filters.indices.contains(sender.selectedSegment) else { return }
+        if !model.searchQuery.trimmingCharacters(in: .whitespaces).isEmpty {
+            model.searchQuery = ""
+        }
+        model.storeFilter = filters[sender.selectedSegment]
+    }
+
+    public func controlTextDidChange(_ notification: Notification) {
+        guard let field = notification.object as? NSSearchField else { return }
+        model.searchQuery = field.stringValue
+    }
+
+    // MARK: - NSToolbarDelegate
+
+    public func toolbarDefaultItemIdentifiers(_ toolbar: NSToolbar) -> [NSToolbarItem.Identifier] {
+        // Filter hard left of the content area, search hard right, one flexible
+        // space between them. Centring the filter with a leading flexible space
+        // spent the width twice and pushed the search field into the overflow
+        // menu at the window's minimum size.
+        [ItemID.storeControls, .flexibleSpace, ItemID.action]
+    }
+
+    public func toolbarAllowedItemIdentifiers(_ toolbar: NSToolbar) -> [NSToolbarItem.Identifier] {
+        toolbarDefaultItemIdentifiers(toolbar)
+    }
+
+    public func toolbar(
+        _ toolbar: NSToolbar,
+        itemForItemIdentifier itemIdentifier: NSToolbarItem.Identifier,
+        willBeInsertedIntoToolbar flag: Bool
+    ) -> NSToolbarItem? {
+        switch itemIdentifier {
+        case ItemID.storeControls:
+            let control = NSSegmentedControl(
+                labels: StoreFilter.allCases.map(\.title),
+                trackingMode: .selectOne,
+                target: self,
+                action: #selector(filterChanged(_:))
+            )
+            control.segmentStyle = .automatic
+            control.segmentDistribution = .fillEqually
+            for index in 0..<control.segmentCount {
+                control.setWidth(66, forSegment: index)
+            }
+            control.selectedSegment = StoreFilter.allCases.firstIndex(of: model.storeFilter) ?? 0
+
+            let field = NSSearchField()
+            field.delegate = self
+            field.placeholderString = String(localized: "Search extensions")
+            field.stringValue = model.searchQuery
+            field.translatesAutoresizingMaskIntoConstraints = false
+            field.widthAnchor.constraint(equalToConstant: 170).isActive = true
+
+            let stack = NSStackView(views: [control, field])
+            stack.orientation = .horizontal
+            stack.alignment = .centerY
+            stack.spacing = 10
+
+            let item = NSToolbarItem(itemIdentifier: itemIdentifier)
+            item.view = stack
+            item.label = String(localized: "Extensions")
+            item.visibilityPriority = .high
+            filterControl = control
+            searchField = field
+            storeControlsItem = item
+            setHidden(item, model.tab != .store)
+            return item
+
+        case ItemID.action:
+            let button = NSButton(
+                image: NSImage(systemSymbolName: "plus", accessibilityDescription: nil) ?? NSImage(),
+                target: self,
+                action: #selector(actionButtonPressed(_:))
+            )
+            button.bezelStyle = .toolbar
+
+            let item = NSToolbarItem(itemIdentifier: itemIdentifier)
+            item.view = button
+            item.label = String(localized: "Add")
+            item.visibilityPriority = .high
+            actionButton = button
+            actionItem = item
+            sync(tab: model.tab)
+            return item
+
+        default:
+            return nil
+        }
+    }
+}

--- a/Sources/OpenClip/UI/Preferences/PreferencesToolbar.swift
+++ b/Sources/OpenClip/UI/Preferences/PreferencesToolbar.swift
@@ -59,6 +59,7 @@ public final class PreferencesToolbarController: NSObject, NSToolbarDelegate, NS
             // Once the content view has a split view the toolbar can be told
             // where the sidebar ends.
             installSidebarTrackingSeparator(retriesLeft: 20)
+            window?.setAccessibilityTitle(model.tab.windowTitle)
         }
     }
 
@@ -113,6 +114,7 @@ public final class PreferencesToolbarController: NSObject, NSToolbarDelegate, NS
 
     private func sync(tab: PreferenceTab) {
         titleLabel?.stringValue = tab.windowTitle
+        window?.setAccessibilityTitle(tab.windowTitle)
         let showsStoreControls = (tab == .store)
         setHidden(filterItem, !showsStoreControls)
         setHidden(searchItem, !showsStoreControls)
@@ -145,7 +147,7 @@ public final class PreferencesToolbarController: NSObject, NSToolbarDelegate, NS
         guard let button = actionButton else { return }
         button.image = NSImage(systemSymbolName: symbol, accessibilityDescription: tooltip)
         button.toolTip = tooltip
-        button.isEnabled = true
+        button.isEnabled = !(model.tab == .store && model.isRefreshing)
         setHidden(actionItem, false)
         actionItem?.toolTip = tooltip
     }

--- a/Sources/OpenClip/UI/Preferences/PreferencesView.swift
+++ b/Sources/OpenClip/UI/Preferences/PreferencesView.swift
@@ -122,7 +122,12 @@ public struct PreferencesView: View {
             }
         }
         .onChange(of: toolbarModel.storeFilter) { _, filter in
+            guard storeViewModel.selectedFilter != filter else { return }
             storeViewModel.selectedFilter = filter
+        }
+        .onChange(of: storeViewModel.selectedFilter) { _, filter in
+            guard toolbarModel.storeFilter != filter else { return }
+            toolbarModel.storeFilter = filter
         }
         .onChange(of: toolbarModel.searchQuery) { _, query in
             guard storeViewModel.searchQuery != query else { return }

--- a/Sources/OpenClip/UI/Preferences/PreferencesView.swift
+++ b/Sources/OpenClip/UI/Preferences/PreferencesView.swift
@@ -2,6 +2,9 @@
 // OpenClip
 //
 // Renders the primary multi-tab preferences window interface for OpenClip.
+// The chrome is deliberately stock AppKit/SwiftUI — a sidebar `List` and a
+// system toolbar — so the window inherits System Settings' look, vibrancy and
+// dark-mode behaviour instead of re-implementing them.
 import SwiftUI
 import Core
 import KeyboardShortcuts
@@ -28,13 +31,25 @@ public enum PreferenceTab: String, CaseIterable, Hashable, Sendable {
         case .about: return "info.circle.fill"
         }
     }
+
+    /// Sidebar symbol tint, matching System Settings' coloured glyph tiles.
+    public var tint: Color {
+        switch self {
+        case .general: return .gray
+        case .appearance: return .pink
+        case .actions: return .orange
+        case .store: return .blue
+        case .appRules: return .indigo
+        case .about: return .teal
+        }
+    }
 }
 
 @MainActor
 public struct PreferencesView: View {
     /// Shared max content width for the detail area. Keeps Actions/Appearance
     /// compact and aligned with the window rather than stretching infinitely.
-    private static let detailContentMaxWidth: CGFloat = 480
+    private static let detailContentMaxWidth: CGFloat = 520
 
     @State private var disabledActionIDs: Set<String> = []
     @State private var disabledPackages: Set<String> = []
@@ -50,204 +65,16 @@ public struct PreferencesView: View {
     }
 
     public var body: some View {
-        HStack(spacing: 0) {
-            // Seamless Sidebar
-            VStack(alignment: .leading, spacing: 4) {
-                // Top spacing so the window traffic lights (close/minimize/expand)
-                // float seamlessly over the sidebar without covering the first tab item.
-                Spacer()
-                    .frame(height: 36)
-                
-                ForEach(PreferenceTab.allCases, id: \.self) { tab in
-                    Button(action: {
-                        selectedTab = tab
-                    }) {
-                        HStack(spacing: 10) {
-                            Image(systemName: tab.icon)
-                                .font(.system(size: 13, weight: .medium))
-                                .frame(width: 18)
-                            Text(tab.localizedTitle)
-                                .font(.system(size: 13, weight: .medium))
-                            Spacer()
-                        }
-                        .padding(.horizontal, 10)
-                        .padding(.vertical, 7)
-                        .foregroundColor(selectedTab == tab ? .white : .primary)
-                        .background(
-                            selectedTab == tab ?
-                            Color.accentColor : Color.clear
-                        )
-                        .cornerRadius(8)
-                        .contentShape(Rectangle())
-                    }
-                    .buttonStyle(.plain)
-                    .accessibilityLabel(tab.localizedTitle)
-                    .accessibilityAddTraits(selectedTab == tab ? [.isSelected] : [])
-                }
-                
-                Spacer()
-                
-                // Bottom footer icons (Help and GitHub - NO TEXT)
-                HStack(spacing: 14) {
-                    Button(action: {
-                        if let url = URL(string: "https://www.getopenclip.app/docs") {
-                            NSWorkspace.shared.open(url)
-                        }
-                    }) {
-                        Image(systemName: "questionmark.circle")
-                            .font(.system(size: 15))
-                            .foregroundColor(.primary)
-                    }
-                    .buttonStyle(.plain)
-                    .help("Documentation")
-                    .accessibilityLabel("Documentation")
-                    
-                    Button(action: {
-                        if let url = URL(string: "https://github.com/ganeshmshetty/openclip") {
-                            NSWorkspace.shared.open(url)
-                        }
-                    }) {
-                        Image(systemName: "chevron.left.forwardslash.chevron.right")
-                            .font(.system(size: 15))
-                            .foregroundColor(.primary)
-                    }
-                    .buttonStyle(.plain)
-                    .help("GitHub Repository")
-                    .accessibilityLabel("GitHub Repository")
-                    
-                    Spacer()
-                }
-                .padding(.horizontal, 12)
-                .padding(.bottom, 16)
-            }
-            .padding(.horizontal, 10)
-            .frame(width: 200)
-            .background(Color.primary.opacity(0.02))
-            
-            Divider()
-                .opacity(0.3)
-            
-            // Detail Area
-            VStack(alignment: .leading, spacing: 0) {
-                HStack(alignment: .center) {
-                    Text(selectedTab.localizedTitle)
-                        .font(.system(size: 20, weight: .bold))
-                    
-                    Spacer()
-
-                    if selectedTab == .actions {
-                        Menu {
-                            Button {
-                                showingCreateGroupSheet = true
-                            } label: {
-                                Label(String(localized: "New Group"), systemImage: "folder.badge.plus")
-                            }
-
-                            Button {
-                                showingAddActionSheet = true
-                            } label: {
-                                Label(String(localized: "Add Custom Action"), systemImage: "plus.circle")
-                            }
-
-                            Button {
-                                presentInstallExtensionPanel()
-                            } label: {
-                                Label(String(localized: "Install Extension…"), systemImage: "square.and.arrow.down")
-                            }
-                        } label: {
-                            Label(String(localized: "Add"), systemImage: "plus")
-                        }
-                        .menuStyle(.button)
-                        .help(String(localized: "Add Action or Group"))
-                    } else if selectedTab == .store {
-                        HStack(spacing: 8) {
-                            Button {
-                                Task {
-                                    await storeViewModel.refreshCatalog()
-                                }
-                            } label: {
-                                if storeViewModel.isLoading {
-                                    ProgressView()
-                                        .controlSize(.mini)
-                                        .frame(width: 24, height: 24)
-                                } else {
-                                    Image(systemName: "arrow.clockwise")
-                                        .font(.system(size: 11, weight: .medium))
-                                        .foregroundColor(.secondary)
-                                        .frame(width: 24, height: 24)
-                                }
-                            }
-                            .buttonStyle(.plain)
-                            .background(Color.primary.opacity(0.06))
-                            .cornerRadius(6)
-                            .contentShape(Rectangle())
-                            .disabled(storeViewModel.isLoading)
-                            .help(String(localized: "Refresh Catalog"))
-                            .accessibilityLabel(String(localized: "Refresh Catalog"))
-
-                            HStack(spacing: 6) {
-                                Image(systemName: "magnifyingglass")
-                                    .foregroundColor(.secondary)
-                                    .font(.system(size: 12))
-                                TextField(String(localized: "Search extensions..."), text: $storeViewModel.searchQuery)
-                                    .textFieldStyle(.plain)
-                                    .font(.system(size: 12))
-                                    .onChange(of: storeViewModel.searchQuery) { _, _ in
-                                        storeViewModel.queryDidChange()
-                                    }
-                                if storeViewModel.isLoading && !storeViewModel.extensions.isEmpty {
-                                    ProgressView()
-                                        .controlSize(.small)
-                                        .scaleEffect(0.65)
-                                        .frame(width: 14, height: 14)
-                                }
-                            }
-                            .padding(.horizontal, 8)
-                            .padding(.vertical, 4)
-                            .background(Color.primary.opacity(0.06))
-                            .cornerRadius(6)
-                            .frame(width: 200)
-                        }
-                    }
-                }
-                .frame(maxWidth: selectedTab == .store ? .infinity : Self.detailContentMaxWidth)
-                .frame(maxWidth: .infinity)
-                .padding(.top, 36)
-                .padding(.horizontal, 24)
-                .padding(.bottom, 16)
-                
-                Group {
-                    switch selectedTab {
-                    case .general: 
-                        GeneralTab()
-                    case .appearance: 
-                        AppearanceTab()
-                    case .actions:
-                        ActionsTab(
-                            disabledActionIDs: $disabledActionIDs,
-                            disabledPackages: $disabledPackages,
-                            showingAddActionSheet: $showingAddActionSheet,
-                            showingCreateGroupSheet: $showingCreateGroupSheet
-                        )
-                    case .store:
-                        ExtensionStoreView(viewModel: storeViewModel)
-                    case .appRules: 
-                        AppRulesTab()
-                    case .about: 
-                        AboutTab()
-                    }
-                }
-                .frame(maxWidth: selectedTab == .store ? .infinity : Self.detailContentMaxWidth)
-                .frame(maxWidth: .infinity)
-                .padding(.horizontal, selectedTab == .store ? 20 : 16)
-                // General, Appearance, Actions, and Store run edge-to-edge to the window bottom; other tabs keep breathing room.
-                .padding(.bottom, (selectedTab == .general || selectedTab == .appearance || selectedTab == .actions || selectedTab == .store) ? 0 : 16)
-            }
-            .frame(maxWidth: .infinity, maxHeight: .infinity)
+        NavigationSplitView {
+            sidebar
+        } detail: {
+            detail
         }
-        .ignoresSafeArea(.all, edges: .top)
-        .background(Color(NSColor.windowBackgroundColor))
-        .frame(minWidth: 760, idealWidth: 760, minHeight: 520, idealHeight: 620)
+        .navigationSplitViewStyle(.balanced)
+        // No frame here on purpose: the window owns its size (see
+        // StatusBarController.showPreferences). Wrapping the split view in a
+        // frame makes SwiftUI lay it out as ordinary content inside the window
+        // rather than as the window's own split view.
         .onAppear {
             loadDisabledState()
             Task {
@@ -284,7 +111,167 @@ public struct PreferencesView: View {
             }
         }
     }
-    
+
+    // MARK: - Sidebar
+
+    /// `List` selection is optional by contract; the tab itself never is, so a
+    /// nil write (Escape, clicking empty space) keeps the current tab.
+    private var sidebarSelection: Binding<PreferenceTab?> {
+        Binding(
+            get: { selectedTab },
+            set: { newValue in
+                if let newValue { selectedTab = newValue }
+            }
+        )
+    }
+
+    private var sidebar: some View {
+        List(PreferenceTab.allCases, id: \.self, selection: sidebarSelection) { tab in
+            Label {
+                Text(tab.localizedTitle)
+            } icon: {
+                Image(systemName: tab.icon)
+                    .foregroundStyle(tab.tint)
+            }
+            .accessibilityLabel(tab.localizedTitle)
+        }
+        .listStyle(.sidebar)
+        .navigationSplitViewColumnWidth(min: 190, ideal: 205, max: 260)
+        .safeAreaInset(edge: .bottom, spacing: 0) {
+            sidebarFooter
+        }
+    }
+
+    private var sidebarFooter: some View {
+        HStack(spacing: 14) {
+            Button {
+                if let url = URL(string: "https://www.getopenclip.app/docs") {
+                    NSWorkspace.shared.open(url)
+                }
+            } label: {
+                Image(systemName: "questionmark.circle")
+            }
+            .help("Documentation")
+            .accessibilityLabel("Documentation")
+
+            Button {
+                if let url = URL(string: "https://github.com/ganeshmshetty/openclip") {
+                    NSWorkspace.shared.open(url)
+                }
+            } label: {
+                Image(systemName: "chevron.left.forwardslash.chevron.right")
+            }
+            .help("GitHub Repository")
+            .accessibilityLabel("GitHub Repository")
+
+            Spacer()
+        }
+        .buttonStyle(.borderless)
+        .foregroundStyle(.secondary)
+        .padding(.horizontal, 16)
+        .padding(.vertical, 10)
+    }
+
+    // MARK: - Detail
+
+    private var detail: some View {
+        detailContent
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+            .navigationTitle(Text(selectedTab.localizedTitle))
+            .toolbar { toolbarContent }
+    }
+
+    @ViewBuilder
+    private var detailContent: some View {
+        switch selectedTab {
+        case .general:
+            GeneralTab()
+        case .appearance:
+            AppearanceTab()
+        case .actions:
+            ActionsTab(
+                disabledActionIDs: $disabledActionIDs,
+                disabledPackages: $disabledPackages,
+                showingAddActionSheet: $showingAddActionSheet,
+                showingCreateGroupSheet: $showingCreateGroupSheet
+            )
+            .frame(maxWidth: Self.detailContentMaxWidth)
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+        case .store:
+            ExtensionStoreView(viewModel: storeViewModel)
+        case .appRules:
+            AppRulesTab()
+        case .about:
+            // AboutTab caps its own column width and already fills the pane.
+            AboutTab()
+        }
+    }
+
+    /// One toolbar item, always. Publishing items only on some tabs let SwiftUI
+    /// tear the window's toolbar down on the tabs that had none, and a window
+    /// that gains and loses its toolbar re-measures its title bar each time —
+    /// which is what pushed the traffic lights out of the sidebar on the way in
+    /// and out of General, Appearance and About. The item stays put and only its
+    /// contents change.
+    @ToolbarContentBuilder
+    private var toolbarContent: some ToolbarContent {
+        ToolbarItem(placement: .primaryAction) {
+            switch selectedTab {
+            case .actions:
+                addMenu
+            case .store:
+                refreshButton
+            default:
+                // A zero-size placeholder: the item has to exist for the toolbar
+                // to, but there is nothing to act on from these tabs.
+                Color.clear.frame(width: 0, height: 0)
+            }
+        }
+    }
+
+    private var addMenu: some View {
+        Menu {
+            Button {
+                showingCreateGroupSheet = true
+            } label: {
+                Label(String(localized: "New Group"), systemImage: "folder.badge.plus")
+            }
+
+            Button {
+                showingAddActionSheet = true
+            } label: {
+                Label(String(localized: "Add Custom Action"), systemImage: "plus.circle")
+            }
+
+            Button {
+                presentInstallExtensionPanel()
+            } label: {
+                Label(String(localized: "Install Extension…"), systemImage: "square.and.arrow.down")
+            }
+        } label: {
+            Label(String(localized: "Add"), systemImage: "plus")
+        }
+        .help(String(localized: "Add Action or Group"))
+    }
+
+    private var refreshButton: some View {
+        Button {
+            Task {
+                await storeViewModel.refreshCatalog()
+            }
+        } label: {
+            if storeViewModel.isLoading {
+                ProgressView()
+                    .controlSize(.small)
+            } else {
+                Label(String(localized: "Refresh Catalog"), systemImage: "arrow.clockwise")
+            }
+        }
+        .disabled(storeViewModel.isLoading)
+        .help(String(localized: "Refresh Catalog"))
+        .accessibilityLabel(String(localized: "Refresh Catalog"))
+    }
+
     private func loadDisabledState() {
         disabledActionIDs = DefaultSettingsStore.shared.get(.disabledActionIDs)
         disabledPackages = DefaultSettingsStore.shared.get(.disabledPackages)

--- a/Sources/OpenClip/UI/Preferences/PreferencesView.swift
+++ b/Sources/OpenClip/UI/Preferences/PreferencesView.swift
@@ -32,6 +32,13 @@ public enum PreferenceTab: String, CaseIterable, Hashable, Sendable {
         }
     }
 
+    /// The window's title for this pane. The window is titled after whatever is
+    /// on screen, the way every stock settings window is — "OpenClip Preferences"
+    /// on all six panes said nothing about where you were.
+    public var windowTitle: String {
+        String(localized: String.LocalizationValue(rawValue))
+    }
+
     /// Sidebar symbol tint, matching System Settings' coloured glyph tiles.
     public var tint: Color {
         switch self {
@@ -57,11 +64,20 @@ public struct PreferencesView: View {
     @State private var activeSheet: PreferencesSheet?
     @State private var showingAddActionSheet = false
     @State private var showingCreateGroupSheet = false
+    @State private var showingAppPicker = false
     @StateObject private var storeViewModel = ExtensionsStoreViewModel()
     @ObservedObject private var coordinator = ActionCoordinator.shared
+    /// Owned by the window (StatusBarController) so the AppKit toolbar and these
+    /// panes talk to the same object; the fallback instance is only for the
+    /// SwiftUI `Settings` scene, which has no toolbar of its own.
+    @ObservedObject private var toolbarModel: PreferencesToolbarModel
 
-    public init(initialTab: PreferenceTab = .general) {
+    public init(
+        initialTab: PreferenceTab = .general,
+        toolbarModel: PreferencesToolbarModel = PreferencesToolbarModel()
+    ) {
         _selectedTab = State(initialValue: initialTab)
+        _toolbarModel = ObservedObject(wrappedValue: toolbarModel)
     }
 
     public var body: some View {
@@ -70,23 +86,54 @@ public struct PreferencesView: View {
         } detail: {
             detail
         }
-        .navigationSplitViewStyle(.balanced)
+        .minimumWindowContentSize(width: 760, height: 480)
+        // Left at the system default: `.balanced` lets the detail column push
+        // into the sidebar's width, which is the case that runs out of room
+        // first when the window is dragged narrow.
+        .navigationSplitViewStyle(.automatic)
         // No frame here on purpose: the window owns its size (see
         // StatusBarController.showPreferences). Wrapping the split view in a
         // frame makes SwiftUI lay it out as ordinary content inside the window
         // rather than as the window's own split view.
         .onAppear {
+            toolbarModel.tab = selectedTab
             loadDisabledState()
             Task {
                 await storeViewModel.resetAndFetch(limit: 100)
             }
         }
         .onChange(of: selectedTab) { _, newTab in
+            toolbarModel.tab = newTab
             if newTab == .store && storeViewModel.extensions.isEmpty {
                 Task {
                     await storeViewModel.resetAndFetch(limit: 100)
                 }
             }
+        }
+        // Toolbar <-> panes. The toolbar owns the store's filter and search box,
+        // so those travel through the model in both directions.
+        .onReceive(toolbarModel.actions) { action in
+            switch action {
+            case .newGroup: showingCreateGroupSheet = true
+            case .addCustomAction: showingAddActionSheet = true
+            case .installExtension: presentInstallExtensionPanel()
+            case .addApplication: showingAppPicker = true
+            case .refresh: Task { await storeViewModel.refreshCatalog() }
+            }
+        }
+        .onChange(of: toolbarModel.storeFilter) { _, filter in
+            storeViewModel.selectedFilter = filter
+        }
+        .onChange(of: toolbarModel.searchQuery) { _, query in
+            guard storeViewModel.searchQuery != query else { return }
+            storeViewModel.searchQuery = query
+            storeViewModel.queryDidChange()
+        }
+        .onChange(of: storeViewModel.searchQuery) { _, query in
+            toolbarModel.searchQuery = query
+        }
+        .onChange(of: storeViewModel.isLoading) { _, isLoading in
+            toolbarModel.isRefreshing = isLoading
         }
         .onChange(of: disabledActionIDs) { _, _ in saveDisabledState() }
         .onChange(of: disabledPackages) { _, _ in saveDisabledState() }
@@ -98,6 +145,11 @@ public struct PreferencesView: View {
         .onReceive(NotificationCenter.default.publisher(for: .openClipSelectPreferencesTab)) { notification in
             if let tab = notification.object as? PreferenceTab {
                 selectedTab = tab
+            }
+        }
+        .sheet(isPresented: $showingAppPicker) {
+            AppPickerSheet { bundleID in
+                RuleEngine.shared.addOrUpdateRule(AppRule(bundleIdentifiers: [bundleID]))
             }
         }
         .sheet(item: $activeSheet) { route in
@@ -136,7 +188,7 @@ public struct PreferencesView: View {
             .accessibilityLabel(tab.localizedTitle)
         }
         .listStyle(.sidebar)
-        .navigationSplitViewColumnWidth(min: 190, ideal: 205, max: 260)
+        .navigationSplitViewColumnWidth(min: 190, ideal: 205, max: 240)
         .safeAreaInset(edge: .bottom, spacing: 0) {
             sidebarFooter
         }
@@ -176,9 +228,11 @@ public struct PreferencesView: View {
 
     private var detail: some View {
         detailContent
+            // The detail column's floor, which is what stops the window shrinking:
+            // the split view happily collapses the sidebar, so the minimum the
+            // window inherits is whatever the content insists on.
+            .frame(minWidth: 540, minHeight: 460)
             .frame(maxWidth: .infinity, maxHeight: .infinity)
-            .navigationTitle(Text(selectedTab.localizedTitle))
-            .toolbar { toolbarContent }
     }
 
     @ViewBuilder
@@ -200,76 +254,11 @@ public struct PreferencesView: View {
         case .store:
             ExtensionStoreView(viewModel: storeViewModel)
         case .appRules:
-            AppRulesTab()
+            AppRulesTab(showingAppPicker: $showingAppPicker)
         case .about:
             // AboutTab caps its own column width and already fills the pane.
             AboutTab()
         }
-    }
-
-    /// One toolbar item, always. Publishing items only on some tabs let SwiftUI
-    /// tear the window's toolbar down on the tabs that had none, and a window
-    /// that gains and loses its toolbar re-measures its title bar each time —
-    /// which is what pushed the traffic lights out of the sidebar on the way in
-    /// and out of General, Appearance and About. The item stays put and only its
-    /// contents change.
-    @ToolbarContentBuilder
-    private var toolbarContent: some ToolbarContent {
-        ToolbarItem(placement: .primaryAction) {
-            switch selectedTab {
-            case .actions:
-                addMenu
-            case .store:
-                refreshButton
-            default:
-                // A zero-size placeholder: the item has to exist for the toolbar
-                // to, but there is nothing to act on from these tabs.
-                Color.clear.frame(width: 0, height: 0)
-            }
-        }
-    }
-
-    private var addMenu: some View {
-        Menu {
-            Button {
-                showingCreateGroupSheet = true
-            } label: {
-                Label(String(localized: "New Group"), systemImage: "folder.badge.plus")
-            }
-
-            Button {
-                showingAddActionSheet = true
-            } label: {
-                Label(String(localized: "Add Custom Action"), systemImage: "plus.circle")
-            }
-
-            Button {
-                presentInstallExtensionPanel()
-            } label: {
-                Label(String(localized: "Install Extension…"), systemImage: "square.and.arrow.down")
-            }
-        } label: {
-            Label(String(localized: "Add"), systemImage: "plus")
-        }
-        .help(String(localized: "Add Action or Group"))
-    }
-
-    private var refreshButton: some View {
-        Button {
-            Task {
-                await storeViewModel.refreshCatalog()
-            }
-        } label: {
-            if storeViewModel.isLoading {
-                ProgressView()
-                    .controlSize(.small)
-            } else {
-                Label(String(localized: "Refresh Catalog"), systemImage: "arrow.clockwise")
-            }
-        }
-        .disabled(storeViewModel.isLoading)
-        .help(String(localized: "Refresh Catalog"))
-        .accessibilityLabel(String(localized: "Refresh Catalog"))
     }
 
     private func loadDisabledState() {

--- a/Sources/OpenClip/UI/Preferences/SettingsRowLabel.swift
+++ b/Sources/OpenClip/UI/Preferences/SettingsRowLabel.swift
@@ -1,0 +1,42 @@
+// SettingsRowLabel.swift
+// OpenClip
+//
+// The one shared label shape used by every preferences row: a symbol, a title,
+// and an optional line of secondary text. Everything else about a row — the
+// card, the dividers, the row height, the label/control split — is left to the
+// system's grouped `Form`, so rows follow System Settings rather than tracking
+// a private style sheet.
+import SwiftUI
+
+struct SettingsRowLabel: View {
+    let title: LocalizedStringKey
+    var subtitle: LocalizedStringKey?
+    var systemImage: String?
+
+    init(title: LocalizedStringKey, subtitle: LocalizedStringKey? = nil, systemImage: String? = nil) {
+        self.title = title
+        self.subtitle = subtitle
+        self.systemImage = systemImage
+    }
+
+    var body: some View {
+        HStack(alignment: .center, spacing: 10) {
+            if let systemImage {
+                Image(systemName: systemImage)
+                    .font(.system(size: 15))
+                    .foregroundStyle(.secondary)
+                    .frame(width: 20, alignment: .center)
+                    .accessibilityHidden(true)
+            }
+            VStack(alignment: .leading, spacing: 2) {
+                Text(title)
+                if let subtitle {
+                    Text(subtitle)
+                        .font(.callout)
+                        .foregroundStyle(.secondary)
+                        .fixedSize(horizontal: false, vertical: true)
+                }
+            }
+        }
+    }
+}

--- a/Sources/OpenClip/UI/Preferences/SettingsRowLabel.swift
+++ b/Sources/OpenClip/UI/Preferences/SettingsRowLabel.swift
@@ -1,11 +1,14 @@
 // SettingsRowLabel.swift
 // OpenClip
 //
-// The one shared label shape used by every preferences row: a symbol, a title,
-// and an optional line of secondary text. Everything else about a row — the
-// card, the dividers, the row height, the label/control split — is left to the
-// system's grouped `Form`, so rows follow System Settings rather than tracking
-// a private style sheet.
+// The shared row shapes used by every preferences pane: a symbol, a title, an
+// optional line of secondary text, and a trailing control that stays centred
+// against the whole label rather than riding the first line of it.
+//
+// The rows sit inside a grouped `Form`, which still owns the card, the
+// dividers and the row insets — only the label/control split is taken over
+// here, because `LabeledContent` aligns a control to the label's first
+// baseline and leaves it high on any row that carries a description.
 import SwiftUI
 
 struct SettingsRowLabel: View {
@@ -37,6 +40,53 @@ struct SettingsRowLabel: View {
                         .fixedSize(horizontal: false, vertical: true)
                 }
             }
+        }
+    }
+}
+
+/// A full settings row: label on the left, control on the right, both centred
+/// on the row's height.
+struct SettingsRow<Trailing: View>: View {
+    let title: LocalizedStringKey
+    var subtitle: LocalizedStringKey?
+    var systemImage: String?
+    @ViewBuilder var trailing: () -> Trailing
+
+    init(
+        title: LocalizedStringKey,
+        subtitle: LocalizedStringKey? = nil,
+        systemImage: String? = nil,
+        @ViewBuilder trailing: @escaping () -> Trailing
+    ) {
+        self.title = title
+        self.subtitle = subtitle
+        self.systemImage = systemImage
+        self.trailing = trailing
+    }
+
+    var body: some View {
+        HStack(alignment: .center, spacing: 12) {
+            SettingsRowLabel(title: title, subtitle: subtitle, systemImage: systemImage)
+            Spacer(minLength: 12)
+            trailing()
+        }
+        .padding(.vertical, 2)
+    }
+}
+
+/// A row whose whole label describes one switch.
+struct SettingsToggleRow: View {
+    let title: LocalizedStringKey
+    var subtitle: LocalizedStringKey?
+    var systemImage: String?
+    @Binding var isOn: Bool
+
+    var body: some View {
+        SettingsRow(title: title, subtitle: subtitle, systemImage: systemImage) {
+            Toggle("", isOn: $isOn)
+                .labelsHidden()
+                .toggleStyle(.switch)
+                .accessibilityLabel(title)
         }
     }
 }

--- a/scripts/translations/fr.json
+++ b/scripts/translations/fr.json
@@ -455,5 +455,7 @@
   "Unsupported file format. Please choose a PNG, SVG, JPG, or ICNS file.": "Format de fichier non pris en charge. Veuillez choisir un fichier PNG, SVG, JPG ou ICNS.",
   "Customize Icon": "Personnaliser l’icône",
   "Move Up": "Monter",
-  "Move Down": "Descendre"
+  "Move Down": "Descendre",
+  "%@ download": "%@ téléchargement",
+  "%@ downloads": "%@ téléchargements"
 }

--- a/scripts/translations/ja.json
+++ b/scripts/translations/ja.json
@@ -455,5 +455,7 @@
   "Unsupported file format. Please choose a PNG, SVG, JPG, or ICNS file.": "サポートされていないファイル形式です。PNG、SVG、JPG、または ICNS ファイルを選択してください。",
   "Customize Icon": "アイコンをカスタマイズ",
   "Move Up": "上に移動",
-  "Move Down": "下に移動"
+  "Move Down": "下に移動",
+  "%@ download": "%@ ダウンロード",
+  "%@ downloads": "%@ ダウンロード"
 }

--- a/scripts/translations/zh-Hans.json
+++ b/scripts/translations/zh-Hans.json
@@ -455,5 +455,7 @@
   "Unsupported file format. Please choose a PNG, SVG, JPG, or ICNS file.": "不支持的文件格式。请选择 PNG、SVG、JPG 或 ICNS 文件。",
   "Customize Icon": "自定义图标",
   "Move Up": "上移",
-  "Move Down": "下移"
+  "Move Down": "下移",
+  "%@ download": "%@ 次下载",
+  "%@ downloads": "%@ 次下载"
 }

--- a/scripts/translations/zh-Hant.json
+++ b/scripts/translations/zh-Hant.json
@@ -455,5 +455,7 @@
   "Unsupported file format. Please choose a PNG, SVG, JPG, or ICNS file.": "不支援的檔案格式。請選擇 PNG、SVG、JPG 或 ICNS 檔案。",
   "Customize Icon": "自訂圖示",
   "Move Up": "上移",
-  "Move Down": "下移"
+  "Move Down": "下移",
+  "%@ download": "%@ 次下載",
+  "%@ downloads": "%@ 次下載"
 }


### PR DESCRIPTION
## Summary

Rebuilds the preferences window on the stock AppKit pieces instead of the hand-drawn ones.

The window is now an `NSSplitViewController` with a real source-list sidebar and a persistent `NSToolbar` in `.unified` style, so the sidebar runs full height, the traffic lights stay put, and each pane's controls (the Store's filter and search field, App Rules' add button) live in the title bar where the system expects them. The panes themselves were tidied to match: `SettingsRowLabel` gives every row the same icon/title/subtitle shape, and `NativeSearchField` replaces the custom search box with `NSSearchField`.

Two details worth calling out, both explained in comments at the point they matter:

- The window title is empty and `titleVisibility` is hidden. The pane's name is a toolbar item, so a title would be drawn a second time beside it.
- `titlebarAppearsTransparent` is deliberately off. It drops the title bar's backdrop across the whole window, and App Rules' rows then slid visibly through the gaps between toolbar items. The sidebar still runs full height without it, because `NSSplitViewItem.allowsFullHeightLayout` is what clears that half of the title bar.

Actions and the Store reach the pane's top edge so their content fades out under the toolbar the way the Form-based panes already did. `ActionsScrollView` measures the overlap and insets its rows back below the title bar, since AppKit only adjusts scroll views the window owns directly.

Rebased on current `main`, on top of #81 and #82.

---

## Type of Change
- [x] UI / Theme / Accessibility improvement

---

## Testing & Verification

### Environment Tested:
- **macOS Version:** macOS 26
- **Architecture:** Apple Silicon
- **Target Apps Verified:** Safari, Notes, Finder

### Test Execution:
- [x] Ran `./scripts/test.sh core` (178 tests, 0 failures)
- [x] Ran `./scripts/test.sh` (1271 tests, 0 failures)
- [x] Tested live in app


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a native preferences toolbar with contextual search, filtering, refresh, and action controls.
  - Added native search fields for app and icon selection.
  - Added grouped settings rows, improved empty states, and consistent preferences window sizing.

- **Improvements**
  - Redesigned preferences navigation and layouts for a more consistent macOS experience.
  - Updated theme, appearance, app rules, software updates, and extension store presentations.
  - Improved toolbar scrolling behavior and extension download-count display.

- **Localization**
  - Added translated singular and plural download labels in supported languages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->